### PR TITLE
feat: implement inbound STARTTLS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ go run ./cmd/mta
 - `MTA_LISTEN_ADDR` (default: `:2525`)
 - `MTA_HOSTNAME` (default: `orinoco.local`)
 - `MTA_QUEUE_DIR` (default: `./var/queue`)
+- `MTA_TLS_CERT_FILE` (default: unset)
+- `MTA_TLS_KEY_FILE` (default: unset)
 - `MTA_MAX_MESSAGE_BYTES` (default: `10485760`)
 - `MTA_WORKER_COUNT` (default: `4`)
 - `MTA_SCAN_INTERVAL` (default: `5s`)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,8 @@ type Config struct {
 	ListenAddr      string
 	Hostname        string
 	QueueDir        string
+	TLSCertFile     string
+	TLSKeyFile      string
 	MaxMessageBytes int64
 	WorkerCount     int
 	ScanInterval    time.Duration
@@ -22,6 +24,8 @@ func Load() Config {
 		ListenAddr:      env("MTA_LISTEN_ADDR", ":2525"),
 		Hostname:        env("MTA_HOSTNAME", "orinoco.local"),
 		QueueDir:        env("MTA_QUEUE_DIR", "./var/queue"),
+		TLSCertFile:     env("MTA_TLS_CERT_FILE", ""),
+		TLSKeyFile:      env("MTA_TLS_KEY_FILE", ""),
 		MaxMessageBytes: envInt64("MTA_MAX_MESSAGE_BYTES", 10*1024*1024),
 		WorkerCount:     envInt("MTA_WORKER_COUNT", 4),
 		ScanInterval:    envDuration("MTA_SCAN_INTERVAL", 5*time.Second),

--- a/internal/smtp/server.go
+++ b/internal/smtp/server.go
@@ -3,6 +3,7 @@ package smtp
 import (
 	"bufio"
 	"context"
+	"crypto/tls"
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
@@ -21,17 +22,23 @@ import (
 )
 
 type Server struct {
-	cfg   config.Config
-	queue *queue.Store
-	ln    net.Listener
-	wg    sync.WaitGroup
+	cfg        config.Config
+	queue      *queue.Store
+	tlsConfig  *tls.Config
+	tlsLoadErr error
+	ln         net.Listener
+	wg         sync.WaitGroup
 }
 
 func NewServer(cfg config.Config, q *queue.Store) *Server {
-	return &Server{cfg: cfg, queue: q}
+	tlsConfig, err := loadTLSConfig(cfg)
+	return &Server{cfg: cfg, queue: q, tlsConfig: tlsConfig, tlsLoadErr: err}
 }
 
 func (s *Server) Run(ctx context.Context) error {
+	if s.tlsLoadErr != nil {
+		return s.tlsLoadErr
+	}
 	ln, err := net.Listen("tcp", s.cfg.ListenAddr)
 	if err != nil {
 		return err
@@ -70,6 +77,7 @@ type session struct {
 	rcptTo   []string
 	data     []byte
 	seenHelo bool
+	tls      bool
 }
 
 func (s *Server) handleConn(conn net.Conn) {
@@ -102,11 +110,7 @@ func (s *Server) handleConn(conn net.Conn) {
 			ss.mailFrom = ""
 			ss.rcptTo = nil
 			ss.data = nil
-			writeLine(w, "250-"+s.cfg.Hostname)
-			writeLine(w, "250-PIPELINING")
-			writeLine(w, "250-SIZE 10485760")
-			writeLine(w, "250-8BITMIME")
-			writeLine(w, "250 STARTTLS")
+			writeEHLOResponse(w, s.cfg.Hostname, s.cfg.MaxMessageBytes, s.tlsConfig != nil && !ss.tls)
 		case "MAIL":
 			if !ss.seenHelo {
 				writeResp(w, 503, "send EHLO/HELO first")
@@ -181,7 +185,28 @@ func (s *Server) handleConn(conn net.Conn) {
 			writeResp(w, 221, "bye")
 			return
 		case "STARTTLS":
-			writeResp(w, 502, "STARTTLS not configured")
+			if ss.tls {
+				writeResp(w, 503, "already using TLS")
+				continue
+			}
+			if s.tlsConfig == nil {
+				writeResp(w, 454, "TLS not available due to temporary reason")
+				continue
+			}
+			writeResp(w, 220, "Ready to start TLS")
+			tlsConn := tls.Server(conn, s.tlsConfig)
+			if err := tlsConn.Handshake(); err != nil {
+				return
+			}
+			conn = tlsConn
+			_ = conn.SetDeadline(time.Now().Add(10 * time.Minute))
+			r = bufio.NewReader(conn)
+			w = bufio.NewWriter(conn)
+			ss.tls = true
+			ss.seenHelo = false
+			ss.mailFrom = ""
+			ss.rcptTo = nil
+			ss.data = nil
 		default:
 			writeResp(w, 500, "unsupported command")
 		}
@@ -289,4 +314,33 @@ func parseRemoteIP(remote string) net.IP {
 		return net.ParseIP(remote)
 	}
 	return net.ParseIP(host)
+}
+
+func writeEHLOResponse(w *bufio.Writer, hostname string, maxMessageBytes int64, advertiseStartTLS bool) {
+	_ = writeLine(w, "250-"+hostname)
+	_ = writeLine(w, "250-PIPELINING")
+	_ = writeLine(w, fmt.Sprintf("250-SIZE %d", maxMessageBytes))
+	_ = writeLine(w, "250-8BITMIME")
+	if advertiseStartTLS {
+		_ = writeLine(w, "250 STARTTLS")
+		return
+	}
+	_ = writeLine(w, "250 HELP")
+}
+
+func loadTLSConfig(cfg config.Config) (*tls.Config, error) {
+	if cfg.TLSCertFile == "" && cfg.TLSKeyFile == "" {
+		return nil, nil
+	}
+	if cfg.TLSCertFile == "" || cfg.TLSKeyFile == "" {
+		return nil, errors.New("both MTA_TLS_CERT_FILE and MTA_TLS_KEY_FILE must be set")
+	}
+	cert, err := tls.LoadX509KeyPair(cfg.TLSCertFile, cfg.TLSKeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("load TLS cert/key: %w", err)
+	}
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	}, nil
 }

--- a/internal/smtp/server_test.go
+++ b/internal/smtp/server_test.go
@@ -2,8 +2,19 @@ package smtp
 
 import (
 	"bufio"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"math/big"
+	"net"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/tamago/orinoco-mta/internal/config"
 )
 
 func TestSplitVerb(t *testing.T) {
@@ -66,4 +77,165 @@ func TestParseRemoteIP(t *testing.T) {
 	if got := parseRemoteIP("2001:db8::1"); got == nil || got.String() != "2001:db8::1" {
 		t.Fatalf("got=%v", got)
 	}
+}
+
+func TestEHLOResponseWithoutTLSDoesNotAdvertiseStartTLS(t *testing.T) {
+	s := &Server{cfg: config.Config{Hostname: "mx.example.test"}}
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	go s.handleConn(server)
+
+	r := bufio.NewReader(client)
+	w := bufio.NewWriter(client)
+
+	_, _ = readSMTPResponse(t, r) // banner
+	if _, err := w.WriteString("EHLO client.example\r\n"); err != nil {
+		t.Fatalf("write EHLO: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("flush EHLO: %v", err)
+	}
+	resp, _ := readSMTPResponse(t, r)
+	if strings.Contains(resp, "STARTTLS") {
+		t.Fatalf("STARTTLS must not be advertised when TLS is not configured: %q", resp)
+	}
+}
+
+func TestSTARTTLSWithoutTLSConfigReturns454(t *testing.T) {
+	s := &Server{cfg: config.Config{Hostname: "mx.example.test"}}
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	go s.handleConn(server)
+
+	r := bufio.NewReader(client)
+	w := bufio.NewWriter(client)
+
+	_, _ = readSMTPResponse(t, r) // banner
+	if _, err := w.WriteString("EHLO client.example\r\n"); err != nil {
+		t.Fatalf("write EHLO: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("flush EHLO: %v", err)
+	}
+	_, _ = readSMTPResponse(t, r)
+
+	if _, err := w.WriteString("STARTTLS\r\n"); err != nil {
+		t.Fatalf("write STARTTLS: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("flush STARTTLS: %v", err)
+	}
+	resp, code := readSMTPResponse(t, r)
+	if code != 454 {
+		t.Fatalf("code=%d resp=%q want=454", code, resp)
+	}
+}
+
+func TestSTARTTLSWithTLSConfigUpgradesConnection(t *testing.T) {
+	cert, err := selfSignedCert()
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	s := &Server{
+		cfg:       config.Config{Hostname: "mx.example.test"},
+		tlsConfig: &tls.Config{Certificates: []tls.Certificate{cert}},
+	}
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	go s.handleConn(server)
+
+	r := bufio.NewReader(client)
+	w := bufio.NewWriter(client)
+	_, _ = readSMTPResponse(t, r) // banner
+
+	if _, err := w.WriteString("EHLO client.example\r\n"); err != nil {
+		t.Fatalf("write EHLO: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("flush EHLO: %v", err)
+	}
+	resp, _ := readSMTPResponse(t, r)
+	if !strings.Contains(resp, "STARTTLS") {
+		t.Fatalf("STARTTLS must be advertised when TLS is configured: %q", resp)
+	}
+
+	if _, err := w.WriteString("STARTTLS\r\n"); err != nil {
+		t.Fatalf("write STARTTLS: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("flush STARTTLS: %v", err)
+	}
+	_, code := readSMTPResponse(t, r)
+	if code != 220 {
+		t.Fatalf("code=%d want=220", code)
+	}
+
+	tlsClient := tls.Client(client, &tls.Config{InsecureSkipVerify: true})
+	if err := tlsClient.Handshake(); err != nil {
+		t.Fatalf("tls handshake: %v", err)
+	}
+	defer tlsClient.Close()
+	rt := bufio.NewReader(tlsClient)
+	wt := bufio.NewWriter(tlsClient)
+
+	if _, err := wt.WriteString("EHLO client.example\r\n"); err != nil {
+		t.Fatalf("write EHLO over TLS: %v", err)
+	}
+	if err := wt.Flush(); err != nil {
+		t.Fatalf("flush EHLO over TLS: %v", err)
+	}
+	_, code = readSMTPResponse(t, rt)
+	if code != 250 {
+		t.Fatalf("code=%d want=250", code)
+	}
+}
+
+func readSMTPResponse(t *testing.T, r *bufio.Reader) (string, int) {
+	t.Helper()
+	var lines []string
+	code := 0
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			t.Fatalf("read response: %v", err)
+		}
+		line = strings.TrimRight(line, "\r\n")
+		lines = append(lines, line)
+		if len(line) >= 3 && code == 0 {
+			if _, err := fmt.Sscanf(line[:3], "%d", &code); err != nil {
+				t.Fatalf("parse code: %v line=%q", err, line)
+			}
+		}
+		if len(line) >= 4 && line[3] == ' ' {
+			return strings.Join(lines, "\n"), code
+		}
+	}
+}
+
+func selfSignedCert() (tls.Certificate, error) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "mx.example.test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{"mx.example.test"},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	return tls.Certificate{
+		Certificate: [][]byte{der},
+		PrivateKey:  priv,
+		Leaf:        tmpl,
+	}, nil
 }


### PR DESCRIPTION
## Summary
- implement inbound STARTTLS command handling with TLS handshake
- advertise STARTTLS only when TLS cert/key are configured
- reset SMTP transaction state after TLS upgrade and require EHLO again
- add tests for STARTTLS advertise/454 response/successful upgrade
- document TLS env vars in README

## Related Issue
Closes #1

## Validation
- `go vet ./...`
- `go test ./...`