### PR TITLE
fix: DMARC relaxed alignment の組織ドメイン判定を改善

### DIFF
--- a/internal/auth/dmarc.go
+++ b/internal/auth/dmarc.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"net"
+	"slices"
 	"strings"
 	"time"
 
@@ -74,10 +75,7 @@ func aligned(fromDomain, authDomain, mode string) bool {
 	if strings.EqualFold(mode, "s") {
 		return strings.EqualFold(fromDomain, authDomain)
 	}
-	if strings.EqualFold(fromDomain, authDomain) {
-		return true
-	}
-	return strings.HasSuffix(fromDomain, "."+authDomain) || strings.HasSuffix(authDomain, "."+fromDomain)
+	return organizationalDomain(fromDomain) == organizationalDomain(authDomain)
 }
 
 func lookupDMARC(domain string) (string, bool, error) {
@@ -94,4 +92,28 @@ func lookupDMARC(domain string) (string, bool, error) {
 		}
 	}
 	return "", false, nil
+}
+
+func organizationalDomain(domain string) string {
+	domain = strings.Trim(strings.ToLower(domain), ".")
+	if domain == "" {
+		return ""
+	}
+	labels := strings.Split(domain, ".")
+	if len(labels) <= 2 {
+		return domain
+	}
+	publicSuffix2 := labels[len(labels)-2] + "." + labels[len(labels)-1]
+	twoLevelPSL := []string{
+		"co.uk", "org.uk", "gov.uk", "ac.uk",
+		"co.jp", "or.jp", "ne.jp",
+		"com.au", "net.au", "org.au",
+		"co.nz", "co.kr", "co.in",
+		"com.br", "com.mx", "com.tr",
+		"com.cn", "com.tw", "com.hk", "com.sg",
+	}
+	if slices.Contains(twoLevelPSL, publicSuffix2) && len(labels) >= 3 {
+		return labels[len(labels)-3] + "." + publicSuffix2
+	}
+	return publicSuffix2
 }

--- a/internal/auth/dmarc_test.go
+++ b/internal/auth/dmarc_test.go
@@ -20,6 +20,7 @@ func TestAligned(t *testing.T) {
 		{name: "strict exact", fromDomain: "example.com", authDomain: "example.com", mode: "s", want: true},
 		{name: "strict subdomain no", fromDomain: "a.example.com", authDomain: "example.com", mode: "s", want: false},
 		{name: "relaxed subdomain yes", fromDomain: "a.example.com", authDomain: "example.com", mode: "r", want: true},
+		{name: "relaxed org domain co uk", fromDomain: "a.example.co.uk", authDomain: "b.example.co.uk", mode: "r", want: true},
 		{name: "relaxed unrelated", fromDomain: "example.com", authDomain: "example.net", mode: "r", want: false},
 	}
 	for _, tt := range tests {
@@ -28,5 +29,21 @@ func TestAligned(t *testing.T) {
 				t.Fatalf("got=%v want=%v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestOrganizationalDomain(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{in: "a.example.com", want: "example.com"},
+		{in: "a.example.co.uk", want: "example.co.uk"},
+		{in: "example", want: "example"},
+	}
+	for _, tt := range tests {
+		if got := organizationalDomain(tt.in); got != tt.want {
+			t.Fatalf("in=%q got=%q want=%q", tt.in, got, tt.want)
+		}
 	}
 }


### PR DESCRIPTION
## 概要
- DMARCのrelaxed alignmentを組織ドメイン比較へ変更
- `co.uk` など主要な2階層public suffix相当を考慮する `organizationalDomain` を追加
- 先行テスト（RED）追加後に実装し、TDDで反映

## 関連Issue
Closes #2

## 検証
- `go test ./internal/auth`
- `go test ./...`