### PR TITLE
feat: DSNパースとSuppression List管理を追加

### DIFF
--- a/cmd/mta/main.go
+++ b/cmd/mta/main.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"log"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 
+	"github.com/tamago0224/orinoco-mta/internal/bounce"
 	"github.com/tamago0224/orinoco-mta/internal/config"
 	"github.com/tamago0224/orinoco-mta/internal/delivery"
 	"github.com/tamago0224/orinoco-mta/internal/queue"
@@ -24,8 +26,12 @@ func main() {
 	if err != nil {
 		log.Fatalf("queue init failed: %v", err)
 	}
+	sup, err := bounce.NewSuppressionStore(filepath.Join(cfg.QueueDir, "suppression.json"))
+	if err != nil {
+		log.Fatalf("suppression init failed: %v", err)
+	}
 
-	d := worker.New(cfg, q, delivery.NewClient(cfg))
+	d := worker.New(cfg, q, delivery.NewClient(cfg), sup)
 	s := smtp.NewServer(cfg, q)
 
 	errCh := make(chan error, 2)

--- a/internal/bounce/dsn.go
+++ b/internal/bounce/dsn.go
@@ -1,0 +1,64 @@
+package bounce
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+)
+
+type DSNReport struct {
+	Recipient      string
+	Action         string
+	Status         string
+	DiagnosticCode string
+}
+
+func ParseDSN(raw []byte) ([]DSNReport, error) {
+	s := bufio.NewScanner(bytes.NewReader(raw))
+	var reports []DSNReport
+	cur := DSNReport{}
+	hasAny := false
+	flush := func() {
+		if cur.Recipient == "" && cur.Action == "" && cur.Status == "" && cur.DiagnosticCode == "" {
+			return
+		}
+		reports = append(reports, cur)
+		cur = DSNReport{}
+	}
+	for s.Scan() {
+		line := strings.TrimSpace(s.Text())
+		if line == "" {
+			flush()
+			hasAny = false
+			continue
+		}
+		idx := strings.Index(line, ":")
+		if idx <= 0 {
+			continue
+		}
+		key := strings.ToLower(strings.TrimSpace(line[:idx]))
+		val := strings.TrimSpace(line[idx+1:])
+		hasAny = true
+		switch key {
+		case "final-recipient":
+			cur.Recipient = parseRecipient(val)
+		case "action":
+			cur.Action = strings.ToLower(val)
+		case "status":
+			cur.Status = val
+		case "diagnostic-code":
+			cur.DiagnosticCode = val
+		}
+	}
+	if hasAny {
+		flush()
+	}
+	return reports, s.Err()
+}
+
+func parseRecipient(v string) string {
+	if i := strings.Index(v, ";"); i >= 0 {
+		v = v[i+1:]
+	}
+	return strings.ToLower(strings.TrimSpace(v))
+}

--- a/internal/bounce/dsn_test.go
+++ b/internal/bounce/dsn_test.go
@@ -1,0 +1,18 @@
+package bounce
+
+import "testing"
+
+func TestParseDSN(t *testing.T) {
+	raw := []byte("Final-Recipient: rfc822; user@example.com\r\nAction: failed\r\nStatus: 5.1.1\r\nDiagnostic-Code: smtp; 550 5.1.1 User unknown\r\n")
+	reports, err := ParseDSN(raw)
+	if err != nil {
+		t.Fatalf("parse dsn: %v", err)
+	}
+	if len(reports) != 1 {
+		t.Fatalf("len=%d", len(reports))
+	}
+	r := reports[0]
+	if r.Recipient != "user@example.com" || r.Action != "failed" || r.Status != "5.1.1" {
+		t.Fatalf("unexpected report: %+v", r)
+	}
+}

--- a/internal/bounce/suppression.go
+++ b/internal/bounce/suppression.go
@@ -1,0 +1,109 @@
+package bounce
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+type SuppressionEntry struct {
+	Address   string    `json:"address"`
+	Reason    string    `json:"reason"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type SuppressionStore struct {
+	path    string
+	mu      sync.RWMutex
+	entries map[string]SuppressionEntry
+}
+
+func NewSuppressionStore(path string) (*SuppressionStore, error) {
+	s := &SuppressionStore{path: path, entries: map[string]SuppressionEntry{}}
+	if path == "" {
+		return s, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, err
+	}
+	if err := s.load(); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func (s *SuppressionStore) IsSuppressed(addr string) bool {
+	n := normalizeAddress(addr)
+	if n == "" {
+		return false
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	_, ok := s.entries[n]
+	return ok
+}
+
+func (s *SuppressionStore) Add(addr, reason string) error {
+	n := normalizeAddress(addr)
+	if n == "" {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.entries[n]; ok {
+		return nil
+	}
+	s.entries[n] = SuppressionEntry{Address: n, Reason: reason, CreatedAt: time.Now().UTC()}
+	return s.saveLocked()
+}
+
+func (s *SuppressionStore) load() error {
+	b, err := os.ReadFile(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if len(b) == 0 {
+		return nil
+	}
+	var list []SuppressionEntry
+	if err := json.Unmarshal(b, &list); err != nil {
+		return err
+	}
+	for _, e := range list {
+		s.entries[normalizeAddress(e.Address)] = e
+	}
+	return nil
+}
+
+func (s *SuppressionStore) saveLocked() error {
+	if s.path == "" {
+		return nil
+	}
+	list := make([]SuppressionEntry, 0, len(s.entries))
+	for _, e := range s.entries {
+		list = append(list, e)
+	}
+	b, err := json.MarshalIndent(list, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, s.path)
+}
+
+func normalizeAddress(addr string) string {
+	addr = strings.TrimSpace(strings.ToLower(addr))
+	if addr == "" || !strings.Contains(addr, "@") {
+		return ""
+	}
+	return addr
+}

--- a/internal/bounce/suppression_test.go
+++ b/internal/bounce/suppression_test.go
@@ -1,0 +1,28 @@
+package bounce
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestSuppressionStoreAddAndPersist(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "suppression.json")
+	s, err := NewSuppressionStore(p)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	if err := s.Add("User@Example.com", "hard bounce"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if !s.IsSuppressed("user@example.com") {
+		t.Fatal("address should be suppressed")
+	}
+
+	s2, err := NewSuppressionStore(p)
+	if err != nil {
+		t.Fatalf("reload store: %v", err)
+	}
+	if !s2.IsSuppressed("user@example.com") {
+		t.Fatal("suppression should persist")
+	}
+}

--- a/internal/worker/dispatcher.go
+++ b/internal/worker/dispatcher.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/tamago0224/orinoco-mta/internal/bounce"
 	"github.com/tamago0224/orinoco-mta/internal/config"
 	"github.com/tamago0224/orinoco-mta/internal/delivery"
 	"github.com/tamago0224/orinoco-mta/internal/model"
@@ -18,10 +19,11 @@ type Dispatcher struct {
 	cfg   config.Config
 	queue *queue.Store
 	cl    *delivery.Client
+	sup   *bounce.SuppressionStore
 }
 
-func New(cfg config.Config, q *queue.Store, cl *delivery.Client) *Dispatcher {
-	return &Dispatcher{cfg: cfg, queue: q, cl: cl}
+func New(cfg config.Config, q *queue.Store, cl *delivery.Client, sup *bounce.SuppressionStore) *Dispatcher {
+	return &Dispatcher{cfg: cfg, queue: q, cl: cl, sup: sup}
 }
 
 func (d *Dispatcher) Run(ctx context.Context) error {
@@ -71,9 +73,22 @@ func (d *Dispatcher) handleMessage(ctx context.Context, msg *model.Message) {
 		reasons []string
 	)
 	for _, rcpt := range msg.RcptTo {
+		if d.sup != nil && d.sup.IsSuppressed(rcpt) {
+			reasons = append(reasons, rcpt+": suppressed")
+			continue
+		}
 		if err := d.cl.Deliver(ctx, msg, rcpt); err != nil {
-			errs = append(errs, err)
 			reasons = append(reasons, rcpt+": "+err.Error())
+			var smtpErr *delivery.SMTPResponseError
+			if errors.As(err, &smtpErr) && smtpErr.Permanent() {
+				if d.sup != nil {
+					if sErr := d.sup.Add(rcpt, smtpErr.Line); sErr != nil {
+						log.Printf("suppression add error addr=%s: %v", rcpt, sErr)
+					}
+				}
+				continue
+			}
+			errs = append(errs, err)
 		}
 	}
 


### PR DESCRIPTION
## 概要
- DSN情報を抽出する `internal/bounce` パッケージを追加
- Suppression Listの永続ストア（JSON）を追加
- worker配送処理にSuppression判定を統合
  - suppression対象宛先は配送スキップ
  - 5xx hard bounceでsuppressionに自動追加
- 起動時に `queue/suppression.json` をロードするよう main を更新

## 関連Issue
Closes #7

## 検証
- `go vet ./...`
- `go test ./internal/bounce`
- `go test ./...`