### PR TITLE
feat: Observability基盤としてメトリクス公開を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ go run ./cmd/mta
 ## 主要環境変数
 
 - `MTA_LISTEN_ADDR` (default: `:2525`)
+- `MTA_OBSERVABILITY_ADDR` (default: `:9090`)
 - `MTA_HOSTNAME` (default: `orinoco.local`)
 - `MTA_QUEUE_DIR` (default: `./var/queue`)
 - `MTA_TLS_CERT_FILE` (default: unset)

--- a/cmd/mta/main.go
+++ b/cmd/mta/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/tamago0224/orinoco-mta/internal/bounce"
 	"github.com/tamago0224/orinoco-mta/internal/config"
 	"github.com/tamago0224/orinoco-mta/internal/delivery"
+	"github.com/tamago0224/orinoco-mta/internal/observability"
 	"github.com/tamago0224/orinoco-mta/internal/queue"
 	"github.com/tamago0224/orinoco-mta/internal/smtp"
 	"github.com/tamago0224/orinoco-mta/internal/worker"
@@ -30,15 +31,17 @@ func main() {
 	if err != nil {
 		log.Fatalf("suppression init failed: %v", err)
 	}
+	metrics := observability.NewMetrics()
 
-	d := worker.New(cfg, q, delivery.NewClient(cfg), sup)
-	s := smtp.NewServer(cfg, q)
+	d := worker.New(cfg, q, delivery.NewClient(cfg), sup, metrics)
+	s := smtp.NewServer(cfg, q, metrics)
 
-	errCh := make(chan error, 2)
+	errCh := make(chan error, 3)
 	go func() { errCh <- s.Run(ctx) }()
 	go func() { errCh <- d.Run(ctx) }()
+	go func() { errCh <- observability.RunServer(ctx, cfg.ObservabilityAddr, metrics) }()
 
-	for i := 0; i < 2; i++ {
+	for i := 0; i < 3; i++ {
 		err := <-errCh
 		if err == nil || errors.Is(err, context.Canceled) {
 			continue

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,38 +8,40 @@ import (
 )
 
 type Config struct {
-	ListenAddr       string
-	Hostname         string
-	QueueDir         string
-	TLSCertFile      string
-	TLSKeyFile       string
-	IngressRateLimit int
-	DNSBLZones       []string
-	DNSBLCacheTTL    time.Duration
-	MaxMessageBytes  int64
-	WorkerCount      int
-	MaxAttempts      int
-	MaxRetryAge      time.Duration
-	RetrySchedule    []time.Duration
-	ScanInterval     time.Duration
-	DialTimeout      time.Duration
-	SendTimeout      time.Duration
+	ListenAddr        string
+	ObservabilityAddr string
+	Hostname          string
+	QueueDir          string
+	TLSCertFile       string
+	TLSKeyFile        string
+	IngressRateLimit  int
+	DNSBLZones        []string
+	DNSBLCacheTTL     time.Duration
+	MaxMessageBytes   int64
+	WorkerCount       int
+	MaxAttempts       int
+	MaxRetryAge       time.Duration
+	RetrySchedule     []time.Duration
+	ScanInterval      time.Duration
+	DialTimeout       time.Duration
+	SendTimeout       time.Duration
 }
 
 func Load() Config {
 	return Config{
-		ListenAddr:       env("MTA_LISTEN_ADDR", ":2525"),
-		Hostname:         env("MTA_HOSTNAME", "orinoco.local"),
-		QueueDir:         env("MTA_QUEUE_DIR", "./var/queue"),
-		TLSCertFile:      env("MTA_TLS_CERT_FILE", ""),
-		TLSKeyFile:       env("MTA_TLS_KEY_FILE", ""),
-		IngressRateLimit: envInt("MTA_INGRESS_RATE_LIMIT_PER_MINUTE", 100),
-		DNSBLZones:       envCSV("MTA_DNSBL_ZONES", []string{}),
-		DNSBLCacheTTL:    envDuration("MTA_DNSBL_CACHE_TTL", 5*time.Minute),
-		MaxMessageBytes:  envInt64("MTA_MAX_MESSAGE_BYTES", 10*1024*1024),
-		WorkerCount:      envInt("MTA_WORKER_COUNT", 4),
-		MaxAttempts:      envInt("MTA_MAX_ATTEMPTS", 12),
-		MaxRetryAge:      envDuration("MTA_MAX_RETRY_AGE", 5*24*time.Hour),
+		ListenAddr:        env("MTA_LISTEN_ADDR", ":2525"),
+		ObservabilityAddr: env("MTA_OBSERVABILITY_ADDR", ":9090"),
+		Hostname:          env("MTA_HOSTNAME", "orinoco.local"),
+		QueueDir:          env("MTA_QUEUE_DIR", "./var/queue"),
+		TLSCertFile:       env("MTA_TLS_CERT_FILE", ""),
+		TLSKeyFile:        env("MTA_TLS_KEY_FILE", ""),
+		IngressRateLimit:  envInt("MTA_INGRESS_RATE_LIMIT_PER_MINUTE", 100),
+		DNSBLZones:        envCSV("MTA_DNSBL_ZONES", []string{}),
+		DNSBLCacheTTL:     envDuration("MTA_DNSBL_CACHE_TTL", 5*time.Minute),
+		MaxMessageBytes:   envInt64("MTA_MAX_MESSAGE_BYTES", 10*1024*1024),
+		WorkerCount:       envInt("MTA_WORKER_COUNT", 4),
+		MaxAttempts:       envInt("MTA_MAX_ATTEMPTS", 12),
+		MaxRetryAge:       envDuration("MTA_MAX_RETRY_AGE", 5*24*time.Hour),
 		RetrySchedule: envDurationList(
 			"MTA_RETRY_SCHEDULE",
 			[]time.Duration{5 * time.Minute, 30 * time.Minute, 2 * time.Hour, 6 * time.Hour, 24 * time.Hour},

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -1,0 +1,103 @@
+package observability
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+type Counter struct {
+	name string
+	v    atomic.Uint64
+}
+
+func (c *Counter) Inc() {
+	c.v.Add(1)
+}
+
+func (c *Counter) Add(n uint64) {
+	c.v.Add(n)
+}
+
+func (c *Counter) Load() uint64 {
+	return c.v.Load()
+}
+
+type Metrics struct {
+	mu       sync.RWMutex
+	counters map[string]*Counter
+}
+
+func NewMetrics() *Metrics {
+	return &Metrics{counters: map[string]*Counter{}}
+}
+
+func (m *Metrics) Counter(name string) *Counter {
+	m.mu.RLock()
+	if c, ok := m.counters[name]; ok {
+		m.mu.RUnlock()
+		return c
+	}
+	m.mu.RUnlock()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if c, ok := m.counters[name]; ok {
+		return c
+	}
+	c := &Counter{name: sanitizeMetricName(name)}
+	m.counters[name] = c
+	return c
+}
+
+func (m *Metrics) Snapshot() map[string]uint64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make(map[string]uint64, len(m.counters))
+	for k, c := range m.counters {
+		out[c.name] = c.Load()
+		_ = k
+	}
+	return out
+}
+
+func (m *Metrics) RenderPrometheus() string {
+	snap := m.Snapshot()
+	names := make([]string, 0, len(snap))
+	for n := range snap {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	var b strings.Builder
+	for _, n := range names {
+		fmt.Fprintf(&b, "# TYPE %s counter\n", n)
+		fmt.Fprintf(&b, "%s %d\n", n, snap[n])
+	}
+	return b.String()
+}
+
+func sanitizeMetricName(in string) string {
+	in = strings.ToLower(strings.TrimSpace(in))
+	if in == "" {
+		return "orinoco_unknown_total"
+	}
+	var b strings.Builder
+	for i := 0; i < len(in); i++ {
+		ch := in[i]
+		if (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '_' {
+			b.WriteByte(ch)
+		} else {
+			b.WriteByte('_')
+		}
+	}
+	name := b.String()
+	if !strings.HasSuffix(name, "_total") {
+		name += "_total"
+	}
+	if name[0] >= '0' && name[0] <= '9' {
+		name = "orinoco_" + name
+	}
+	return name
+}

--- a/internal/observability/metrics_test.go
+++ b/internal/observability/metrics_test.go
@@ -1,0 +1,28 @@
+package observability
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMetricsCounterAndRender(t *testing.T) {
+	m := NewMetrics()
+	m.Counter("smtp_connections").Inc()
+	m.Counter("smtp_connections").Add(2)
+	m.Counter("worker.delivery.success").Inc()
+
+	s := m.Snapshot()
+	if s["smtp_connections_total"] != 3 {
+		t.Fatalf("smtp_connections_total=%d", s["smtp_connections_total"])
+	}
+	if s["worker_delivery_success_total"] != 1 {
+		t.Fatalf("worker_delivery_success_total=%d", s["worker_delivery_success_total"])
+	}
+
+	r := m.RenderPrometheus()
+	for _, k := range []string{"smtp_connections_total", "worker_delivery_success_total"} {
+		if !strings.Contains(r, k) {
+			t.Fatalf("missing %s in render: %s", k, r)
+		}
+	}
+}

--- a/internal/observability/server.go
+++ b/internal/observability/server.go
@@ -1,0 +1,38 @@
+package observability
+
+import (
+	"context"
+	"log"
+	"net/http"
+)
+
+func RunServer(ctx context.Context, addr string, m *Metrics) error {
+	if addr == "" {
+		return nil
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
+		if m == nil {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+		_, _ = w.Write([]byte(m.RenderPrometheus()))
+	})
+
+	srv := &http.Server{Addr: addr, Handler: mux}
+	go func() {
+		<-ctx.Done()
+		_ = srv.Shutdown(context.Background())
+	}()
+	log.Printf("observability listening on %s", addr)
+	err := srv.ListenAndServe()
+	if err == http.ErrServerClosed {
+		return nil
+	}
+	return err
+}

--- a/internal/observability/server_test.go
+++ b/internal/observability/server_test.go
@@ -1,0 +1,41 @@
+package observability
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestRunServerMetricsEndpoint(t *testing.T) {
+	m := NewMetrics()
+	m.Counter("smtp_connections").Inc()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	addr := "127.0.0.1:29090"
+	go func() {
+		_ = RunServer(ctx, addr, m)
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		resp, err := http.Get("http://" + addr + "/metrics")
+		if err == nil {
+			b, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status=%d", resp.StatusCode)
+			}
+			if len(b) == 0 {
+				t.Fatal("empty metrics body")
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("metrics endpoint not ready: %v", err)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}

--- a/internal/smtp/server.go
+++ b/internal/smtp/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/tamago0224/orinoco-mta/internal/ingress"
 	"github.com/tamago0224/orinoco-mta/internal/mailauth"
 	"github.com/tamago0224/orinoco-mta/internal/model"
+	"github.com/tamago0224/orinoco-mta/internal/observability"
 	"github.com/tamago0224/orinoco-mta/internal/queue"
 	"github.com/tamago0224/orinoco-mta/internal/util"
 )
@@ -29,11 +30,12 @@ type Server struct {
 	tlsLoadErr error
 	limiter    *ingress.RateLimiter
 	dnsbl      *ingress.DNSBLChecker
+	metrics    *observability.Metrics
 	ln         net.Listener
 	wg         sync.WaitGroup
 }
 
-func NewServer(cfg config.Config, q *queue.Store) *Server {
+func NewServer(cfg config.Config, q *queue.Store, metrics *observability.Metrics) *Server {
 	tlsConfig, err := loadTLSConfig(cfg)
 	return &Server{
 		cfg:        cfg,
@@ -42,6 +44,7 @@ func NewServer(cfg config.Config, q *queue.Store) *Server {
 		tlsLoadErr: err,
 		limiter:    ingress.NewRateLimiter(cfg.IngressRateLimit, time.Minute),
 		dnsbl:      ingress.NewDNSBLChecker(cfg.DNSBLZones, cfg.DNSBLCacheTTL, nil),
+		metrics:    metrics,
 	}
 }
 
@@ -93,17 +96,22 @@ type session struct {
 func (s *Server) handleConn(conn net.Conn) {
 	defer conn.Close()
 	_ = conn.SetDeadline(time.Now().Add(10 * time.Minute))
+	s.metricInc("smtp_connections")
 	remoteIP := parseRemoteIP(conn.RemoteAddr().String())
 	r := bufio.NewReader(conn)
 	w := bufio.NewWriter(conn)
 	if remoteIP != nil {
 		remoteStr := remoteIP.String()
 		if s.limiter != nil && !s.limiter.Allow(remoteStr, time.Now().UTC()) {
+			s.metricInc("smtp_reject_rate_limit")
+			log.Printf("event=ingress_reject reason=rate_limit remote_ip=%s", remoteStr)
 			writeResp(w, 421, "rate limit exceeded, try again later")
 			return
 		}
 		if s.dnsbl != nil {
 			if listed, zone := s.dnsbl.IsListed(remoteStr); listed {
+				s.metricInc("smtp_reject_dnsbl")
+				log.Printf("event=ingress_reject reason=dnsbl zone=%s remote_ip=%s", zone, remoteStr)
 				writeResp(w, 554, "connection rejected (dnsbl: "+zone+")")
 				return
 			}
@@ -194,9 +202,11 @@ func (s *Server) handleConn(conn net.Conn) {
 			}
 			if err := s.enqueue(ss); err != nil {
 				log.Printf("enqueue error: %v", err)
+				s.metricInc("smtp_enqueue_fail")
 				writeResp(w, 451, "temporary local problem")
 				continue
 			}
+			s.metricInc("smtp_queued_messages")
 			writeResp(w, 250, "queued")
 			ss.mailFrom = ""
 			ss.rcptTo = nil
@@ -237,6 +247,12 @@ func (s *Server) handleConn(conn net.Conn) {
 		default:
 			writeResp(w, 500, "unsupported command")
 		}
+	}
+}
+
+func (s *Server) metricInc(name string) {
+	if s.metrics != nil {
+		s.metrics.Counter(name).Inc()
 	}
 }
 

--- a/internal/worker/dispatcher.go
+++ b/internal/worker/dispatcher.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tamago0224/orinoco-mta/internal/config"
 	"github.com/tamago0224/orinoco-mta/internal/delivery"
 	"github.com/tamago0224/orinoco-mta/internal/model"
+	"github.com/tamago0224/orinoco-mta/internal/observability"
 	"github.com/tamago0224/orinoco-mta/internal/queue"
 )
 
@@ -20,10 +21,11 @@ type Dispatcher struct {
 	queue *queue.Store
 	cl    *delivery.Client
 	sup   *bounce.SuppressionStore
+	m     *observability.Metrics
 }
 
-func New(cfg config.Config, q *queue.Store, cl *delivery.Client, sup *bounce.SuppressionStore) *Dispatcher {
-	return &Dispatcher{cfg: cfg, queue: q, cl: cl, sup: sup}
+func New(cfg config.Config, q *queue.Store, cl *delivery.Client, sup *bounce.SuppressionStore, metrics *observability.Metrics) *Dispatcher {
+	return &Dispatcher{cfg: cfg, queue: q, cl: cl, sup: sup, m: metrics}
 }
 
 func (d *Dispatcher) Run(ctx context.Context) error {
@@ -75,12 +77,14 @@ func (d *Dispatcher) handleMessage(ctx context.Context, msg *model.Message) {
 	for _, rcpt := range msg.RcptTo {
 		if d.sup != nil && d.sup.IsSuppressed(rcpt) {
 			reasons = append(reasons, rcpt+": suppressed")
+			d.metricInc("worker_suppressed_recipient")
 			continue
 		}
 		if err := d.cl.Deliver(ctx, msg, rcpt); err != nil {
 			reasons = append(reasons, rcpt+": "+err.Error())
 			var smtpErr *delivery.SMTPResponseError
 			if errors.As(err, &smtpErr) && smtpErr.Permanent() {
+				d.metricInc("worker_permanent_bounce")
 				if d.sup != nil {
 					if sErr := d.sup.Add(rcpt, smtpErr.Line); sErr != nil {
 						log.Printf("suppression add error addr=%s: %v", rcpt, sErr)
@@ -88,7 +92,10 @@ func (d *Dispatcher) handleMessage(ctx context.Context, msg *model.Message) {
 				}
 				continue
 			}
+			d.metricInc("worker_temporary_failure")
 			errs = append(errs, err)
+		} else {
+			d.metricInc("worker_delivery_success")
 		}
 	}
 
@@ -96,6 +103,7 @@ func (d *Dispatcher) handleMessage(ctx context.Context, msg *model.Message) {
 		if err := d.queue.AckSent(msg.ID, msg); err != nil {
 			log.Printf("ack sent error id=%s: %v", msg.ID, err)
 		}
+		d.metricInc("worker_ack_sent")
 		return
 	}
 
@@ -104,12 +112,14 @@ func (d *Dispatcher) handleMessage(ctx context.Context, msg *model.Message) {
 		if err := d.queue.Fail(msg, reason); err != nil {
 			log.Printf("mark failed error id=%s: %v", msg.ID, err)
 		}
+		d.metricInc("worker_mark_failed")
 		return
 	}
 	delay := backoff(msg.Attempts, d.cfg.RetrySchedule)
 	if err := d.queue.Retry(msg, delay, reason); err != nil {
 		log.Printf("retry schedule error id=%s: %v", msg.ID, err)
 	}
+	d.metricInc("worker_retry_scheduled")
 }
 
 func backoff(attempts int, schedule []time.Duration) time.Duration {
@@ -159,4 +169,10 @@ func shouldFail(msg *model.Message, errs []error, cfg config.Config, now time.Ti
 		return false
 	}
 	return hasPermanent
+}
+
+func (d *Dispatcher) metricInc(name string) {
+	if d.m != nil {
+		d.m.Counter(name).Inc()
+	}
 }


### PR DESCRIPTION
## 概要
- `internal/observability` を新規追加
  - Prometheus形式で出力するメトリクス集約
  - `/metrics` と `/healthz` を提供するHTTPサーバ
- `cmd/mta` で observability サーバを並行起動
- SMTP/worker に主要カウンタを追加
  - 接続数、キュー投入数、レート制限/DNSBL拒否
  - 配送成功、再送、恒久失敗、suppression関連
- 設定追加: `MTA_OBSERVABILITY_ADDR`
- README更新と observability のテスト追加

## 関連Issue
Closes #8

## 検証
- `go test ./...`
- `go vet ./...`