### PR TITLE
feat: 送信時MTA-STSポリシー取得とenforce適用を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ go run ./cmd/mta
 - `MTA_INGRESS_RATE_LIMIT_PER_MINUTE` (default: `100`)
 - `MTA_DNSBL_ZONES` (default: unset, comma-separated)
 - `MTA_DNSBL_CACHE_TTL` (default: `5m`)
+- `MTA_MTA_STS_CACHE_TTL` (default: `1h`)
+- `MTA_MTA_STS_FETCH_TIMEOUT` (default: `5s`)
 - `MTA_MAX_MESSAGE_BYTES` (default: `10485760`)
 - `MTA_WORKER_COUNT` (default: `4`)
 - `MTA_MAX_ATTEMPTS` (default: `12`)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,40 +8,44 @@ import (
 )
 
 type Config struct {
-	ListenAddr        string
-	ObservabilityAddr string
-	Hostname          string
-	QueueDir          string
-	TLSCertFile       string
-	TLSKeyFile        string
-	IngressRateLimit  int
-	DNSBLZones        []string
-	DNSBLCacheTTL     time.Duration
-	MaxMessageBytes   int64
-	WorkerCount       int
-	MaxAttempts       int
-	MaxRetryAge       time.Duration
-	RetrySchedule     []time.Duration
-	ScanInterval      time.Duration
-	DialTimeout       time.Duration
-	SendTimeout       time.Duration
+	ListenAddr         string
+	ObservabilityAddr  string
+	Hostname           string
+	QueueDir           string
+	TLSCertFile        string
+	TLSKeyFile         string
+	IngressRateLimit   int
+	DNSBLZones         []string
+	DNSBLCacheTTL      time.Duration
+	MTASTSCacheTTL     time.Duration
+	MTASTSFetchTimeout time.Duration
+	MaxMessageBytes    int64
+	WorkerCount        int
+	MaxAttempts        int
+	MaxRetryAge        time.Duration
+	RetrySchedule      []time.Duration
+	ScanInterval       time.Duration
+	DialTimeout        time.Duration
+	SendTimeout        time.Duration
 }
 
 func Load() Config {
 	return Config{
-		ListenAddr:        env("MTA_LISTEN_ADDR", ":2525"),
-		ObservabilityAddr: env("MTA_OBSERVABILITY_ADDR", ":9090"),
-		Hostname:          env("MTA_HOSTNAME", "orinoco.local"),
-		QueueDir:          env("MTA_QUEUE_DIR", "./var/queue"),
-		TLSCertFile:       env("MTA_TLS_CERT_FILE", ""),
-		TLSKeyFile:        env("MTA_TLS_KEY_FILE", ""),
-		IngressRateLimit:  envInt("MTA_INGRESS_RATE_LIMIT_PER_MINUTE", 100),
-		DNSBLZones:        envCSV("MTA_DNSBL_ZONES", []string{}),
-		DNSBLCacheTTL:     envDuration("MTA_DNSBL_CACHE_TTL", 5*time.Minute),
-		MaxMessageBytes:   envInt64("MTA_MAX_MESSAGE_BYTES", 10*1024*1024),
-		WorkerCount:       envInt("MTA_WORKER_COUNT", 4),
-		MaxAttempts:       envInt("MTA_MAX_ATTEMPTS", 12),
-		MaxRetryAge:       envDuration("MTA_MAX_RETRY_AGE", 5*24*time.Hour),
+		ListenAddr:         env("MTA_LISTEN_ADDR", ":2525"),
+		ObservabilityAddr:  env("MTA_OBSERVABILITY_ADDR", ":9090"),
+		Hostname:           env("MTA_HOSTNAME", "orinoco.local"),
+		QueueDir:           env("MTA_QUEUE_DIR", "./var/queue"),
+		TLSCertFile:        env("MTA_TLS_CERT_FILE", ""),
+		TLSKeyFile:         env("MTA_TLS_KEY_FILE", ""),
+		IngressRateLimit:   envInt("MTA_INGRESS_RATE_LIMIT_PER_MINUTE", 100),
+		DNSBLZones:         envCSV("MTA_DNSBL_ZONES", []string{}),
+		DNSBLCacheTTL:      envDuration("MTA_DNSBL_CACHE_TTL", 5*time.Minute),
+		MTASTSCacheTTL:     envDuration("MTA_MTA_STS_CACHE_TTL", time.Hour),
+		MTASTSFetchTimeout: envDuration("MTA_MTA_STS_FETCH_TIMEOUT", 5*time.Second),
+		MaxMessageBytes:    envInt64("MTA_MAX_MESSAGE_BYTES", 10*1024*1024),
+		WorkerCount:        envInt("MTA_WORKER_COUNT", 4),
+		MaxAttempts:        envInt("MTA_MAX_ATTEMPTS", 12),
+		MaxRetryAge:        envDuration("MTA_MAX_RETRY_AGE", 5*24*time.Hour),
 		RetrySchedule: envDurationList(
 			"MTA_RETRY_SCHEDULE",
 			[]time.Duration{5 * time.Minute, 30 * time.Minute, 2 * time.Hour, 6 * time.Hour, 24 * time.Hour},

--- a/internal/delivery/mta_sts.go
+++ b/internal/delivery/mta_sts.go
@@ -1,0 +1,168 @@
+package delivery
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+type MTASTSPolicy struct {
+	Version   string
+	Mode      string
+	MX        []string
+	MaxAge    time.Duration
+	ExpiresAt time.Time
+}
+
+func (p MTASTSPolicy) AllowsMX(host string) bool {
+	host = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(host), "."))
+	for _, pat := range p.MX {
+		pat = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(pat), "."))
+		if pat == "" {
+			continue
+		}
+		if strings.HasPrefix(pat, "*.") {
+			suffix := strings.TrimPrefix(pat, "*.")
+			if strings.HasSuffix(host, "."+suffix) {
+				return true
+			}
+			continue
+		}
+		if host == pat {
+			return true
+		}
+	}
+	return false
+}
+
+type MTASTSResolver struct {
+	ttl       time.Duration
+	fetchTO   time.Duration
+	fetchFunc func(ctx context.Context, domain string) (string, error)
+
+	mu    sync.Mutex
+	cache map[string]MTASTSPolicy
+}
+
+func NewMTASTSResolver(ttl, fetchTimeout time.Duration, fetchFunc func(ctx context.Context, domain string) (string, error)) *MTASTSResolver {
+	if fetchFunc == nil {
+		fetchFunc = fetchMTASTSPolicyTextHTTP(fetchTimeout)
+	}
+	if ttl <= 0 {
+		ttl = time.Hour
+	}
+	if fetchTimeout <= 0 {
+		fetchTimeout = 5 * time.Second
+	}
+	return &MTASTSResolver{ttl: ttl, fetchTO: fetchTimeout, fetchFunc: fetchFunc, cache: map[string]MTASTSPolicy{}}
+}
+
+func (r *MTASTSResolver) Lookup(ctx context.Context, domain string) (MTASTSPolicy, error) {
+	domain = strings.ToLower(strings.TrimSpace(domain))
+	if domain == "" {
+		return MTASTSPolicy{}, errors.New("empty domain")
+	}
+	now := time.Now().UTC()
+	r.mu.Lock()
+	if p, ok := r.cache[domain]; ok && now.Before(p.ExpiresAt) {
+		r.mu.Unlock()
+		return p, nil
+	}
+	r.mu.Unlock()
+
+	text, err := r.fetchFunc(ctx, domain)
+	if err != nil {
+		return MTASTSPolicy{}, err
+	}
+	p, err := parseMTASTSPolicy(text)
+	if err != nil {
+		return MTASTSPolicy{}, err
+	}
+	expire := now.Add(p.MaxAge)
+	if ttlExpire := now.Add(r.ttl); ttlExpire.Before(expire) {
+		expire = ttlExpire
+	}
+	p.ExpiresAt = expire
+
+	r.mu.Lock()
+	r.cache[domain] = p
+	r.mu.Unlock()
+	return p, nil
+}
+
+func parseMTASTSPolicy(raw string) (MTASTSPolicy, error) {
+	var p MTASTSPolicy
+	for _, line := range strings.Split(strings.ReplaceAll(raw, "\r\n", "\n"), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		k := strings.ToLower(strings.TrimSpace(parts[0]))
+		v := strings.TrimSpace(parts[1])
+		switch k {
+		case "version":
+			p.Version = v
+		case "mode":
+			p.Mode = strings.ToLower(v)
+		case "mx":
+			if v != "" {
+				p.MX = append(p.MX, v)
+			}
+		case "max_age":
+			n, err := strconv.Atoi(v)
+			if err != nil {
+				return MTASTSPolicy{}, fmt.Errorf("invalid max_age: %w", err)
+			}
+			p.MaxAge = time.Duration(n) * time.Second
+		}
+	}
+	if p.Version != "STSv1" {
+		return MTASTSPolicy{}, errors.New("invalid mta-sts version")
+	}
+	switch p.Mode {
+	case "enforce", "testing", "none":
+	default:
+		return MTASTSPolicy{}, errors.New("invalid mta-sts mode")
+	}
+	if p.MaxAge <= 0 {
+		return MTASTSPolicy{}, errors.New("max_age must be positive")
+	}
+	if p.Mode != "none" && len(p.MX) == 0 {
+		return MTASTSPolicy{}, errors.New("mx is required for non-none mode")
+	}
+	return p, nil
+}
+
+func fetchMTASTSPolicyTextHTTP(timeout time.Duration) func(context.Context, string) (string, error) {
+	client := &http.Client{Timeout: timeout}
+	return func(ctx context.Context, domain string) (string, error) {
+		url := fmt.Sprintf("https://mta-sts.%s/.well-known/mta-sts.txt", domain)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return "", err
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return "", err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode > 299 {
+			return "", fmt.Errorf("unexpected status %d", resp.StatusCode)
+		}
+		b, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		if err != nil {
+			return "", err
+		}
+		return string(b), nil
+	}
+}

--- a/internal/delivery/mta_sts_test.go
+++ b/internal/delivery/mta_sts_test.go
@@ -1,0 +1,56 @@
+package delivery
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestParseMTASTSPolicy(t *testing.T) {
+	raw := "version: STSv1\nmode: enforce\nmx: *.example.net\nmx: mail.example.org\nmax_age: 86400\n"
+	p, err := parseMTASTSPolicy(raw)
+	if err != nil {
+		t.Fatalf("parse policy: %v", err)
+	}
+	if p.Mode != "enforce" || p.MaxAge != 24*time.Hour {
+		t.Fatalf("unexpected policy: %+v", p)
+	}
+	if len(p.MX) != 2 {
+		t.Fatalf("mx count=%d", len(p.MX))
+	}
+}
+
+func TestMTASTSAllowsMX(t *testing.T) {
+	p := MTASTSPolicy{Mode: "enforce", MX: []string{"*.example.net", "mail.example.org"}}
+	if !p.AllowsMX("mx1.example.net") {
+		t.Fatal("wildcard should match")
+	}
+	if !p.AllowsMX("mail.example.org") {
+		t.Fatal("exact match should match")
+	}
+	if p.AllowsMX("bad.example.com") {
+		t.Fatal("unlisted host should not match")
+	}
+}
+
+func TestMTASTSResolverCachesResult(t *testing.T) {
+	calls := 0
+	r := NewMTASTSResolver(5*time.Minute, 2*time.Second, func(ctx context.Context, domain string) (string, error) {
+		calls++
+		return "version: STSv1\nmode: enforce\nmx: *.example.net\nmax_age: 120\n", nil
+	})
+	p1, err := r.Lookup(context.Background(), "example.com")
+	if err != nil {
+		t.Fatalf("lookup1: %v", err)
+	}
+	p2, err := r.Lookup(context.Background(), "example.com")
+	if err != nil {
+		t.Fatalf("lookup2: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected cache hit, calls=%d", calls)
+	}
+	if p1.Mode != p2.Mode {
+		t.Fatalf("cached policy mismatch")
+	}
+}

--- a/internal/delivery/smtp_client.go
+++ b/internal/delivery/smtp_client.go
@@ -17,11 +17,15 @@ import (
 )
 
 type Client struct {
-	cfg config.Config
+	cfg    config.Config
+	mtaSTS *MTASTSResolver
 }
 
 func NewClient(cfg config.Config) *Client {
-	return &Client{cfg: cfg}
+	return &Client{
+		cfg:    cfg,
+		mtaSTS: NewMTASTSResolver(cfg.MTASTSCacheTTL, cfg.MTASTSFetchTimeout, nil),
+	}
 }
 
 func (c *Client) Deliver(ctx context.Context, msg *model.Message, rcpt string) error {
@@ -33,9 +37,27 @@ func (c *Client) Deliver(ctx context.Context, msg *model.Message, rcpt string) e
 	if err != nil {
 		return fmt.Errorf("mx lookup failed: %w", err)
 	}
+	requireTLS := false
+	if c.mtaSTS != nil {
+		if p, pErr := c.mtaSTS.Lookup(ctx, domain); pErr == nil {
+			if p.Mode == "enforce" {
+				requireTLS = true
+				filtered := make([]router.MXHost, 0, len(mxHosts))
+				for _, mx := range mxHosts {
+					if p.AllowsMX(mx.Host) {
+						filtered = append(filtered, mx)
+					}
+				}
+				if len(filtered) == 0 {
+					return &SMTPResponseError{Code: 454, Line: "mta-sts policy mismatch: no allowed mx"}
+				}
+				mxHosts = filtered
+			}
+		}
+	}
 	var lastErr error
 	for _, mx := range mxHosts {
-		if err := c.deliverHost(ctx, mx.Host, msg, rcpt); err == nil {
+		if err := c.deliverHost(ctx, mx.Host, msg, rcpt, requireTLS); err == nil {
 			return nil
 		} else {
 			lastErr = err
@@ -47,7 +69,7 @@ func (c *Client) Deliver(ctx context.Context, msg *model.Message, rcpt string) e
 	return lastErr
 }
 
-func (c *Client) deliverHost(ctx context.Context, host string, msg *model.Message, rcpt string) error {
+func (c *Client) deliverHost(ctx context.Context, host string, msg *model.Message, rcpt string, requireTLS bool) error {
 	dialer := &net.Dialer{Timeout: c.cfg.DialTimeout}
 	conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(host, "25"))
 	if err != nil {
@@ -88,6 +110,9 @@ func (c *Client) deliverHost(ctx context.Context, host string, msg *model.Messag
 		if code == 220 {
 			tlsConn := tls.Client(conn, &tls.Config{ServerName: host, MinVersion: tls.VersionTLS12})
 			if err := tlsConn.HandshakeContext(ctx); err != nil {
+				if requireTLS {
+					return &SMTPResponseError{Code: 454, Line: "starttls handshake failed"}
+				}
 				return err
 			}
 			conn = tlsConn
@@ -100,6 +125,8 @@ func (c *Client) deliverHost(ctx context.Context, host string, msg *model.Messag
 				return err
 			}
 		}
+	} else if requireTLS {
+		return &SMTPResponseError{Code: 454, Line: "mta-sts enforce requires starttls"}
 	}
 
 	if err := writeLine(w, fmt.Sprintf("MAIL FROM:<%s>", msg.MailFrom)); err != nil {


### PR DESCRIPTION
## 概要
- 送信側に MTA-STS ポリシーリゾルバを追加
  - `https://mta-sts.<domain>/.well-known/mta-sts.txt` 取得
  - パース、TTLキャッシュ、MXパターン判定
- `mode=enforce` 時に許可MXのみ配送対象に制限
- `mode=enforce` 時は STARTTLS必須化（未対応/失敗は一時失敗として扱う）
- 設定追加
  - `MTA_MTA_STS_CACHE_TTL`
  - `MTA_MTA_STS_FETCH_TIMEOUT`
- 単体テストを追加（ポリシーパース、MX判定、キャッシュ）

## 関連Issue
Refs #4

## 検証
- `go test ./internal/delivery`
- `go test ./...`
- `go vet ./...`

## 補足
- DANE検証（TLSA/DNSSEC）は本PRでは未実装です。続きで対応します。