### PR TITLE
配送ポリシーに DANE 優先判定を追加

### DIFF
--- a/internal/delivery/dane.go
+++ b/internal/delivery/dane.go
@@ -1,0 +1,247 @@
+package delivery
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	dnsTypeTLSA = 52
+	dnsClassIN  = 1
+)
+
+type TLSARecord struct {
+	Usage                  uint8
+	Selector               uint8
+	MatchingType           uint8
+	CertificateAssociation []byte
+}
+
+type DANEResult struct {
+	AuthenticatedData bool
+	Records           []TLSARecord
+}
+
+func (r DANEResult) HasUsableTLSA() bool {
+	if !r.AuthenticatedData {
+		return false
+	}
+	for _, rec := range r.Records {
+		if rec.Usage == 3 && rec.Selector == 1 && rec.MatchingType == 1 && len(rec.CertificateAssociation) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+type DANEResolver struct {
+	timeout  time.Duration
+	lookupFn func(context.Context, string, int) (DANEResult, error)
+}
+
+func NewDANEResolver(timeout time.Duration, lookupFn func(context.Context, string, int) (DANEResult, error)) *DANEResolver {
+	if timeout <= 0 {
+		timeout = 2 * time.Second
+	}
+	if lookupFn == nil {
+		lookupFn = lookupTLSAUDP(timeout)
+	}
+	return &DANEResolver{timeout: timeout, lookupFn: lookupFn}
+}
+
+func (r *DANEResolver) LookupHost(ctx context.Context, host string, port int) (DANEResult, error) {
+	host = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+	if host == "" {
+		return DANEResult{}, errors.New("empty host")
+	}
+	if port <= 0 {
+		port = 25
+	}
+	return r.lookupFn(ctx, host, port)
+}
+
+func lookupTLSAUDP(timeout time.Duration) func(context.Context, string, int) (DANEResult, error) {
+	return func(ctx context.Context, host string, port int) (DANEResult, error) {
+		qname := fmt.Sprintf("_%d._tcp.%s", port, host)
+		packet, queryID, err := buildDNSQuery(qname, dnsTypeTLSA)
+		if err != nil {
+			return DANEResult{}, err
+		}
+
+		servers := systemDNSServers()
+		var lastErr error
+		for _, server := range servers {
+			dialer := &net.Dialer{Timeout: timeout}
+			conn, err := dialer.DialContext(ctx, "udp", net.JoinHostPort(server, "53"))
+			if err != nil {
+				lastErr = err
+				continue
+			}
+			_ = conn.SetDeadline(time.Now().Add(timeout))
+			_, err = conn.Write(packet)
+			if err != nil {
+				lastErr = err
+				_ = conn.Close()
+				continue
+			}
+
+			buf := make([]byte, 4096)
+			n, err := conn.Read(buf)
+			_ = conn.Close()
+			if err != nil {
+				lastErr = err
+				continue
+			}
+			return parseTLSAResponse(buf[:n], queryID)
+		}
+		if lastErr == nil {
+			lastErr = errors.New("no dns servers available")
+		}
+		return DANEResult{}, lastErr
+	}
+}
+
+func systemDNSServers() []string {
+	content, err := os.ReadFile("/etc/resolv.conf")
+	if err == nil {
+		lines := strings.Split(strings.ReplaceAll(string(content), "\r\n", "\n"), "\n")
+		out := make([]string, 0, 2)
+		for _, line := range lines {
+			line = strings.TrimSpace(line)
+			if !strings.HasPrefix(line, "nameserver ") {
+				continue
+			}
+			parts := strings.Fields(line)
+			if len(parts) >= 2 && parts[1] != "" {
+				out = append(out, parts[1])
+			}
+		}
+		if len(out) > 0 {
+			return out
+		}
+	}
+	return []string{"127.0.0.53", "8.8.8.8"}
+}
+
+func buildDNSQuery(qname string, qtype uint16) ([]byte, uint16, error) {
+	labels := strings.Split(strings.Trim(strings.TrimSpace(qname), "."), ".")
+	if len(labels) == 0 {
+		return nil, 0, errors.New("empty qname")
+	}
+	id := uint16(time.Now().UTC().UnixNano())
+	header := make([]byte, 12)
+	binary.BigEndian.PutUint16(header[0:2], id)
+	binary.BigEndian.PutUint16(header[2:4], 0x0100) // RD
+	binary.BigEndian.PutUint16(header[4:6], 1)      // QDCOUNT
+
+	q := make([]byte, 0, 256)
+	q = append(q, header...)
+	for _, label := range labels {
+		if label == "" || len(label) > 63 {
+			return nil, 0, errors.New("invalid dns label")
+		}
+		q = append(q, byte(len(label)))
+		q = append(q, []byte(label)...)
+	}
+	q = append(q, 0x00)
+	tmp := make([]byte, 4)
+	binary.BigEndian.PutUint16(tmp[0:2], qtype)
+	binary.BigEndian.PutUint16(tmp[2:4], dnsClassIN)
+	q = append(q, tmp...)
+	return q, id, nil
+}
+
+func parseTLSAResponse(packet []byte, queryID uint16) (DANEResult, error) {
+	if len(packet) < 12 {
+		return DANEResult{}, errors.New("short dns packet")
+	}
+	if binary.BigEndian.Uint16(packet[0:2]) != queryID {
+		return DANEResult{}, errors.New("dns id mismatch")
+	}
+	flags := binary.BigEndian.Uint16(packet[2:4])
+	rcode := flags & 0x000f
+	if rcode != 0 {
+		return DANEResult{}, fmt.Errorf("dns rcode=%d", rcode)
+	}
+	ad := (flags & 0x0020) != 0
+
+	qd := int(binary.BigEndian.Uint16(packet[4:6]))
+	an := int(binary.BigEndian.Uint16(packet[6:8]))
+	offset := 12
+
+	for i := 0; i < qd; i++ {
+		var err error
+		offset, err = skipDNSName(packet, offset)
+		if err != nil {
+			return DANEResult{}, err
+		}
+		if len(packet) < offset+4 {
+			return DANEResult{}, errors.New("short dns question")
+		}
+		offset += 4
+	}
+
+	records := make([]TLSARecord, 0, an)
+	for i := 0; i < an; i++ {
+		var err error
+		offset, err = skipDNSName(packet, offset)
+		if err != nil {
+			return DANEResult{}, err
+		}
+		if len(packet) < offset+10 {
+			return DANEResult{}, errors.New("short dns answer")
+		}
+		typ := binary.BigEndian.Uint16(packet[offset : offset+2])
+		class := binary.BigEndian.Uint16(packet[offset+2 : offset+4])
+		rdlen := int(binary.BigEndian.Uint16(packet[offset+8 : offset+10]))
+		offset += 10
+		if len(packet) < offset+rdlen {
+			return DANEResult{}, errors.New("short dns rdata")
+		}
+		rdata := packet[offset : offset+rdlen]
+		offset += rdlen
+
+		if typ != dnsTypeTLSA || class != dnsClassIN {
+			continue
+		}
+		if len(rdata) < 3 {
+			continue
+		}
+		records = append(records, TLSARecord{
+			Usage:                  rdata[0],
+			Selector:               rdata[1],
+			MatchingType:           rdata[2],
+			CertificateAssociation: append([]byte(nil), rdata[3:]...),
+		})
+	}
+	return DANEResult{AuthenticatedData: ad, Records: records}, nil
+}
+
+func skipDNSName(packet []byte, offset int) (int, error) {
+	for {
+		if offset >= len(packet) {
+			return 0, errors.New("dns name overflow")
+		}
+		l := int(packet[offset])
+		if l == 0 {
+			return offset + 1, nil
+		}
+		if l&0xc0 == 0xc0 {
+			if offset+1 >= len(packet) {
+				return 0, errors.New("short dns compression pointer")
+			}
+			return offset + 2, nil
+		}
+		offset++
+		if l > 63 || offset+l > len(packet) {
+			return 0, errors.New("invalid dns label length")
+		}
+		offset += l
+	}
+}

--- a/internal/delivery/dane_test.go
+++ b/internal/delivery/dane_test.go
@@ -1,0 +1,64 @@
+package delivery
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func TestDANEResultHasUsableTLSA(t *testing.T) {
+	ok := DANEResult{
+		AuthenticatedData: true,
+		Records:           []TLSARecord{{Usage: 3, Selector: 1, MatchingType: 1, CertificateAssociation: []byte{0xaa}}},
+	}
+	if !ok.HasUsableTLSA() {
+		t.Fatal("expected usable tlsa")
+	}
+	if (DANEResult{AuthenticatedData: false, Records: ok.Records}).HasUsableTLSA() {
+		t.Fatal("dnssec ad=false must not be treated as usable")
+	}
+}
+
+func TestParseTLSAResponse(t *testing.T) {
+	queryID := uint16(0x1234)
+	packet := []byte{
+		0x12, 0x34, // id
+		0x81, 0xa0, // flags: response + RD + RA + AD
+		0x00, 0x01, // qdcount
+		0x00, 0x01, // ancount
+		0x00, 0x00, // nscount
+		0x00, 0x00, // arcount
+		0x03, '_', '2', '5', // _25
+		0x04, '_', 't', 'c', 'p',
+		0x07, 'e', 'x', 'a', 'm', 'p', 'l', 'e',
+		0x03, 'n', 'e', 't',
+		0x00,
+		0x00, 0x34, // QTYPE TLSA
+		0x00, 0x01, // QCLASS IN
+		0xc0, 0x0c, // NAME pointer
+		0x00, 0x34, // TYPE TLSA
+		0x00, 0x01, // CLASS IN
+		0x00, 0x00, 0x01, 0x2c, // TTL
+		0x00, 0x05, // RDLENGTH
+		0x03,       // usage
+		0x01,       // selector
+		0x01,       // matching
+		0xde, 0xad, // cert association
+	}
+	res, err := parseTLSAResponse(packet, queryID)
+	if err != nil {
+		t.Fatalf("parseTLSAResponse: %v", err)
+	}
+	if !res.AuthenticatedData {
+		t.Fatal("expected AD=true")
+	}
+	if len(res.Records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(res.Records))
+	}
+	r := res.Records[0]
+	if r.Usage != 3 || r.Selector != 1 || r.MatchingType != 1 {
+		t.Fatalf("unexpected parsed record: %+v", r)
+	}
+	if binary.BigEndian.Uint16(r.CertificateAssociation) != 0xdead {
+		t.Fatalf("unexpected cert association: %x", r.CertificateAssociation)
+	}
+}

--- a/internal/delivery/smtp_client.go
+++ b/internal/delivery/smtp_client.go
@@ -20,6 +20,7 @@ import (
 
 type Client struct {
 	cfg           config.Config
+	dane          *DANEResolver
 	mtaSTS        *MTASTSResolver
 	resolveMXFn   func(string, time.Duration) ([]router.MXHost, error)
 	deliverHostFn func(context.Context, string, int, *model.Message, string, bool) error
@@ -29,6 +30,7 @@ type Client struct {
 func NewClient(cfg config.Config) *Client {
 	c := &Client{
 		cfg:         cfg,
+		dane:        NewDANEResolver(cfg.DialTimeout, nil),
 		mtaSTS:      NewMTASTSResolver(cfg.MTASTSCacheTTL, cfg.MTASTSFetchTimeout, nil),
 		resolveMXFn: router.LookupWithTimeout,
 	}
@@ -71,7 +73,23 @@ func (c *Client) deliverByMX(ctx context.Context, msg *model.Message, rcpt strin
 		return fmt.Errorf("mx lookup failed: %w", err)
 	}
 	requireTLS := false
-	if c.mtaSTS != nil {
+	daneCandidates := make([]router.MXHost, 0, len(mxHosts))
+	if c.dane != nil {
+		for _, mx := range mxHosts {
+			res, lErr := c.dane.LookupHost(ctx, mx.Host, 25)
+			if lErr != nil {
+				continue
+			}
+			if res.HasUsableTLSA() {
+				daneCandidates = append(daneCandidates, mx)
+			}
+		}
+	}
+	if len(daneCandidates) > 0 {
+		// RFC 7672 precedence: if usable DANE is available, apply it before MTA-STS.
+		requireTLS = true
+		mxHosts = daneCandidates
+	} else if c.mtaSTS != nil {
 		if p, pErr := c.mtaSTS.Lookup(ctx, domain); pErr == nil {
 			if p.Mode == "enforce" {
 				requireTLS = true

--- a/internal/delivery/smtp_policy_test.go
+++ b/internal/delivery/smtp_policy_test.go
@@ -1,0 +1,81 @@
+package delivery
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tamago0224/orinoco-mta/internal/config"
+	"github.com/tamago0224/orinoco-mta/internal/model"
+	"github.com/tamago0224/orinoco-mta/internal/router"
+)
+
+func TestDeliverByMX_DANETakesPrecedenceOverMTASTS(t *testing.T) {
+	cl := NewClient(config.Config{})
+	cl.resolveMXFn = func(string, time.Duration) ([]router.MXHost, error) {
+		return []router.MXHost{{Host: "mx1.example.net", Pref: 10}, {Host: "mx2.example.net", Pref: 20}}, nil
+	}
+	cl.mtaSTS = NewMTASTSResolver(time.Minute, time.Second, func(context.Context, string) (string, error) {
+		return "version: STSv1\nmode: enforce\nmx: blocked.example.net\nmax_age: 3600\n", nil
+	})
+	cl.dane = NewDANEResolver(time.Second, func(_ context.Context, host string, _ int) (DANEResult, error) {
+		if host != "mx1.example.net" {
+			return DANEResult{}, nil
+		}
+		return DANEResult{
+			AuthenticatedData: true,
+			Records:           []TLSARecord{{Usage: 3, Selector: 1, MatchingType: 1, CertificateAssociation: []byte{0x01}}},
+		}, nil
+	})
+
+	var calledHost string
+	var requireTLS bool
+	cl.deliverHostFn = func(ctx context.Context, host string, port int, msg *model.Message, rcpt string, reqTLS bool) error {
+		calledHost = host
+		requireTLS = reqTLS
+		return nil
+	}
+
+	err := cl.deliverByMX(context.Background(), &model.Message{MailFrom: "sender@example.org", Data: []byte("x")}, "user@example.org")
+	if err != nil {
+		t.Fatalf("deliverByMX: %v", err)
+	}
+	if calledHost != "mx1.example.net" {
+		t.Fatalf("expected DANE path to keep mx1 candidate, got %q", calledHost)
+	}
+	if !requireTLS {
+		t.Fatal("expected TLS required when DANE is active")
+	}
+}
+
+func TestDeliverByMX_FallsBackToMTASTSWhenNoUsableDANE(t *testing.T) {
+	cl := NewClient(config.Config{})
+	cl.resolveMXFn = func(string, time.Duration) ([]router.MXHost, error) {
+		return []router.MXHost{{Host: "mx1.example.net", Pref: 10}, {Host: "mx2.example.net", Pref: 20}}, nil
+	}
+	cl.mtaSTS = NewMTASTSResolver(time.Minute, time.Second, func(context.Context, string) (string, error) {
+		return "version: STSv1\nmode: enforce\nmx: mx2.example.net\nmax_age: 3600\n", nil
+	})
+	cl.dane = NewDANEResolver(time.Second, func(context.Context, string, int) (DANEResult, error) {
+		return DANEResult{}, nil
+	})
+
+	var calledHost string
+	var requireTLS bool
+	cl.deliverHostFn = func(ctx context.Context, host string, port int, msg *model.Message, rcpt string, reqTLS bool) error {
+		calledHost = host
+		requireTLS = reqTLS
+		return nil
+	}
+
+	err := cl.deliverByMX(context.Background(), &model.Message{MailFrom: "sender@example.org", Data: []byte("x")}, "user@example.org")
+	if err != nil {
+		t.Fatalf("deliverByMX: %v", err)
+	}
+	if calledHost != "mx2.example.net" {
+		t.Fatalf("expected MTA-STS filtering to pick mx2, got %q", calledHost)
+	}
+	if !requireTLS {
+		t.Fatal("expected TLS required by MTA-STS enforce")
+	}
+}


### PR DESCRIPTION
## Summary
- SMTP配送時のTLSポリシー判定を `DANE > MTA-STS > Opportunistic TLS` の順に適用
- DANE向けにTLSA解決器（UDP DNSクエリ + 最小パーサ）を追加
- DANEが有効なMXが存在する場合はその候補へ絞り込み、TLS必須で配送

## Changes
- `internal/delivery/dane.go` を追加
- TLSAレコード型、DANE判定ロジックを実装
- 自前のDNSクエリ構築/応答パース（TLSA type=52）を実装
- ADビット付き応答のみを「usable DANE」として扱う
- `internal/delivery/smtp_client.go` を更新
- `Client` にDANE resolverを追加
- `deliverByMX` で DANE候補がある場合は MTA-STS より優先するよう変更
- テスト追加
- `internal/delivery/smtp_policy_test.go`
- `internal/delivery/dane_test.go`

## Validation
- `go test ./internal/delivery -run 'Test(DANEResultHasUsableTLSA|ParseTLSAResponse|DeliverByMX_DANETakesPrecedenceOverMTASTS|DeliverByMX_FallsBackToMTASTSWhenNoUsableDANE)'`
- `go test ./...`

## Risks / Follow-ups
- 現時点では TLSA レコードの存在確認とADビット判定まで
- 証明書ハンドシェイク時のTLSA照合（ピン検証）は今後の追補が必要
- DNSSEC検証は再帰リゾルバのADビットに依存

Refs #4