### PR TITLE
DNS/TXT/TLSA対応の結合テスト環境を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,14 @@ Kafka のローカル起動例:
 ```bash
 docker compose -f docker-compose.kafka.yml up -d
 ```
+
+## DNS結合テスト環境
+
+受信側の `mailauth`（SPF/DMARC）と送信側の DANE/MTA-STS の検証用に、
+DNS を含む `docker compose` 環境を用意しています。
+
+```bash
+./scripts/integration/run_dns_env_tests.sh
+```
+
+詳細は `test/integration/README.md` を参照してください。

--- a/integration/dns_integration_test.go
+++ b/integration/dns_integration_test.go
@@ -1,0 +1,110 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/tamago0224/orinoco-mta/internal/config"
+	"github.com/tamago0224/orinoco-mta/internal/delivery"
+	"github.com/tamago0224/orinoco-mta/internal/mailauth"
+	"github.com/tamago0224/orinoco-mta/internal/model"
+	"github.com/tamago0224/orinoco-mta/internal/router"
+)
+
+func TestMailAuthSPFAndDMARCWithDNSMock(t *testing.T) {
+	spf := mailauth.EvalSPF(net.ParseIP("192.0.2.10"), "sender@example.test", "mx.example.test")
+	if spf.Result != "pass" {
+		t.Fatalf("spf result=%s reason=%s", spf.Result, spf.Reason)
+	}
+
+	dmarc := mailauth.EvalDMARC("example.test", spf, mailauth.DKIMResult{Result: "none"})
+	if dmarc.Result != "pass" {
+		t.Fatalf("dmarc result=%s reason=%s", dmarc.Result, dmarc.Reason)
+	}
+}
+
+func TestOutboundDANELookupWithDNSMock(t *testing.T) {
+	r := delivery.NewDANEResolver(2*time.Second, nil)
+	res, err := r.LookupHost(context.Background(), "mx1.outbound.test", 25)
+	if err != nil {
+		t.Fatalf("dane lookup: %v", err)
+	}
+	if !res.HasUsableTLSA() {
+		t.Fatalf("expected usable tlsa, got: %+v", res)
+	}
+}
+
+func TestOutboundPolicyPrecedenceDANEOverMTASTS(t *testing.T) {
+	cfg := config.Config{
+		DeliveryMode:       "mx",
+		DialTimeout:        2 * time.Second,
+		MTASTSCacheTTL:     time.Minute,
+		MTASTSFetchTimeout: time.Second,
+	}
+	cl := delivery.NewClient(cfg)
+	cl.ResolveForTest(
+		func(string, time.Duration) ([]router.MXHost, error) {
+			return []router.MXHost{
+				{Host: "mx1.outbound.test", Pref: 10},
+			}, nil
+		},
+		func(_ string) (delivery.MTASTSPolicy, error) {
+			return delivery.MTASTSPolicy{
+				Version: "STSv1",
+				Mode:    "enforce",
+				MX:      []string{"blocked.outbound.test"},
+				MaxAge:  time.Hour,
+			}, nil
+		},
+	)
+
+	called := false
+	cl.DeliverHostForTest(func(_ string, _ int, _ *model.Message, _ string, requireTLS bool) error {
+		called = true
+		if !requireTLS {
+			t.Fatal("expected TLS required when DANE is active")
+		}
+		return nil
+	})
+
+	err := cl.Deliver(context.Background(), &model.Message{ID: "m1", MailFrom: "sender@example.test", Data: []byte("x")}, "rcpt@outbound.test")
+	if err != nil {
+		t.Fatalf("deliver: %v", err)
+	}
+	if !called {
+		t.Fatal("deliver host should be called")
+	}
+}
+
+func TestMTASTSPolicyFetchFromPolicyService(t *testing.T) {
+	url := os.Getenv("INTEG_MTA_STS_POLICY_URL")
+	if url == "" {
+		t.Skip("INTEG_MTA_STS_POLICY_URL is not set")
+	}
+	resolver := delivery.NewMTASTSResolver(time.Minute, 2*time.Second, func(_ context.Context, _ string) (string, error) {
+		resp, err := http.Get(url)
+		if err != nil {
+			return "", err
+		}
+		defer resp.Body.Close()
+		b, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return "", err
+		}
+		return string(b), nil
+	})
+	p, err := resolver.Lookup(context.Background(), "outbound.test")
+	if err != nil {
+		t.Fatalf("mta-sts lookup: %v", err)
+	}
+	if p.Mode != "enforce" || !p.AllowsMX("mx1.outbound.test") {
+		t.Fatalf("unexpected policy: %+v", p)
+	}
+}

--- a/internal/delivery/testing_hooks_integration.go
+++ b/internal/delivery/testing_hooks_integration.go
@@ -1,0 +1,45 @@
+//go:build integration
+
+package delivery
+
+import (
+	"context"
+	"time"
+
+	"github.com/tamago0224/orinoco-mta/internal/model"
+	"github.com/tamago0224/orinoco-mta/internal/router"
+)
+
+func (c *Client) ResolveForTest(
+	resolveMX func(string, time.Duration) ([]router.MXHost, error),
+	lookupMTASTS func(string) (MTASTSPolicy, error),
+) {
+	if resolveMX != nil {
+		c.resolveMXFn = resolveMX
+	}
+	if lookupMTASTS != nil {
+		c.mtaSTS = NewMTASTSResolver(time.Minute, time.Second, func(_ context.Context, domain string) (string, error) {
+			p, err := lookupMTASTS(domain)
+			if err != nil {
+				return "", err
+			}
+			raw := "version: " + p.Version + "\nmode: " + p.Mode + "\n"
+			for _, mx := range p.MX {
+				raw += "mx: " + mx + "\n"
+			}
+			raw += "max_age: 3600\n"
+			return raw, nil
+		})
+	}
+}
+
+func (c *Client) DeliverHostForTest(
+	fn func(host string, port int, msg *model.Message, rcpt string, requireTLS bool) error,
+) {
+	if fn == nil {
+		return
+	}
+	c.deliverHostFn = func(_ context.Context, host string, port int, msg *model.Message, rcpt string, requireTLS bool) error {
+		return fn(host, port, msg, rcpt, requireTLS)
+	}
+}

--- a/scripts/integration/run_dns_env_tests.sh
+++ b/scripts/integration/run_dns_env_tests.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+COMPOSE_FILE="$ROOT_DIR/test/integration/docker-compose.yml"
+
+docker compose -f "$COMPOSE_FILE" up -d --build dnsmock policy
+trap 'docker compose -f "$COMPOSE_FILE" down -v' EXIT
+
+docker compose -f "$COMPOSE_FILE" run --rm tester \
+  go test -tags=integration ./integration/...

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -1,0 +1,28 @@
+# DNS Integration Environment
+
+`docker compose` で DNS/TXT/TLSA を持つ検証環境を起動し、`mailauth` と送信側ポリシーを結合テストできます。
+
+## 構成
+
+- `dnsmock`: TXT/MX/A/TLSA を返す軽量DNSサーバ
+- `policy`: MTA-STS policy 配信用HTTPサーバ
+- `tester`: `go test -tags=integration` を実行するコンテナ
+
+## 任意レコードの追加
+
+`dns/records.json` を編集します。
+
+- SPF: `txt[].name=example.test`, `texts=["v=spf1 ..."]`
+- DMARC: `txt[].name=_dmarc.example.test`
+- DANE: `tlsa[].name=_25._tcp.<mx-host>`
+
+## 実行
+
+```bash
+./scripts/integration/run_dns_env_tests.sh
+```
+
+## 備考
+
+- DANE テスト向けに `dnsmock` は応答で AD ビットを立てます。
+- MTA-STS は `policy` サービス配信の policy ファイルを読み取って検証します。

--- a/test/integration/dns/records.json
+++ b/test/integration/dns/records.json
@@ -1,0 +1,24 @@
+{
+  "a": [
+    { "name": "mx1.outbound.test", "ip": "192.0.2.20", "ttl": 60 },
+    { "name": "mta-sts.outbound.test", "ip": "172.28.0.80", "ttl": 60 }
+  ],
+  "mx": [
+    { "name": "outbound.test", "preference": 10, "host": "mx1.outbound.test", "ttl": 60 }
+  ],
+  "txt": [
+    { "name": "example.test", "texts": ["v=spf1 ip4:192.0.2.10 -all"], "ttl": 60 },
+    { "name": "_dmarc.example.test", "texts": ["v=DMARC1; p=reject; aspf=s; adkim=s"], "ttl": 60 },
+    { "name": "_mta-sts.outbound.test", "texts": ["v=STSv1; id=20260309T000000"], "ttl": 60 }
+  ],
+  "tlsa": [
+    {
+      "name": "_25._tcp.mx1.outbound.test",
+      "usage": 3,
+      "selector": 1,
+      "matching_type": 1,
+      "data_hex": "0123456789abcdef",
+      "ttl": 60
+    }
+  ]
+}

--- a/test/integration/dnsmock/Dockerfile
+++ b/test/integration/dnsmock/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.23-alpine AS builder
+WORKDIR /src
+COPY main.go .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /out/dnsmock ./main.go
+
+FROM alpine:3.20
+RUN adduser -D -u 10001 app
+USER app
+COPY --from=builder /out/dnsmock /usr/local/bin/dnsmock
+ENTRYPOINT ["/usr/local/bin/dnsmock"]

--- a/test/integration/dnsmock/main.go
+++ b/test/integration/dnsmock/main.go
@@ -1,0 +1,340 @@
+package main
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	typeA    = 1
+	typeMX   = 15
+	typeTXT  = 16
+	typeTLSA = 52
+	classIN  = 1
+)
+
+type recordSet struct {
+	A    []aRecord    `json:"a"`
+	MX   []mxRecord   `json:"mx"`
+	TXT  []txtRecord  `json:"txt"`
+	TLSA []tlsaRecord `json:"tlsa"`
+}
+
+type aRecord struct {
+	Name string `json:"name"`
+	IP   string `json:"ip"`
+	TTL  uint32 `json:"ttl"`
+}
+
+type mxRecord struct {
+	Name       string `json:"name"`
+	Preference uint16 `json:"preference"`
+	Host       string `json:"host"`
+	TTL        uint32 `json:"ttl"`
+}
+
+type txtRecord struct {
+	Name  string   `json:"name"`
+	Texts []string `json:"texts"`
+	TTL   uint32   `json:"ttl"`
+}
+
+type tlsaRecord struct {
+	Name         string `json:"name"`
+	Usage        uint8  `json:"usage"`
+	Selector     uint8  `json:"selector"`
+	MatchingType uint8  `json:"matching_type"`
+	DataHex      string `json:"data_hex"`
+	TTL          uint32 `json:"ttl"`
+}
+
+type rr struct {
+	name  string
+	typ   uint16
+	class uint16
+	ttl   uint32
+	rdata []byte
+}
+
+func main() {
+	path := strings.TrimSpace(os.Getenv("DNSMOCK_RECORDS_FILE"))
+	if path == "" {
+		path = "/records.json"
+	}
+	records, err := loadRecords(path)
+	if err != nil {
+		log.Fatalf("load records: %v", err)
+	}
+
+	pc, err := net.ListenPacket("udp", ":53")
+	if err != nil {
+		log.Fatalf("listen udp 53: %v", err)
+	}
+	defer pc.Close()
+
+	ln, err := net.Listen("tcp", ":53")
+	if err != nil {
+		log.Fatalf("listen tcp 53: %v", err)
+	}
+	defer ln.Close()
+
+	go serveUDP(pc, records)
+	go serveTCP(ln, records)
+
+	log.Printf("dnsmock started, records=%s", path)
+	select {}
+}
+
+func serveUDP(pc net.PacketConn, records recordSet) {
+	buf := make([]byte, 4096)
+	for {
+		n, addr, err := pc.ReadFrom(buf)
+		if err != nil {
+			log.Printf("udp read error: %v", err)
+			continue
+		}
+		resp, err := answerQuery(buf[:n], records)
+		if err != nil {
+			log.Printf("udp query error: %v", err)
+			continue
+		}
+		if _, err := pc.WriteTo(resp, addr); err != nil {
+			log.Printf("udp write error: %v", err)
+		}
+	}
+}
+
+func serveTCP(ln net.Listener, records recordSet) {
+	for {
+		c, err := ln.Accept()
+		if err != nil {
+			log.Printf("tcp accept error: %v", err)
+			continue
+		}
+		go func(conn net.Conn) {
+			defer conn.Close()
+			_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
+			lenBuf := make([]byte, 2)
+			if _, err := conn.Read(lenBuf); err != nil {
+				return
+			}
+			n := int(binary.BigEndian.Uint16(lenBuf))
+			if n <= 0 || n > 4096 {
+				return
+			}
+			buf := make([]byte, n)
+			if _, err := conn.Read(buf); err != nil {
+				return
+			}
+			resp, err := answerQuery(buf, records)
+			if err != nil {
+				return
+			}
+			outLen := make([]byte, 2)
+			binary.BigEndian.PutUint16(outLen, uint16(len(resp)))
+			_, _ = conn.Write(append(outLen, resp...))
+		}(c)
+	}
+}
+
+func loadRecords(path string) (recordSet, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return recordSet{}, err
+	}
+	var r recordSet
+	if err := json.Unmarshal(b, &r); err != nil {
+		return recordSet{}, err
+	}
+	return r, nil
+}
+
+func answerQuery(query []byte, records recordSet) ([]byte, error) {
+	if len(query) < 12 {
+		return nil, errors.New("short query")
+	}
+	id := binary.BigEndian.Uint16(query[0:2])
+	flags := binary.BigEndian.Uint16(query[2:4])
+	qdCount := binary.BigEndian.Uint16(query[4:6])
+	if qdCount != 1 {
+		return nil, errors.New("only qdcount=1 supported")
+	}
+
+	offset := 12
+	qname, next, err := readName(query, offset)
+	if err != nil {
+		return nil, err
+	}
+	offset = next
+	if len(query) < offset+4 {
+		return nil, errors.New("short question tail")
+	}
+	qtype := binary.BigEndian.Uint16(query[offset : offset+2])
+	qclass := binary.BigEndian.Uint16(query[offset+2 : offset+4])
+	offset += 4
+
+	if qclass != classIN {
+		return nil, errors.New("unsupported qclass")
+	}
+
+	answers := lookupRR(records, qname, qtype)
+	rcode := uint16(0)
+	if len(answers) == 0 {
+		rcode = 3
+	}
+
+	resp := make([]byte, 12, 512)
+	binary.BigEndian.PutUint16(resp[0:2], id)
+	// QR=1, RA=1, AD=1 (for DANE integration tests)
+	outFlags := uint16(0x8000 | 0x0080 | 0x0020)
+	if flags&0x0100 != 0 {
+		outFlags |= 0x0100 // copy RD
+	}
+	outFlags |= rcode
+	binary.BigEndian.PutUint16(resp[2:4], outFlags)
+	binary.BigEndian.PutUint16(resp[4:6], 1)
+	binary.BigEndian.PutUint16(resp[6:8], uint16(len(answers)))
+	binary.BigEndian.PutUint16(resp[8:10], 0)
+	binary.BigEndian.PutUint16(resp[10:12], 0)
+
+	resp = append(resp, query[12:offset]...)
+	for _, a := range answers {
+		resp = append(resp, 0xc0, 0x0c) // name pointer
+		tmp := make([]byte, 10)
+		binary.BigEndian.PutUint16(tmp[0:2], a.typ)
+		binary.BigEndian.PutUint16(tmp[2:4], a.class)
+		binary.BigEndian.PutUint32(tmp[4:8], a.ttl)
+		binary.BigEndian.PutUint16(tmp[8:10], uint16(len(a.rdata)))
+		resp = append(resp, tmp...)
+		resp = append(resp, a.rdata...)
+	}
+	return resp, nil
+}
+
+func readName(packet []byte, offset int) (string, int, error) {
+	labels := make([]string, 0, 4)
+	for {
+		if offset >= len(packet) {
+			return "", 0, errors.New("name overflow")
+		}
+		l := int(packet[offset])
+		offset++
+		if l == 0 {
+			break
+		}
+		if l > 63 || offset+l > len(packet) {
+			return "", 0, errors.New("invalid label length")
+		}
+		labels = append(labels, string(packet[offset:offset+l]))
+		offset += l
+	}
+	return strings.ToLower(strings.Join(labels, ".")), offset, nil
+}
+
+func lookupRR(records recordSet, qname string, qtype uint16) []rr {
+	name := strings.TrimSuffix(strings.ToLower(strings.TrimSpace(qname)), ".")
+	out := make([]rr, 0, 4)
+	switch qtype {
+	case typeA:
+		for _, r := range records.A {
+			if normalizeName(r.Name) != name {
+				continue
+			}
+			ip := net.ParseIP(strings.TrimSpace(r.IP)).To4()
+			if ip == nil {
+				continue
+			}
+			ttl := r.TTL
+			if ttl == 0 {
+				ttl = 60
+			}
+			out = append(out, rr{name: name, typ: typeA, class: classIN, ttl: ttl, rdata: []byte(ip)})
+		}
+	case typeMX:
+		for _, r := range records.MX {
+			if normalizeName(r.Name) != name {
+				continue
+			}
+			host := normalizeName(r.Host)
+			hostWire, err := encodeName(host)
+			if err != nil {
+				continue
+			}
+			rd := make([]byte, 2, 64)
+			binary.BigEndian.PutUint16(rd[0:2], r.Preference)
+			rd = append(rd, hostWire...)
+			ttl := r.TTL
+			if ttl == 0 {
+				ttl = 60
+			}
+			out = append(out, rr{name: name, typ: typeMX, class: classIN, ttl: ttl, rdata: rd})
+		}
+	case typeTXT:
+		for _, r := range records.TXT {
+			if normalizeName(r.Name) != name {
+				continue
+			}
+			rd := make([]byte, 0, 256)
+			for _, t := range r.Texts {
+				tb := []byte(t)
+				if len(tb) > 255 {
+					tb = tb[:255]
+				}
+				rd = append(rd, byte(len(tb)))
+				rd = append(rd, tb...)
+			}
+			ttl := r.TTL
+			if ttl == 0 {
+				ttl = 60
+			}
+			out = append(out, rr{name: name, typ: typeTXT, class: classIN, ttl: ttl, rdata: rd})
+		}
+	case typeTLSA:
+		for _, r := range records.TLSA {
+			if normalizeName(r.Name) != name {
+				continue
+			}
+			data, err := hex.DecodeString(strings.TrimSpace(r.DataHex))
+			if err != nil {
+				continue
+			}
+			rd := []byte{r.Usage, r.Selector, r.MatchingType}
+			rd = append(rd, data...)
+			ttl := r.TTL
+			if ttl == 0 {
+				ttl = 60
+			}
+			out = append(out, rr{name: name, typ: typeTLSA, class: classIN, ttl: ttl, rdata: rd})
+		}
+	}
+	return out
+}
+
+func normalizeName(v string) string {
+	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(v)), ".")
+}
+
+func encodeName(name string) ([]byte, error) {
+	labels := strings.Split(normalizeName(name), ".")
+	if len(labels) == 0 {
+		return nil, fmt.Errorf("empty name")
+	}
+	out := make([]byte, 0, 64)
+	for _, label := range labels {
+		if label == "" || len(label) > 63 {
+			return nil, fmt.Errorf("invalid label")
+		}
+		out = append(out, byte(len(label)))
+		out = append(out, []byte(label)...)
+	}
+	out = append(out, 0)
+	return out, nil
+}

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -1,0 +1,45 @@
+services:
+  dnsmock:
+    build:
+      context: ./dnsmock
+      dockerfile: Dockerfile
+    image: orinoco-dnsmock:latest
+    container_name: orinoco-dnsmock
+    volumes:
+      - ./dns/records.json:/records.json:ro
+    environment:
+      DNSMOCK_RECORDS_FILE: /records.json
+    networks:
+      integration-net:
+        ipv4_address: 172.28.0.53
+
+  policy:
+    image: nginx:1.27-alpine
+    container_name: orinoco-mta-sts-policy
+    volumes:
+      - ./mta-sts/mta-sts.txt:/usr/share/nginx/html/.well-known/mta-sts.txt:ro
+    networks:
+      integration-net:
+        ipv4_address: 172.28.0.80
+
+  tester:
+    image: golang:1.23
+    container_name: orinoco-integration-tester
+    working_dir: /workspace
+    volumes:
+      - ../../:/workspace
+    dns:
+      - 172.28.0.53
+    environment:
+      INTEG_MTA_STS_POLICY_URL: http://policy/.well-known/mta-sts.txt
+    networks:
+      integration-net:
+        ipv4_address: 172.28.0.90
+    command: ["sleep", "infinity"]
+
+networks:
+  integration-net:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.28.0.0/16

--- a/test/integration/mta-sts/mta-sts.txt
+++ b/test/integration/mta-sts/mta-sts.txt
@@ -1,0 +1,4 @@
+version: STSv1
+mode: enforce
+mx: mx1.outbound.test
+max_age: 86400


### PR DESCRIPTION
## Summary
- Docker Compose で DNS/TXT/TLSA を持つ結合テスト環境を追加
- 受信側（mailauth: SPF/DMARC）と送信側（DANE/MTA-STS）を実レコードで検証できるようにした

## Changes
- `test/integration/docker-compose.yml`
  - `dnsmock`（軽量DNS）
  - `policy`（MTA-STS policy 配信）
  - `tester`（integration test runner）
- `test/integration/dnsmock/*`
  - 任意の `A/MX/TXT/TLSA` を JSON から返す DNS サーバを実装
  - DANE 検証用に AD ビット付き応答を返却
- `test/integration/dns/records.json`
  - SPF/DMARC/MX/TLSA のサンプルレコードを定義
- `integration/dns_integration_test.go`
  - mailauth（SPF/DMARC）結合テスト
  - DANE lookup 結合テスト
  - DANE > MTA-STS 優先判定テスト
  - MTA-STS policy 取得テスト
- `scripts/integration/run_dns_env_tests.sh`
  - 環境の up/test/down を一括実行
- `test/integration/README.md`, `README.md`
  - 利用手順とレコード編集方法を追記
- `internal/delivery/testing_hooks_integration.go`
  - integration タグ限定のテストフックを追加

## Validation
- `go test ./...`
- `./scripts/integration/run_dns_env_tests.sh`

## Notes
- MTA-STS の結合テストはローカル環境で扱いやすいよう policy 配信サーバを使って検証
- 本番のHTTPS証明書運用とは切り分けている
