### PR TITLE
Submission(587) + SMTP AUTH の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ go run ./cmd/mta
 ## 主要環境変数
 
 - `MTA_LISTEN_ADDR` (default: `:2525`)
+- `MTA_SUBMISSION_ADDR` (default: unset, set e.g. `:587` to enable Submission listener)
+- `MTA_SUBMISSION_AUTH_REQUIRED` (default: `true`)
+- `MTA_SUBMISSION_USERS` (default: unset, format: `user@example.com:password,...`)
+- `MTA_SUBMISSION_ENFORCE_SENDER_IDENTITY` (default: `true`, requires `MAIL FROM` domain to match authenticated user domain)
 - `MTA_OBSERVABILITY_ADDR` (default: `:9090`)
 - `MTA_HOSTNAME` (default: `orinoco.local`)
 - `MTA_QUEUE_DIR` (default: `./var/queue`)

--- a/cmd/mta/main.go
+++ b/cmd/mta/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/tamago0224/orinoco-mta/internal/bounce"
@@ -14,6 +15,7 @@ import (
 	"github.com/tamago0224/orinoco-mta/internal/observability"
 	"github.com/tamago0224/orinoco-mta/internal/queue"
 	"github.com/tamago0224/orinoco-mta/internal/smtp"
+	"github.com/tamago0224/orinoco-mta/internal/userauth"
 	"github.com/tamago0224/orinoco-mta/internal/worker"
 )
 
@@ -40,13 +42,31 @@ func main() {
 
 	d := worker.New(cfg, q, delivery.NewClient(cfg), sup, metrics)
 	s := smtp.NewServer(cfg, q, metrics)
+	var submissionServer *smtp.Server
+	if cfg.SubmissionAddr != "" {
+		authBackend, aErr := userauth.NewStatic(cfg.SubmissionUsers)
+		if aErr != nil {
+			log.Fatalf("submission auth init failed: %v", aErr)
+		}
+		if cfg.SubmissionAuth && strings.TrimSpace(cfg.SubmissionUsers) == "" {
+			log.Fatalf("submission auth is required but MTA_SUBMISSION_USERS is empty")
+		}
+		submissionServer = smtp.NewSubmissionServer(cfg, q, metrics, authBackend)
+	}
 
-	errCh := make(chan error, 3)
+	workers := 3
+	if submissionServer != nil {
+		workers++
+	}
+	errCh := make(chan error, workers)
 	go func() { errCh <- s.Run(ctx) }()
+	if submissionServer != nil {
+		go func() { errCh <- submissionServer.Run(ctx) }()
+	}
 	go func() { errCh <- d.Run(ctx) }()
 	go func() { errCh <- observability.RunServer(ctx, cfg.ObservabilityAddr, metrics) }()
 
-	for i := 0; i < 3; i++ {
+	for i := 0; i < workers; i++ {
 		err := <-errCh
 		if err == nil || errors.Is(err, context.Canceled) {
 			continue

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,10 @@ import (
 
 type Config struct {
 	ListenAddr         string
+	SubmissionAddr     string
+	SubmissionAuth     bool
+	SubmissionUsers    string
+	SubmissionSenderID bool
 	ObservabilityAddr  string
 	Hostname           string
 	QueueDir           string
@@ -45,6 +49,10 @@ type Config struct {
 func Load() Config {
 	return Config{
 		ListenAddr:         env("MTA_LISTEN_ADDR", ":2525"),
+		SubmissionAddr:     env("MTA_SUBMISSION_ADDR", ""),
+		SubmissionAuth:     envBool("MTA_SUBMISSION_AUTH_REQUIRED", true),
+		SubmissionUsers:    env("MTA_SUBMISSION_USERS", ""),
+		SubmissionSenderID: envBool("MTA_SUBMISSION_ENFORCE_SENDER_IDENTITY", true),
 		ObservabilityAddr:  env("MTA_OBSERVABILITY_ADDR", ":9090"),
 		Hostname:           env("MTA_HOSTNAME", "orinoco.local"),
 		QueueDir:           env("MTA_QUEUE_DIR", "./var/queue"),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -67,3 +67,24 @@ func TestLoadRateLimitRules(t *testing.T) {
 		t.Fatalf("unexpected rules: %q", cfg.RateLimitRules)
 	}
 }
+
+func TestLoadSubmissionConfig(t *testing.T) {
+	t.Setenv("MTA_SUBMISSION_ADDR", ":587")
+	t.Setenv("MTA_SUBMISSION_AUTH_REQUIRED", "true")
+	t.Setenv("MTA_SUBMISSION_USERS", "alice@example.com:s3cr3t")
+	t.Setenv("MTA_SUBMISSION_ENFORCE_SENDER_IDENTITY", "true")
+
+	cfg := Load()
+	if cfg.SubmissionAddr != ":587" {
+		t.Fatalf("submission addr=%q", cfg.SubmissionAddr)
+	}
+	if !cfg.SubmissionAuth {
+		t.Fatal("submission auth should be true")
+	}
+	if cfg.SubmissionUsers != "alice@example.com:s3cr3t" {
+		t.Fatalf("submission users=%q", cfg.SubmissionUsers)
+	}
+	if !cfg.SubmissionSenderID {
+		t.Fatal("submission sender identity should be true")
+	}
+}

--- a/internal/smtp/server.go
+++ b/internal/smtp/server.go
@@ -2,9 +2,11 @@ package smtp
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -21,6 +23,7 @@ import (
 	"github.com/tamago0224/orinoco-mta/internal/model"
 	"github.com/tamago0224/orinoco-mta/internal/observability"
 	"github.com/tamago0224/orinoco-mta/internal/queue"
+	"github.com/tamago0224/orinoco-mta/internal/userauth"
 	"github.com/tamago0224/orinoco-mta/internal/util"
 )
 
@@ -36,6 +39,8 @@ type Server struct {
 	metrics     *observability.Metrics
 	ln          net.Listener
 	wg          sync.WaitGroup
+	submission  bool
+	authBackend userauth.Backend
 }
 
 func NewServer(cfg config.Config, q queue.Backend, metrics *observability.Metrics) *Server {
@@ -52,6 +57,15 @@ func NewServer(cfg config.Config, q queue.Backend, metrics *observability.Metric
 		dnsbl:       ingress.NewDNSBLChecker(cfg.DNSBLZones, cfg.DNSBLCacheTTL, nil),
 		metrics:     metrics,
 	}
+}
+
+func NewSubmissionServer(cfg config.Config, q queue.Backend, metrics *observability.Metrics, backend userauth.Backend) *Server {
+	subCfg := cfg
+	subCfg.ListenAddr = cfg.SubmissionAddr
+	s := NewServer(subCfg, q, metrics)
+	s.submission = true
+	s.authBackend = backend
+	return s
 }
 
 func (s *Server) Run(ctx context.Context) error {
@@ -102,6 +116,8 @@ type session struct {
 	seenHelo bool
 	extended bool
 	tls      bool
+	authUser string
+	authOK   bool
 }
 
 type mailFromArgs struct {
@@ -187,7 +203,7 @@ func (s *Server) handleConn(conn net.Conn) {
 			ss.bodyMode = "7BIT"
 			ss.rcptTo = nil
 			ss.data = nil
-			writeEHLOResponse(w, s.cfg.Hostname, s.cfg.MaxMessageBytes, s.tlsConfig != nil && !ss.tls)
+			writeEHLOResponse(w, s.cfg.Hostname, s.cfg.MaxMessageBytes, s.tlsConfig != nil && !ss.tls, s.submission)
 		case "HELO":
 			if arg == "" {
 				writeResp(w, 501, "HELO requires domain")
@@ -204,6 +220,10 @@ func (s *Server) handleConn(conn net.Conn) {
 		case "MAIL":
 			if !ss.seenHelo {
 				writeResp(w, 503, "send EHLO/HELO first")
+				continue
+			}
+			if s.submission && s.cfg.SubmissionAuth && !ss.authOK {
+				writeResp(w, 530, "authentication required")
 				continue
 			}
 			mailArgs, err := parseMailFrom(arg)
@@ -229,6 +249,10 @@ func (s *Server) handleConn(conn net.Conn) {
 			}
 			if mailArgs.HasSize && mailArgs.Size > s.cfg.MaxMessageBytes {
 				writeResp(w, 552, "message size exceeds fixed maximum message size")
+				continue
+			}
+			if s.submission && s.cfg.SubmissionSenderID && ss.authOK && !senderAllowedForAuth(ss.authUser, mailArgs.Address) {
+				writeResp(w, 553, "sender address rejected for authenticated identity")
 				continue
 			}
 			if remoteIP != nil && s.flexLimiter != nil && !s.flexLimiter.Allow("mailfrom", remoteIP.String(), ss.helo, mailArgs.Address, time.Now().UTC()) {
@@ -335,10 +359,39 @@ func (s *Server) handleConn(conn net.Conn) {
 			ss.rcptTo = nil
 			ss.data = nil
 			writeResp(w, 250, "reset state")
+		case "AUTH":
+			if !s.submission {
+				writeResp(w, 502, "AUTH is not supported")
+				continue
+			}
+			if !ss.extended {
+				writeResp(w, 503, "send EHLO first")
+				continue
+			}
+			if s.authBackend == nil {
+				writeResp(w, 454, "authentication backend unavailable")
+				continue
+			}
+			user, ok, err := s.handleAuth(r, w, arg)
+			if err != nil {
+				writeResp(w, 501, err.Error())
+				continue
+			}
+			if !ok {
+				writeResp(w, 535, "authentication credentials invalid")
+				continue
+			}
+			ss.authUser = user
+			ss.authOK = true
+			writeResp(w, 235, "authentication successful")
 		case "NOOP":
 			writeResp(w, 250, "ok")
 		case "HELP":
-			writeResp(w, 214, "Supported commands: EHLO HELO MAIL RCPT DATA RSET NOOP QUIT STARTTLS HELP VRFY EXPN")
+			help := "Supported commands: EHLO HELO MAIL RCPT DATA RSET NOOP QUIT STARTTLS HELP VRFY EXPN"
+			if s.submission {
+				help += " AUTH"
+			}
+			writeResp(w, 214, help)
 		case "VRFY":
 			writeResp(w, 252, "cannot VRFY user, but will accept message")
 		case "EXPN":
@@ -371,6 +424,8 @@ func (s *Server) handleConn(conn net.Conn) {
 			ss.bodyMode = "7BIT"
 			ss.rcptTo = nil
 			ss.data = nil
+			ss.authUser = ""
+			ss.authOK = false
 		default:
 			writeResp(w, 500, "unsupported command")
 		}
@@ -535,11 +590,14 @@ func parseRemoteIP(remote string) net.IP {
 	return net.ParseIP(host)
 }
 
-func writeEHLOResponse(w *bufio.Writer, hostname string, maxMessageBytes int64, advertiseStartTLS bool) {
+func writeEHLOResponse(w *bufio.Writer, hostname string, maxMessageBytes int64, advertiseStartTLS bool, advertiseAuth bool) {
 	_ = writeLine(w, "250-"+hostname)
 	_ = writeLine(w, "250-PIPELINING")
 	_ = writeLine(w, fmt.Sprintf("250-SIZE %d", maxMessageBytes))
 	_ = writeLine(w, "250-8BITMIME")
+	if advertiseAuth {
+		_ = writeLine(w, "250-AUTH PLAIN LOGIN")
+	}
 	if advertiseStartTLS {
 		_ = writeLine(w, "250-STARTTLS")
 	}
@@ -622,6 +680,99 @@ func isASCII(s string) bool {
 		}
 	}
 	return true
+}
+
+func (s *Server) handleAuth(r *bufio.Reader, w *bufio.Writer, arg string) (string, bool, error) {
+	if strings.TrimSpace(arg) == "" {
+		return "", false, errors.New("AUTH requires mechanism")
+	}
+	parts := strings.Fields(arg)
+	mech := strings.ToUpper(parts[0])
+	switch mech {
+	case "PLAIN":
+		var payload string
+		if len(parts) >= 2 {
+			payload = parts[1]
+		} else {
+			if err := writeLine(w, "334 "); err != nil {
+				return "", false, err
+			}
+			line, err := r.ReadString('\n')
+			if err != nil {
+				return "", false, err
+			}
+			payload = strings.TrimSpace(line)
+		}
+		user, pass, err := decodeAuthPlain(payload)
+		if err != nil {
+			return "", false, err
+		}
+		return user, s.authBackend.Validate(user, pass), nil
+	case "LOGIN":
+		if err := writeLine(w, "334 VXNlcm5hbWU6"); err != nil {
+			return "", false, err
+		}
+		userLine, err := r.ReadString('\n')
+		if err != nil {
+			return "", false, err
+		}
+		userRaw, err := decodeBase64Line(userLine)
+		if err != nil {
+			return "", false, errors.New("invalid base64 username")
+		}
+		if err := writeLine(w, "334 UGFzc3dvcmQ6"); err != nil {
+			return "", false, err
+		}
+		passLine, err := r.ReadString('\n')
+		if err != nil {
+			return "", false, err
+		}
+		passRaw, err := decodeBase64Line(passLine)
+		if err != nil {
+			return "", false, errors.New("invalid base64 password")
+		}
+		user := strings.TrimSpace(string(userRaw))
+		pass := strings.TrimSpace(string(passRaw))
+		if user == "" || pass == "" {
+			return "", false, errors.New("empty credentials")
+		}
+		return user, s.authBackend.Validate(user, pass), nil
+	default:
+		return "", false, errors.New("unsupported auth mechanism")
+	}
+}
+
+func decodeAuthPlain(payload string) (string, string, error) {
+	raw, err := decodeBase64Line(payload)
+	if err != nil {
+		return "", "", errors.New("invalid base64 credentials")
+	}
+	parts := bytes.Split(raw, []byte{0})
+	if len(parts) < 3 {
+		return "", "", errors.New("invalid plain auth payload")
+	}
+	user := strings.TrimSpace(string(parts[1]))
+	pass := strings.TrimSpace(string(parts[2]))
+	if user == "" || pass == "" {
+		return "", "", errors.New("empty credentials")
+	}
+	return user, pass, nil
+}
+
+func decodeBase64Line(v string) ([]byte, error) {
+	return base64.StdEncoding.DecodeString(strings.TrimSpace(v))
+}
+
+func senderAllowedForAuth(authUser, mailFrom string) bool {
+	authDomain, ok := util.DomainOf(strings.ToLower(strings.TrimSpace(authUser)))
+	if !ok {
+		return false
+	}
+	fromDomain, ok := util.DomainOf(strings.ToLower(strings.TrimSpace(mailFrom)))
+	if !ok {
+		return false
+	}
+	return strings.EqualFold(authDomain, fromDomain)
 }
 
 func buildReceivedHeader(hostname, helo, remote, id string, now time.Time, tlsOn bool) string {

--- a/internal/smtp/server_test.go
+++ b/internal/smtp/server_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/tamago0224/orinoco-mta/internal/config"
 	"github.com/tamago0224/orinoco-mta/internal/model"
+	"github.com/tamago0224/orinoco-mta/internal/userauth"
 )
 
 func TestSplitVerb(t *testing.T) {
@@ -670,6 +671,146 @@ func TestHELPVRFYEXPNCommands(t *testing.T) {
 	_, expnCode := readSMTPResponse(t, r)
 	if expnCode != 502 {
 		t.Fatalf("expn code=%d want=502", expnCode)
+	}
+}
+
+func TestSubmissionRejectsMailBeforeAuth(t *testing.T) {
+	backend, err := userauth.NewStatic("alice@example.com:s3cr3t")
+	if err != nil {
+		t.Fatalf("new static backend: %v", err)
+	}
+	s := &Server{
+		cfg:         config.Config{Hostname: "sub.example.test", SubmissionAuth: true},
+		submission:  true,
+		authBackend: backend,
+	}
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	go s.handleConn(server)
+
+	r := bufio.NewReader(client)
+	w := bufio.NewWriter(client)
+	_, _ = readSMTPResponse(t, r)
+	mustWriteSMTPLine(t, w, "EHLO client.example")
+	_, _ = readSMTPResponse(t, r)
+	mustWriteSMTPLine(t, w, "MAIL FROM:<alice@example.com>")
+	_, code := readSMTPResponse(t, r)
+	if code != 530 {
+		t.Fatalf("code=%d want=530", code)
+	}
+}
+
+func TestSubmissionAuthPlainSuccess(t *testing.T) {
+	q := &recordingQueue{}
+	backend, err := userauth.NewStatic("alice@example.com:s3cr3t")
+	if err != nil {
+		t.Fatalf("new static backend: %v", err)
+	}
+	s := &Server{
+		cfg: config.Config{
+			Hostname:           "sub.example.test",
+			SubmissionAuth:     true,
+			SubmissionSenderID: true,
+			MaxMessageBytes:    1024 * 1024,
+		},
+		queue:       q,
+		submission:  true,
+		authBackend: backend,
+	}
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	go s.handleConn(server)
+
+	r := bufio.NewReader(client)
+	w := bufio.NewWriter(client)
+	_, _ = readSMTPResponse(t, r)
+	mustWriteSMTPLine(t, w, "EHLO client.example")
+	resp, _ := readSMTPResponse(t, r)
+	if !strings.Contains(resp, "AUTH PLAIN LOGIN") {
+		t.Fatalf("EHLO must advertise AUTH for submission: %q", resp)
+	}
+
+	mustWriteSMTPLine(t, w, "AUTH PLAIN AGFsaWNlQGV4YW1wbGUuY29tAHMzY3IzdA==")
+	_, authCode := readSMTPResponse(t, r)
+	if authCode != 235 {
+		t.Fatalf("auth code=%d want=235", authCode)
+	}
+	mustWriteSMTPLine(t, w, "MAIL FROM:<alice@example.com>")
+	_, mailCode := readSMTPResponse(t, r)
+	if mailCode != 250 {
+		t.Fatalf("mail code=%d want=250", mailCode)
+	}
+}
+
+func TestSubmissionAuthLoginSuccess(t *testing.T) {
+	backend, err := userauth.NewStatic("alice@example.com:s3cr3t")
+	if err != nil {
+		t.Fatalf("new static backend: %v", err)
+	}
+	s := &Server{
+		cfg:         config.Config{Hostname: "sub.example.test", SubmissionAuth: true},
+		submission:  true,
+		authBackend: backend,
+	}
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	go s.handleConn(server)
+
+	r := bufio.NewReader(client)
+	w := bufio.NewWriter(client)
+	_, _ = readSMTPResponse(t, r)
+	mustWriteSMTPLine(t, w, "EHLO client.example")
+	_, _ = readSMTPResponse(t, r)
+	mustWriteSMTPLine(t, w, "AUTH LOGIN")
+	_, code := readSMTPResponse(t, r)
+	if code != 334 {
+		t.Fatalf("first login challenge code=%d want=334", code)
+	}
+	mustWriteSMTPLine(t, w, "YWxpY2VAZXhhbXBsZS5jb20=")
+	_, code = readSMTPResponse(t, r)
+	if code != 334 {
+		t.Fatalf("second login challenge code=%d want=334", code)
+	}
+	mustWriteSMTPLine(t, w, "czNjcjN0")
+	_, code = readSMTPResponse(t, r)
+	if code != 235 {
+		t.Fatalf("final auth code=%d want=235", code)
+	}
+}
+
+func TestSubmissionSenderIdentityMismatchRejected(t *testing.T) {
+	backend, err := userauth.NewStatic("alice@example.com:s3cr3t")
+	if err != nil {
+		t.Fatalf("new static backend: %v", err)
+	}
+	s := &Server{
+		cfg: config.Config{
+			Hostname:           "sub.example.test",
+			SubmissionAuth:     true,
+			SubmissionSenderID: true,
+		},
+		submission:  true,
+		authBackend: backend,
+	}
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	go s.handleConn(server)
+
+	r := bufio.NewReader(client)
+	w := bufio.NewWriter(client)
+	_, _ = readSMTPResponse(t, r)
+	mustWriteSMTPLine(t, w, "EHLO client.example")
+	_, _ = readSMTPResponse(t, r)
+	mustWriteSMTPLine(t, w, "AUTH PLAIN AGFsaWNlQGV4YW1wbGUuY29tAHMzY3IzdA==")
+	_, _ = readSMTPResponse(t, r)
+	mustWriteSMTPLine(t, w, "MAIL FROM:<alice@other.example>")
+	_, code := readSMTPResponse(t, r)
+	if code != 553 {
+		t.Fatalf("code=%d want=553", code)
 	}
 }
 

--- a/internal/userauth/static.go
+++ b/internal/userauth/static.go
@@ -1,0 +1,50 @@
+package userauth
+
+import (
+	"errors"
+	"strings"
+)
+
+type Backend interface {
+	Validate(username, password string) bool
+}
+
+type StaticBackend struct {
+	users map[string]string
+}
+
+func NewStatic(raw string) (*StaticBackend, error) {
+	users := map[string]string{}
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return &StaticBackend{users: users}, nil
+	}
+	for _, part := range strings.Split(s, ",") {
+		p := strings.TrimSpace(part)
+		if p == "" {
+			continue
+		}
+		i := strings.IndexByte(p, ':')
+		if i <= 0 || i == len(p)-1 {
+			return nil, errors.New("invalid submission user entry")
+		}
+		u := strings.ToLower(strings.TrimSpace(p[:i]))
+		pw := strings.TrimSpace(p[i+1:])
+		if u == "" || pw == "" {
+			return nil, errors.New("invalid submission user entry")
+		}
+		users[u] = pw
+	}
+	return &StaticBackend{users: users}, nil
+}
+
+func (b *StaticBackend) Validate(username, password string) bool {
+	if b == nil {
+		return false
+	}
+	pw, ok := b.users[strings.ToLower(strings.TrimSpace(username))]
+	if !ok {
+		return false
+	}
+	return pw == password
+}

--- a/internal/userauth/static_test.go
+++ b/internal/userauth/static_test.go
@@ -1,0 +1,28 @@
+package userauth
+
+import "testing"
+
+func TestNewStaticAndValidate(t *testing.T) {
+	b, err := NewStatic("alice@example.com:s3cr3t, bob@example.com:pass")
+	if err != nil {
+		t.Fatalf("new static: %v", err)
+	}
+	if !b.Validate("alice@example.com", "s3cr3t") {
+		t.Fatal("alice should authenticate")
+	}
+	if !b.Validate("ALICE@EXAMPLE.COM", "s3cr3t") {
+		t.Fatal("username lookup should be case-insensitive")
+	}
+	if b.Validate("bob@example.com", "wrong") {
+		t.Fatal("wrong password must fail")
+	}
+	if b.Validate("charlie@example.com", "pass") {
+		t.Fatal("unknown user must fail")
+	}
+}
+
+func TestNewStaticRejectsInvalidEntry(t *testing.T) {
+	if _, err := NewStatic("alice@example.com"); err == nil {
+		t.Fatal("invalid entry must fail")
+	}
+}


### PR DESCRIPTION
## Summary
- Issue #27 の対応として、Submission 用リスナーと SMTP AUTH を実装しました。
- 既存の MTA 受信（`MTA_LISTEN_ADDR`）はそのまま維持し、`MTA_SUBMISSION_ADDR` を設定したときのみ Submission サーバーを追加起動します。

## Changes
- Submission サーバー起動
  - `MTA_SUBMISSION_ADDR` 設定時に Submission リスナーを起動
  - `cmd/mta/main.go` で通常SMTPと並行稼働
- SMTP AUTH（Submission限定）
  - `AUTH PLAIN` / `AUTH LOGIN` を実装
  - EHLO 応答で `AUTH PLAIN LOGIN` を広告
  - 未認証で `MAIL FROM` を送った場合 `530 authentication required`
- 認証バックエンド
  - `internal/userauth` を追加
  - `MTA_SUBMISSION_USERS`（`user:password,...`）の静的バックエンドを実装
- 認証済み送信者制御
  - `MTA_SUBMISSION_ENFORCE_SENDER_IDENTITY=true` 時、
    認証ユーザーのドメインと `MAIL FROM` ドメインが一致しない送信を `553` で拒否
- 設定追加
  - `MTA_SUBMISSION_ADDR`
  - `MTA_SUBMISSION_AUTH_REQUIRED`
  - `MTA_SUBMISSION_USERS`
  - `MTA_SUBMISSION_ENFORCE_SENDER_IDENTITY`
- テスト追加
  - AUTH 未実施拒否、AUTH PLAIN 成功、AUTH LOGIN 成功、送信者不一致拒否
  - `internal/userauth` のパーサ・認証テスト

## Validation
- `go vet ./...`
- `go test ./...`
- `go test -race ./...`

## Risks / Follow-ups
- 今回は静的ユーザー定義（環境変数）での実装です。DB/LDAP/OIDC 連携は次段で拡張が必要です。
- AUTH 前の STARTTLS 強制ポリシー（平文経路での認証抑止）は未実装です。

Closes #27
