### PR TITLE
slog(JSON) へのログ基盤移行

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ go run ./cmd/mta
 - `MTA_SUBMISSION_AUTH_REQUIRED` (default: `true`)
 - `MTA_SUBMISSION_USERS` (default: unset, format: `user@example.com:password,...`)
 - `MTA_SUBMISSION_ENFORCE_SENDER_IDENTITY` (default: `true`, requires `MAIL FROM` domain to match authenticated user domain)
+- `MTA_LOG_LEVEL` (default: `info`, values: `debug` / `info` / `warn` / `error`, logs are JSON via `slog`)
 - `MTA_OBSERVABILITY_ADDR` (default: `:9090`)
 - `MTA_HOSTNAME` (default: `orinoco.local`)
 - `MTA_QUEUE_DIR` (default: `./var/queue`)

--- a/cmd/mta/main.go
+++ b/cmd/mta/main.go
@@ -3,7 +3,8 @@ package main
 import (
 	"context"
 	"errors"
-	"log"
+	"log/slog"
+	"os"
 	"os/signal"
 	"path/filepath"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	"github.com/tamago0224/orinoco-mta/internal/bounce"
 	"github.com/tamago0224/orinoco-mta/internal/config"
 	"github.com/tamago0224/orinoco-mta/internal/delivery"
+	"github.com/tamago0224/orinoco-mta/internal/logging"
 	"github.com/tamago0224/orinoco-mta/internal/observability"
 	"github.com/tamago0224/orinoco-mta/internal/queue"
 	"github.com/tamago0224/orinoco-mta/internal/smtp"
@@ -21,22 +23,23 @@ import (
 
 func main() {
 	cfg := config.Load()
+	slog.SetDefault(logging.New(cfg.LogLevel, os.Stdout))
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
 	q, err := queue.NewBackend(cfg)
 	if err != nil {
-		log.Fatalf("queue init failed: %v", err)
+		fatal("queue init failed", "error", err)
 	}
 	defer func() {
 		if cErr := q.Close(); cErr != nil {
-			log.Printf("queue close error: %v", cErr)
+			slog.Error("queue close failed", "component", "main", "error", cErr)
 		}
 	}()
 	sup, err := bounce.NewSuppressionStore(filepath.Join(cfg.QueueDir, "suppression.json"))
 	if err != nil {
-		log.Fatalf("suppression init failed: %v", err)
+		fatal("suppression init failed", "error", err)
 	}
 	metrics := observability.NewMetrics()
 
@@ -46,10 +49,10 @@ func main() {
 	if cfg.SubmissionAddr != "" {
 		authBackend, aErr := userauth.NewStatic(cfg.SubmissionUsers)
 		if aErr != nil {
-			log.Fatalf("submission auth init failed: %v", aErr)
+			fatal("submission auth init failed", "error", aErr)
 		}
 		if cfg.SubmissionAuth && strings.TrimSpace(cfg.SubmissionUsers) == "" {
-			log.Fatalf("submission auth is required but MTA_SUBMISSION_USERS is empty")
+			fatal("submission auth is required but MTA_SUBMISSION_USERS is empty")
 		}
 		submissionServer = smtp.NewSubmissionServer(cfg, q, metrics, authBackend)
 	}
@@ -71,7 +74,14 @@ func main() {
 		if err == nil || errors.Is(err, context.Canceled) {
 			continue
 		}
-		log.Printf("runtime error: %v", err)
+		slog.Error("runtime error", "component", "main", "error", err)
 		stop()
 	}
+}
+
+func fatal(msg string, args ...any) {
+	base := []any{"component", "main"}
+	base = append(base, args...)
+	slog.Error(msg, base...)
+	os.Exit(1)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	SubmissionAuth     bool
 	SubmissionUsers    string
 	SubmissionSenderID bool
+	LogLevel           string
 	ObservabilityAddr  string
 	Hostname           string
 	QueueDir           string
@@ -53,6 +54,7 @@ func Load() Config {
 		SubmissionAuth:     envBool("MTA_SUBMISSION_AUTH_REQUIRED", true),
 		SubmissionUsers:    env("MTA_SUBMISSION_USERS", ""),
 		SubmissionSenderID: envBool("MTA_SUBMISSION_ENFORCE_SENDER_IDENTITY", true),
+		LogLevel:           env("MTA_LOG_LEVEL", "info"),
 		ObservabilityAddr:  env("MTA_OBSERVABILITY_ADDR", ":9090"),
 		Hostname:           env("MTA_HOSTNAME", "orinoco.local"),
 		QueueDir:           env("MTA_QUEUE_DIR", "./var/queue"),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -88,3 +88,11 @@ func TestLoadSubmissionConfig(t *testing.T) {
 		t.Fatal("submission sender identity should be true")
 	}
 }
+
+func TestLoadLogLevel(t *testing.T) {
+	t.Setenv("MTA_LOG_LEVEL", "debug")
+	cfg := Load()
+	if cfg.LogLevel != "debug" {
+		t.Fatalf("log level=%q", cfg.LogLevel)
+	}
+}

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -1,0 +1,30 @@
+package logging
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+func New(level string, w io.Writer) *slog.Logger {
+	if w == nil {
+		w = os.Stdout
+	}
+	lvl := parseLevel(level)
+	h := slog.NewJSONHandler(w, &slog.HandlerOptions{Level: lvl})
+	return slog.New(h)
+}
+
+func parseLevel(level string) slog.Level {
+	switch strings.ToLower(strings.TrimSpace(level)) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -1,0 +1,33 @@
+package logging
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestNewJSONLoggerOutputsStructuredRecord(t *testing.T) {
+	var buf bytes.Buffer
+	l := New("debug", &buf)
+	l.Info("smtp listening", slog.String("component", "smtp"), slog.String("remote_ip", "127.0.0.1"))
+	out := buf.String()
+	if !strings.Contains(out, `"msg":"smtp listening"`) {
+		t.Fatalf("missing msg field: %q", out)
+	}
+	if !strings.Contains(out, `"component":"smtp"`) {
+		t.Fatalf("missing component field: %q", out)
+	}
+	if !strings.Contains(out, `"remote_ip":"127.0.0.1"`) {
+		t.Fatalf("missing remote_ip field: %q", out)
+	}
+}
+
+func TestNewLoggerRespectsLevel(t *testing.T) {
+	var buf bytes.Buffer
+	l := New("warn", &buf)
+	l.Info("info should be filtered")
+	if got := strings.TrimSpace(buf.String()); got != "" {
+		t.Fatalf("unexpected output at warn level: %q", got)
+	}
+}

--- a/internal/observability/server.go
+++ b/internal/observability/server.go
@@ -2,7 +2,7 @@ package observability
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"net/http"
 )
 
@@ -29,7 +29,7 @@ func RunServer(ctx context.Context, addr string, m *Metrics) error {
 		<-ctx.Done()
 		_ = srv.Shutdown(context.Background())
 	}()
-	log.Printf("observability listening on %s", addr)
+	slog.Info("observability listening", "component", "observability", "listen_addr", addr)
 	err := srv.ListenAndServe()
 	if err == http.ErrServerClosed {
 		return nil

--- a/internal/smtp/server.go
+++ b/internal/smtp/server.go
@@ -10,7 +10,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"net"
 	"strconv"
 	"strings"
@@ -80,7 +80,7 @@ func (s *Server) Run(ctx context.Context) error {
 		return err
 	}
 	s.ln = ln
-	log.Printf("smtp listening on %s", s.cfg.ListenAddr)
+	slog.Info("smtp listening", "component", "smtp", "listen_addr", s.cfg.ListenAddr, "submission", s.submission)
 
 	go func() {
 		<-ctx.Done()
@@ -93,7 +93,7 @@ func (s *Server) Run(ctx context.Context) error {
 			if errors.Is(err, net.ErrClosed) || ctx.Err() != nil {
 				break
 			}
-			log.Printf("accept error: %v", err)
+			slog.Warn("smtp accept error", "component", "smtp", "error", err)
 			continue
 		}
 		s.wg.Add(1)
@@ -147,20 +147,20 @@ func (s *Server) handleConn(conn net.Conn) {
 		now := time.Now().UTC()
 		if s.limiter != nil && !s.limiter.Allow(remoteStr, now) {
 			s.metricInc("smtp_reject_rate_limit")
-			log.Printf("event=ingress_reject reason=rate_limit remote_ip=%s", remoteStr)
+			slog.Warn("ingress rejected", "component", "smtp", "reason", "rate_limit", "remote_ip", remoteStr)
 			writeResp(w, 421, "rate limit exceeded, try again later")
 			return
 		}
 		if s.flexLimiter != nil && !s.flexLimiter.Allow("connect", remoteStr, "", "", now) {
 			s.metricInc("smtp_reject_rate_limit")
-			log.Printf("event=ingress_reject reason=rate_rule_connect remote_ip=%s", remoteStr)
+			slog.Warn("ingress rejected", "component", "smtp", "reason", "rate_rule_connect", "remote_ip", remoteStr)
 			writeResp(w, 421, "rate limit exceeded, try again later")
 			return
 		}
 		if s.dnsbl != nil {
 			if listed, zone := s.dnsbl.IsListed(remoteStr); listed {
 				s.metricInc("smtp_reject_dnsbl")
-				log.Printf("event=ingress_reject reason=dnsbl zone=%s remote_ip=%s", zone, remoteStr)
+				slog.Warn("ingress rejected", "component", "smtp", "reason", "dnsbl", "zone", zone, "remote_ip", remoteStr)
 				writeResp(w, 554, "connection rejected (dnsbl: "+zone+")")
 				return
 			}
@@ -193,7 +193,7 @@ func (s *Server) handleConn(conn net.Conn) {
 			ss.helo = arg
 			if remoteIP != nil && s.flexLimiter != nil && !s.flexLimiter.Allow("helo", remoteIP.String(), ss.helo, "", time.Now().UTC()) {
 				s.metricInc("smtp_reject_rate_limit")
-				log.Printf("event=ingress_reject reason=rate_rule_helo remote_ip=%s helo=%s", remoteIP.String(), ss.helo)
+				slog.Warn("ingress rejected", "component", "smtp", "reason", "rate_rule_helo", "remote_ip", remoteIP.String(), "helo", ss.helo)
 				writeResp(w, 421, "rate limit exceeded, try again later")
 				return
 			}
@@ -257,7 +257,7 @@ func (s *Server) handleConn(conn net.Conn) {
 			}
 			if remoteIP != nil && s.flexLimiter != nil && !s.flexLimiter.Allow("mailfrom", remoteIP.String(), ss.helo, mailArgs.Address, time.Now().UTC()) {
 				s.metricInc("smtp_reject_rate_limit")
-				log.Printf("event=ingress_reject reason=rate_rule_mailfrom remote_ip=%s helo=%s mail_from=%s", remoteIP.String(), ss.helo, mailArgs.Address)
+				slog.Warn("ingress rejected", "component", "smtp", "reason", "rate_rule_mailfrom", "remote_ip", remoteIP.String(), "helo", ss.helo, "mail_from", mailArgs.Address)
 				writeResp(w, 421, "rate limit exceeded, try again later")
 				return
 			}
@@ -343,7 +343,7 @@ func (s *Server) handleConn(conn net.Conn) {
 			ss.data = mailauth.InjectHeaders(ss.data, []string{received})
 
 			if err := s.enqueue(ss, id); err != nil {
-				log.Printf("enqueue error: %v", err)
+				slog.Error("enqueue failed", "component", "smtp", "error", err, "msg_id", id, "remote_ip", ipString(msgRemoteIP))
 				s.metricInc("smtp_enqueue_fail")
 				writeResp(w, 451, "temporary local problem")
 				continue
@@ -588,6 +588,13 @@ func parseRemoteIP(remote string) net.IP {
 		return net.ParseIP(remote)
 	}
 	return net.ParseIP(host)
+}
+
+func ipString(ip net.IP) string {
+	if ip == nil {
+		return ""
+	}
+	return ip.String()
 }
 
 func writeEHLOResponse(w *bufio.Writer, hostname string, maxMessageBytes int64, advertiseStartTLS bool, advertiseAuth bool) {

--- a/internal/worker/dispatcher.go
+++ b/internal/worker/dispatcher.go
@@ -3,7 +3,7 @@ package worker
 import (
 	"context"
 	"errors"
-	"log"
+	"log/slog"
 	"strings"
 	"sync"
 	"time"
@@ -38,7 +38,7 @@ func (d *Dispatcher) Run(ctx context.Context) error {
 			return ctx.Err()
 		case <-ticker.C:
 			if err := d.processBatch(ctx); err != nil {
-				log.Printf("worker batch error: %v", err)
+				slog.Error("worker batch failed", "component", "worker", "error", err)
 			}
 		}
 	}
@@ -87,7 +87,7 @@ func (d *Dispatcher) handleMessage(ctx context.Context, msg *model.Message) {
 				d.metricInc("worker_permanent_bounce")
 				if d.sup != nil {
 					if sErr := d.sup.Add(rcpt, smtpErr.Line); sErr != nil {
-						log.Printf("suppression add error addr=%s: %v", rcpt, sErr)
+						slog.Error("suppression add failed", "component", "worker", "rcpt", rcpt, "msg_id", msg.ID, "error", sErr)
 					}
 				}
 				continue
@@ -101,7 +101,7 @@ func (d *Dispatcher) handleMessage(ctx context.Context, msg *model.Message) {
 
 	if len(errs) == 0 {
 		if err := d.queue.AckSent(msg.ID, msg); err != nil {
-			log.Printf("ack sent error id=%s: %v", msg.ID, err)
+			slog.Error("ack sent failed", "component", "worker", "msg_id", msg.ID, "error", err)
 		}
 		d.metricInc("worker_ack_sent")
 		return
@@ -110,14 +110,14 @@ func (d *Dispatcher) handleMessage(ctx context.Context, msg *model.Message) {
 	reason := strings.Join(reasons, "; ")
 	if shouldFail(msg, errs, d.cfg, time.Now().UTC()) {
 		if err := d.queue.Fail(msg, reason); err != nil {
-			log.Printf("mark failed error id=%s: %v", msg.ID, err)
+			slog.Error("mark failed failed", "component", "worker", "msg_id", msg.ID, "error", err)
 		}
 		d.metricInc("worker_mark_failed")
 		return
 	}
 	delay := backoff(msg.Attempts, d.cfg.RetrySchedule)
 	if err := d.queue.Retry(msg, delay, reason); err != nil {
-		log.Printf("retry schedule error id=%s: %v", msg.ID, err)
+		slog.Error("retry schedule failed", "component", "worker", "msg_id", msg.ID, "error", err)
 	}
 	d.metricInc("worker_retry_scheduled")
 }


### PR DESCRIPTION
## Summary
- Issue #24 の対応として、ログ出力を `log` から `log/slog` へ移行しました。
- 既定フォーマットは JSON (`slog.NewJSONHandler`) とし、`MTA_LOG_LEVEL` でレベル制御できるようにしました。

## Changes
- ログ初期化基盤の追加
  - `internal/logging` を新規追加
  - `New(level, writer)` で `slog` JSONロガーを生成
  - `debug/info/warn/error` のレベル反映に対応
- アプリ起動時のデフォルトロガー設定
  - `cmd/mta/main.go` で `slog.SetDefault(logging.New(...))` を適用
  - `MTA_LOG_LEVEL` を設定項目に追加（default: `info`）
- 既存ログ出力の置換
  - SMTPサーバー: `internal/smtp/server.go`
  - Worker: `internal/worker/dispatcher.go`
  - Observability: `internal/observability/server.go`
- 共通フィールド付与
  - `component`
  - `msg_id`（キュー投入/ワーカー処理系）
  - `rcpt`（suppression add エラー時）
  - `remote_ip`（SMTP入口拒否/enqueue失敗時）
- README 更新
  - `MTA_LOG_LEVEL` の説明を追加

## Validation
- `go vet ./...`
- `go test ./...`
- `go test -race ./...`

## Risks / Follow-ups
- delivery パッケージには現時点で明示ログがほぼ無いため、今後追加するログも `slog` + 共通フィールド方針で統一します。
- 出力先（stdout以外）やサンプリング、trace/span連携は次段で拡張余地があります。

Closes #24
