### PR TITLE
配送キュー整合性の強化（重複排除・poison隔離）

### DIFF
--- a/internal/queue/kafka.go
+++ b/internal/queue/kafka.go
@@ -120,6 +120,7 @@ func (k *KafkaStore) Due(limit int) ([]*model.Message, error) {
 	}
 	now := time.Now().UTC()
 	out := make([]*model.Message, 0, limit)
+	seen := make(map[string]struct{}, limit)
 
 	// Prefer already-fetched messages first.
 	k.mu.Lock()
@@ -133,7 +134,13 @@ func (k *KafkaStore) Due(limit int) ([]*model.Message, error) {
 			rest = append(rest, item)
 			continue
 		}
+		if _, dup := seen[item.data.ID]; dup {
+			// Drop duplicate message-id to keep processing idempotent.
+			_ = k.commitByReceipt(item.source, item.msg)
+			continue
+		}
 		k.receipts[item.data.ID] = kafkaReceipt{source: item.source, msg: item.msg}
+		seen[item.data.ID] = struct{}{}
 		out = append(out, item.data)
 	}
 	k.staged = rest
@@ -158,9 +165,14 @@ func (k *KafkaStore) Due(limit int) ([]*model.Message, error) {
 				k.mu.Unlock()
 				continue
 			}
+			if _, dup := seen[item.data.ID]; dup {
+				_ = k.commitByReceipt(item.source, item.msg)
+				continue
+			}
 			k.mu.Lock()
 			k.receipts[item.data.ID] = kafkaReceipt{source: item.source, msg: item.msg}
 			k.mu.Unlock()
+			seen[item.data.ID] = struct{}{}
 			out = append(out, item.data)
 			if len(out) >= limit {
 				return out, nil
@@ -172,6 +184,21 @@ func (k *KafkaStore) Due(limit int) ([]*model.Message, error) {
 		}
 	}
 	return out, nil
+}
+
+func (k *KafkaStore) commitByReceipt(source string, msg kafka.Message) error {
+	var reader *kafka.Reader
+	switch source {
+	case "retry":
+		reader = k.retryReader
+	case "inbound":
+		reader = k.inboundReader
+	default:
+		return errors.New("unknown receipt source: " + source)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return reader.CommitMessages(ctx, msg)
 }
 
 func (k *KafkaStore) AckSent(id string, msg *model.Message) error {
@@ -280,18 +307,7 @@ func (k *KafkaStore) commitByID(id string) error {
 	if !ok {
 		return nil
 	}
-	var reader *kafka.Reader
-	switch receipt.source {
-	case "retry":
-		reader = k.retryReader
-	case "inbound":
-		reader = k.inboundReader
-	default:
-		return errors.New("unknown receipt source: " + receipt.source)
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	return reader.CommitMessages(ctx, receipt.msg)
+	return k.commitByReceipt(receipt.source, receipt.msg)
 }
 
 func marshalMessage(msg *model.Message) ([]byte, error) {

--- a/internal/queue/store.go
+++ b/internal/queue/store.go
@@ -18,9 +18,15 @@ type Store struct {
 	inbound       string
 	retry         string
 	dlq           string
+	poison        string
 	sent          string
 	legacyPending string
 }
+
+var (
+	ErrMessageNotFound        = errors.New("message not found")
+	ErrInvalidStateTransition = errors.New("invalid state transition")
+)
 
 func New(root string) (*Store, error) {
 	s := &Store{
@@ -28,10 +34,11 @@ func New(root string) (*Store, error) {
 		inbound:       filepath.Join(root, "mail.inbound"),
 		retry:         filepath.Join(root, "mail.retry"),
 		dlq:           filepath.Join(root, "mail.dlq"),
+		poison:        filepath.Join(root, "mail.dlq", "poison"),
 		sent:          filepath.Join(root, "sent"),
 		legacyPending: filepath.Join(root, "pending"),
 	}
-	for _, d := range []string{s.root, s.inbound, s.retry, s.dlq, s.sent} {
+	for _, d := range []string{s.root, s.inbound, s.retry, s.dlq, s.poison, s.sent} {
 		if err := os.MkdirAll(d, 0o755); err != nil {
 			return nil, err
 		}
@@ -40,6 +47,17 @@ func New(root string) (*Store, error) {
 }
 
 func (s *Store) Enqueue(msg *model.Message) error {
+	if strings.TrimSpace(msg.ID) == "" {
+		return errors.New("message id is required")
+	}
+	st, err := s.messageState(msg.ID)
+	if err != nil {
+		return err
+	}
+	if st != "none" {
+		// Idempotent enqueue: duplicate message id is ignored.
+		return nil
+	}
 	now := time.Now().UTC()
 	msg.CreatedAt = now
 	msg.UpdatedAt = now
@@ -66,6 +84,18 @@ func (s *Store) Due(limit int) ([]*model.Message, error) {
 }
 
 func (s *Store) AckSent(id string, msg *model.Message) error {
+	st, err := s.messageState(id)
+	if err != nil {
+		return err
+	}
+	switch st {
+	case "sent":
+		return nil
+	case "dlq":
+		return ErrInvalidStateTransition
+	case "none":
+		return ErrMessageNotFound
+	}
 	if err := s.removeByID(id); err != nil {
 		return err
 	}
@@ -74,6 +104,16 @@ func (s *Store) AckSent(id string, msg *model.Message) error {
 }
 
 func (s *Store) Retry(msg *model.Message, delay time.Duration, reason string) error {
+	st, err := s.messageState(msg.ID)
+	if err != nil {
+		return err
+	}
+	switch st {
+	case "sent", "dlq":
+		return ErrInvalidStateTransition
+	case "none":
+		return ErrMessageNotFound
+	}
 	if err := s.removeByID(msg.ID); err != nil {
 		return err
 	}
@@ -85,6 +125,18 @@ func (s *Store) Retry(msg *model.Message, delay time.Duration, reason string) er
 }
 
 func (s *Store) Fail(msg *model.Message, reason string) error {
+	st, err := s.messageState(msg.ID)
+	if err != nil {
+		return err
+	}
+	switch st {
+	case "dlq":
+		return nil
+	case "sent":
+		return ErrInvalidStateTransition
+	case "none":
+		return ErrMessageNotFound
+	}
 	if err := s.removeByID(msg.ID); err != nil {
 		return err
 	}
@@ -111,6 +163,7 @@ func (s *Store) dueFromDir(dir string) ([]*model.Message, error) {
 		path := filepath.Join(dir, e.Name())
 		msg, err := s.read(path)
 		if err != nil {
+			_ = s.quarantinePoison(path, e.Name(), err)
 			continue
 		}
 		if msg.NextAttempt.After(now) {
@@ -156,4 +209,49 @@ func (s *Store) read(path string) (*model.Message, error) {
 		return nil, fmt.Errorf("decode %s: %w", path, err)
 	}
 	return &msg, nil
+}
+
+func (s *Store) quarantinePoison(path, name string, cause error) error {
+	b, readErr := os.ReadFile(path)
+	if readErr != nil {
+		return readErr
+	}
+	dst := filepath.Join(s.poison, fmt.Sprintf("%d_%s.bad", time.Now().UTC().UnixNano(), strings.TrimSuffix(name, ".json")))
+	payload := append([]byte(fmt.Sprintf("cause: %v\n", cause)), b...)
+	if err := os.WriteFile(dst, payload, 0o644); err != nil {
+		return err
+	}
+	return os.Remove(path)
+}
+
+func (s *Store) messageState(id string) (string, error) {
+	exists := func(path string) (bool, error) {
+		_, err := os.Stat(path)
+		if err == nil {
+			return true, nil
+		}
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	for _, p := range []struct {
+		state string
+		dir   string
+	}{
+		{state: "inbound", dir: s.inbound},
+		{state: "retry", dir: s.retry},
+		{state: "pending", dir: s.legacyPending},
+		{state: "sent", dir: s.sent},
+		{state: "dlq", dir: s.dlq},
+	} {
+		ok, err := exists(filepath.Join(p.dir, id+".json"))
+		if err != nil {
+			return "", err
+		}
+		if ok {
+			return p.state, nil
+		}
+	}
+	return "none", nil
 }

--- a/internal/queue/store_test.go
+++ b/internal/queue/store_test.go
@@ -1,8 +1,10 @@
 package queue
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -35,6 +37,87 @@ func TestStoreLifecycle(t *testing.T) {
 	}
 	if len(due) != 0 {
 		t.Fatalf("expected empty due queue, got=%d", len(due))
+	}
+}
+
+func TestStoreEnqueueDeduplicatesByMessageID(t *testing.T) {
+	d := t.TempDir()
+	s, err := New(filepath.Join(d, "queue"))
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	m1 := &model.Message{ID: "dup1", MailFrom: "sender@example.com", RcptTo: []string{"r@example.net"}, Data: []byte("x")}
+	if err := s.Enqueue(m1); err != nil {
+		t.Fatalf("enqueue first: %v", err)
+	}
+	m2 := &model.Message{ID: "dup1", MailFrom: "other@example.com", RcptTo: []string{"other@example.net"}, Data: []byte("y")}
+	if err := s.Enqueue(m2); err != nil {
+		t.Fatalf("enqueue duplicate: %v", err)
+	}
+	due, err := s.Due(10)
+	if err != nil {
+		t.Fatalf("due: %v", err)
+	}
+	if len(due) != 1 {
+		t.Fatalf("due count=%d want=1", len(due))
+	}
+	if due[0].MailFrom != "sender@example.com" {
+		t.Fatalf("duplicate enqueue must keep original message, got=%q", due[0].MailFrom)
+	}
+}
+
+func TestStoreRejectsRetryAfterAckState(t *testing.T) {
+	d := t.TempDir()
+	s, err := New(filepath.Join(d, "queue"))
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	msg := &model.Message{ID: "m3", MailFrom: "sender@example.com", RcptTo: []string{"r@example.net"}, Data: []byte("x")}
+	if err := s.Enqueue(msg); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	due, err := s.Due(1)
+	if err != nil || len(due) != 1 {
+		t.Fatalf("due=%v err=%v", due, err)
+	}
+	if err := s.AckSent("m3", due[0]); err != nil {
+		t.Fatalf("ack sent: %v", err)
+	}
+	if err := s.Retry(due[0], time.Minute, "temp"); !errors.Is(err, ErrInvalidStateTransition) {
+		t.Fatalf("retry err=%v want=%v", err, ErrInvalidStateTransition)
+	}
+}
+
+func TestStoreQuarantinesPoisonMessage(t *testing.T) {
+	d := t.TempDir()
+	root := filepath.Join(d, "queue")
+	s, err := New(root)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	path := filepath.Join(root, "mail.inbound", "bad1.json")
+	if err := os.WriteFile(path, []byte("{invalid-json"), 0o644); err != nil {
+		t.Fatalf("write poison: %v", err)
+	}
+	due, err := s.Due(10)
+	if err != nil {
+		t.Fatalf("due: %v", err)
+	}
+	if len(due) != 0 {
+		t.Fatalf("poison should not become due")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("poison source must be removed, err=%v", err)
+	}
+	entries, err := os.ReadDir(filepath.Join(root, "mail.dlq", "poison"))
+	if err != nil {
+		t.Fatalf("read poison dir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("poison file count=%d want=1", len(entries))
+	}
+	if !strings.HasSuffix(entries[0].Name(), ".bad") {
+		t.Fatalf("poison file suffix unexpected: %s", entries[0].Name())
 	}
 }
 


### PR DESCRIPTION
## Summary
- Issue #29 の対応として、キューの重複排除・状態遷移ガード・poison message隔離を実装しました。

## Changes
- Local queue (`internal/queue/store.go`)
  - `Enqueue` で `message id` 重複を検出し、重複投入を idempotent に無視
  - `AckSent/Retry/Fail` に状態遷移ガードを追加
    - `ErrMessageNotFound`
    - `ErrInvalidStateTransition`
  - JSON破損などの poison message を `mail.dlq/poison/*.bad` へ隔離
- Kafka queue (`internal/queue/kafka.go`)
  - `Due()` で同一 `message id` が重複した場合は 1件のみ処理対象にし、重複分は commit して再処理ループを防止
  - commit処理を `commitByReceipt` として共通化
- Tests (`internal/queue/store_test.go`)
  - 重複 `message id` の投入抑止
  - `AckSent` 後 `Retry` の不正遷移拒否
  - poison隔離の動作

## Validation
- `go vet ./...`
- `go test ./...`
- `go test -race ./...`

## Risks / Follow-ups
- Kafka側の重複抑止は consumer 取得バッチ内の `message id` 重複に対する対策です。
  トピック横断・長期間の重複抑止（永続dedupe）は別途ストレージ連携が必要です。
- `mail.dlq/poison` の再処理オペレーション（再投入CLI/API）は未実装です。

Closes #29
