### PR TITLE
送信DKIM署名の実装と鍵ローテーション基盤追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ go run ./cmd/mta
 - `MTA_SCAN_INTERVAL` (default: `5s`)
 - `MTA_DIAL_TIMEOUT` (default: `8s`)
 - `MTA_SEND_TIMEOUT` (default: `20s`)
+- `MTA_DKIM_SIGN_DOMAIN` (default: unset)
+- `MTA_DKIM_SIGN_SELECTOR` (default: unset)
+- `MTA_DKIM_PRIVATE_KEY_FILE` (default: unset, PEM RSA private key)
+- `MTA_DKIM_SIGN_HEADERS` (default: `from:to:subject:date:message-id`)
 
 ## 補足
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,6 +45,10 @@ type Config struct {
 	ScanInterval       time.Duration
 	DialTimeout        time.Duration
 	SendTimeout        time.Duration
+	DKIMSignDomain     string
+	DKIMSignSelector   string
+	DKIMPrivateKeyFile string
+	DKIMSignHeaders    string
 }
 
 func Load() Config {
@@ -86,9 +90,13 @@ func Load() Config {
 			"MTA_RETRY_SCHEDULE",
 			[]time.Duration{5 * time.Minute, 30 * time.Minute, 2 * time.Hour, 6 * time.Hour, 24 * time.Hour},
 		),
-		ScanInterval: envDuration("MTA_SCAN_INTERVAL", 5*time.Second),
-		DialTimeout:  envDuration("MTA_DIAL_TIMEOUT", 8*time.Second),
-		SendTimeout:  envDuration("MTA_SEND_TIMEOUT", 20*time.Second),
+		ScanInterval:       envDuration("MTA_SCAN_INTERVAL", 5*time.Second),
+		DialTimeout:        envDuration("MTA_DIAL_TIMEOUT", 8*time.Second),
+		SendTimeout:        envDuration("MTA_SEND_TIMEOUT", 20*time.Second),
+		DKIMSignDomain:     env("MTA_DKIM_SIGN_DOMAIN", ""),
+		DKIMSignSelector:   env("MTA_DKIM_SIGN_SELECTOR", ""),
+		DKIMPrivateKeyFile: env("MTA_DKIM_PRIVATE_KEY_FILE", ""),
+		DKIMSignHeaders:    env("MTA_DKIM_SIGN_HEADERS", "from:to:subject:date:message-id"),
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -96,3 +96,20 @@ func TestLoadLogLevel(t *testing.T) {
 		t.Fatalf("log level=%q", cfg.LogLevel)
 	}
 }
+
+func TestLoadDKIMSigningConfig(t *testing.T) {
+	t.Setenv("MTA_DKIM_SIGN_DOMAIN", "example.com")
+	t.Setenv("MTA_DKIM_SIGN_SELECTOR", "s1")
+	t.Setenv("MTA_DKIM_PRIVATE_KEY_FILE", "/tmp/dkim.pem")
+	t.Setenv("MTA_DKIM_SIGN_HEADERS", "from:to:subject")
+	cfg := Load()
+	if cfg.DKIMSignDomain != "example.com" || cfg.DKIMSignSelector != "s1" {
+		t.Fatalf("unexpected dkim config: domain=%q selector=%q", cfg.DKIMSignDomain, cfg.DKIMSignSelector)
+	}
+	if cfg.DKIMPrivateKeyFile != "/tmp/dkim.pem" {
+		t.Fatalf("key file=%q", cfg.DKIMPrivateKeyFile)
+	}
+	if cfg.DKIMSignHeaders != "from:to:subject" {
+		t.Fatalf("headers=%q", cfg.DKIMSignHeaders)
+	}
+}

--- a/internal/delivery/modes_test.go
+++ b/internal/delivery/modes_test.go
@@ -2,8 +2,10 @@ package delivery
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/tamago0224/orinoco-mta/internal/config"
@@ -57,4 +59,47 @@ func TestDeliverRelayUsesConfiguredTarget(t *testing.T) {
 	if !called {
 		t.Fatal("relay deliverHostFn should be called")
 	}
+}
+
+func TestDeliverLocalSpoolAppliesDKIMSignerWhenConfigured(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Config{DeliveryMode: "local_spool", LocalSpoolDir: dir}
+	cl := NewClient(cfg)
+	cl.signer = testSigner(func(raw []byte) ([]byte, error) {
+		return append([]byte("DKIM-Signature: test\r\n"), raw...), nil
+	})
+	msg := &model.Message{ID: "m3", MailFrom: "sender@example.com", Data: []byte("From: sender@example.com\r\n\r\nhello")}
+	if err := cl.Deliver(context.Background(), msg, "user@example.net"); err != nil {
+		t.Fatalf("deliver local spool with signer: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read spool dir: %v", err)
+	}
+	b, err := os.ReadFile(filepath.Join(dir, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("read spool file: %v", err)
+	}
+	if !strings.HasPrefix(string(b), "DKIM-Signature: test\r\n") {
+		t.Fatalf("missing dkim signature prefix: %q", string(b))
+	}
+}
+
+func TestDeliverLocalSpoolReturnsSignerError(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Config{DeliveryMode: "local_spool", LocalSpoolDir: dir}
+	cl := NewClient(cfg)
+	cl.signer = testSigner(func(raw []byte) ([]byte, error) {
+		return nil, errors.New("sign failed")
+	})
+	msg := &model.Message{ID: "m4", MailFrom: "sender@example.com", Data: []byte("From: sender@example.com\r\n\r\nhello")}
+	if err := cl.Deliver(context.Background(), msg, "user@example.net"); err == nil {
+		t.Fatal("expected signer error")
+	}
+}
+
+type testSigner func([]byte) ([]byte, error)
+
+func (s testSigner) Sign(raw []byte) ([]byte, error) {
+	return s(raw)
 }

--- a/internal/delivery/smtp_client.go
+++ b/internal/delivery/smtp_client.go
@@ -13,15 +13,21 @@ import (
 	"time"
 
 	"github.com/tamago0224/orinoco-mta/internal/config"
+	"github.com/tamago0224/orinoco-mta/internal/dkim"
 	"github.com/tamago0224/orinoco-mta/internal/model"
 	"github.com/tamago0224/orinoco-mta/internal/router"
 	"github.com/tamago0224/orinoco-mta/internal/util"
 )
 
+type messageSigner interface {
+	Sign(raw []byte) ([]byte, error)
+}
+
 type Client struct {
 	cfg           config.Config
 	dane          *DANEResolver
 	mtaSTS        *MTASTSResolver
+	signer        messageSigner
 	resolveMXFn   func(string, time.Duration) ([]router.MXHost, error)
 	deliverHostFn func(context.Context, string, int, *model.Message, string, bool) error
 	spoolWriteFn  func(*model.Message, string) error
@@ -33,6 +39,11 @@ func NewClient(cfg config.Config) *Client {
 		dane:        NewDANEResolver(cfg.DialTimeout, nil),
 		mtaSTS:      NewMTASTSResolver(cfg.MTASTSCacheTTL, cfg.MTASTSFetchTimeout, nil),
 		resolveMXFn: router.LookupWithTimeout,
+	}
+	if cfg.DKIMSignDomain != "" || cfg.DKIMSignSelector != "" || cfg.DKIMPrivateKeyFile != "" {
+		if signer, err := dkim.NewFileSigner(cfg.DKIMSignDomain, cfg.DKIMSignSelector, cfg.DKIMPrivateKeyFile, cfg.DKIMSignHeaders); err == nil {
+			c.signer = signer
+		}
 	}
 	c.deliverHostFn = c.deliverHost
 	c.spoolWriteFn = c.writeLocalSpool
@@ -204,7 +215,11 @@ func (c *Client) deliverHost(ctx context.Context, host string, port int, msg *mo
 		return fmt.Errorf("data not accepted: %w", err)
 	}
 
-	data := dotStuff(msg.Data)
+	payload, err := c.prepareOutboundData(msg.Data)
+	if err != nil {
+		return err
+	}
+	data := dotStuff(payload)
 	if _, err := w.Write(data); err != nil {
 		return err
 	}
@@ -236,7 +251,11 @@ func (c *Client) writeLocalSpool(msg *model.Message, rcpt string) error {
 	}
 	name := fmt.Sprintf("%s_%s.eml", id, sanitizeFilename(rcpt))
 	path := filepath.Join(dir, name)
-	return os.WriteFile(path, msg.Data, 0o644)
+	payload, err := c.prepareOutboundData(msg.Data)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, payload, 0o644)
 }
 
 func sanitizeFilename(v string) string {
@@ -339,4 +358,11 @@ func dotStuff(data []byte) []byte {
 		}
 	}
 	return []byte(strings.Join(lines, "\r\n"))
+}
+
+func (c *Client) prepareOutboundData(raw []byte) ([]byte, error) {
+	if c.signer == nil {
+		return raw, nil
+	}
+	return c.signer.Sign(raw)
 }

--- a/internal/dkim/signer.go
+++ b/internal/dkim/signer.go
@@ -1,0 +1,262 @@
+package dkim
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+type FileSigner struct {
+	domain   string
+	selector string
+	headers  []string
+	keyFile  string
+
+	mu      sync.RWMutex
+	mtime   time.Time
+	privKey *rsa.PrivateKey
+}
+
+func NewFileSigner(domain, selector, keyFile, headers string) (*FileSigner, error) {
+	d := strings.ToLower(strings.TrimSpace(domain))
+	s := strings.TrimSpace(selector)
+	k := strings.TrimSpace(keyFile)
+	if d == "" || s == "" || k == "" {
+		return nil, errors.New("dkim signer requires domain, selector, and private key file")
+	}
+	h := parseHeaderList(headers)
+	if len(h) == 0 {
+		h = []string{"from", "to", "subject", "date", "message-id"}
+	}
+	f := &FileSigner{
+		domain:   d,
+		selector: s,
+		headers:  h,
+		keyFile:  k,
+	}
+	if err := f.reloadIfNeeded(); err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+func (s *FileSigner) Sign(raw []byte) ([]byte, error) {
+	if err := s.reloadIfNeeded(); err != nil {
+		return nil, err
+	}
+	headerPart, bodyPart, ok := splitMessage(raw)
+	if !ok {
+		return nil, errors.New("invalid message format")
+	}
+	headers := parseRawHeaders(headerPart)
+	if len(headers) == 0 {
+		return nil, errors.New("missing headers")
+	}
+	signedHeaders, canonHeaderPart := buildSignedHeaders(headers, s.headers)
+	if len(signedHeaders) == 0 {
+		return nil, errors.New("no headers available for dkim signing")
+	}
+
+	bh := bodyHash(bodyPart)
+	base := fmt.Sprintf(
+		"v=1; a=rsa-sha256; c=relaxed/relaxed; d=%s; s=%s; t=%d; h=%s; bh=%s; b=",
+		s.domain,
+		s.selector,
+		time.Now().UTC().Unix(),
+		strings.Join(signedHeaders, ":"),
+		bh,
+	)
+
+	signingData := canonHeaderPart + canonHeaderRelaxed("DKIM-Signature", base)
+	sum := sha256.Sum256([]byte(signingData))
+	s.mu.RLock()
+	key := s.privKey
+	s.mu.RUnlock()
+	sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, sum[:])
+	if err != nil {
+		return nil, err
+	}
+	dkimHeader := "DKIM-Signature: " + base + base64.StdEncoding.EncodeToString(sig)
+	var out strings.Builder
+	out.WriteString(dkimHeader)
+	out.WriteString("\r\n")
+	out.WriteString(headerPart)
+	out.WriteString("\r\n\r\n")
+	out.WriteString(bodyPart)
+	return []byte(out.String()), nil
+}
+
+func (s *FileSigner) reloadIfNeeded() error {
+	st, err := os.Stat(s.keyFile)
+	if err != nil {
+		return err
+	}
+	s.mu.RLock()
+	needs := s.privKey == nil || st.ModTime().After(s.mtime)
+	s.mu.RUnlock()
+	if !needs {
+		return nil
+	}
+	key, err := loadPrivateKey(s.keyFile)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.privKey = key
+	s.mtime = st.ModTime()
+	s.mu.Unlock()
+	return nil
+}
+
+func loadPrivateKey(path string) (*rsa.PrivateKey, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	block, _ := pem.Decode(b)
+	if block == nil {
+		return nil, errors.New("invalid pem private key")
+	}
+	switch block.Type {
+	case "RSA PRIVATE KEY":
+		return x509.ParsePKCS1PrivateKey(block.Bytes)
+	case "PRIVATE KEY":
+		keyAny, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, err
+		}
+		key, ok := keyAny.(*rsa.PrivateKey)
+		if !ok {
+			return nil, errors.New("private key is not rsa")
+		}
+		return key, nil
+	default:
+		return nil, fmt.Errorf("unsupported private key type: %s", block.Type)
+	}
+}
+
+type rawHeader struct {
+	name  string
+	value string
+}
+
+func splitMessage(raw []byte) (headers string, body string, ok bool) {
+	s := string(raw)
+	if i := strings.Index(s, "\r\n\r\n"); i >= 0 {
+		return s[:i], s[i+4:], true
+	}
+	if i := strings.Index(s, "\n\n"); i >= 0 {
+		return s[:i], s[i+2:], true
+	}
+	return "", "", false
+}
+
+func parseRawHeaders(part string) []rawHeader {
+	lines := strings.Split(strings.ReplaceAll(part, "\r\n", "\n"), "\n")
+	out := make([]rawHeader, 0, len(lines))
+	var curName string
+	var curVal strings.Builder
+	flush := func() {
+		if curName == "" {
+			return
+		}
+		out = append(out, rawHeader{name: curName, value: curVal.String()})
+		curName = ""
+		curVal.Reset()
+	}
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		if line[0] == ' ' || line[0] == '\t' {
+			if curName != "" {
+				curVal.WriteByte(' ')
+				curVal.WriteString(strings.TrimLeft(line, " \t"))
+			}
+			continue
+		}
+		flush()
+		i := strings.IndexByte(line, ':')
+		if i <= 0 {
+			continue
+		}
+		curName = strings.TrimSpace(line[:i])
+		curVal.WriteString(strings.TrimSpace(line[i+1:]))
+	}
+	flush()
+	return out
+}
+
+func buildSignedHeaders(headers []rawHeader, want []string) ([]string, string) {
+	used := make([]bool, len(headers))
+	names := make([]string, 0, len(want))
+	var b strings.Builder
+	for _, hn := range want {
+		target := strings.ToLower(strings.TrimSpace(hn))
+		if target == "" {
+			continue
+		}
+		for i := len(headers) - 1; i >= 0; i-- {
+			if used[i] {
+				continue
+			}
+			if strings.EqualFold(headers[i].name, target) {
+				used[i] = true
+				names = append(names, target)
+				b.WriteString(canonHeaderRelaxed(headers[i].name, headers[i].value))
+				break
+			}
+		}
+	}
+	return names, b.String()
+}
+
+func canonHeaderRelaxed(name, value string) string {
+	return strings.ToLower(strings.TrimSpace(name)) + ":" + collapseWSP(strings.TrimSpace(value)) + "\r\n"
+}
+
+func collapseWSP(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+func bodyHash(body string) string {
+	lines := strings.Split(strings.ReplaceAll(body, "\r\n", "\n"), "\n")
+	for i := range lines {
+		lines[i] = collapseWSP(strings.TrimRight(lines[i], " \t"))
+	}
+	for len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	canon := "\r\n"
+	if len(lines) > 0 {
+		canon = strings.Join(lines, "\r\n") + "\r\n"
+	}
+	sum := sha256.Sum256([]byte(canon))
+	return base64.StdEncoding.EncodeToString(sum[:])
+}
+
+func parseHeaderList(v string) []string {
+	s := strings.TrimSpace(v)
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ":")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		x := strings.ToLower(strings.TrimSpace(p))
+		if x != "" {
+			out = append(out, x)
+		}
+	}
+	return out
+}

--- a/internal/dkim/signer_test.go
+++ b/internal/dkim/signer_test.go
@@ -1,0 +1,76 @@
+package dkim
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFileSignerSignInjectsDKIMHeader(t *testing.T) {
+	keyPath := filepath.Join(t.TempDir(), "dkim.pem")
+	if err := writeTestKey(keyPath); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	s, err := NewFileSigner("example.com", "s1", keyPath, "from:to:subject")
+	if err != nil {
+		t.Fatalf("new signer: %v", err)
+	}
+	raw := []byte("From: a@example.com\r\nTo: b@example.net\r\nSubject: hi\r\n\r\nhello")
+	got, err := s.Sign(raw)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	out := string(got)
+	if !strings.HasPrefix(out, "DKIM-Signature: ") {
+		t.Fatalf("signed message must start with DKIM-Signature header: %q", out)
+	}
+	if !strings.Contains(out, " d=example.com;") || !strings.Contains(out, " s=s1;") {
+		t.Fatalf("missing d/s tag: %q", out)
+	}
+	if !strings.Contains(out, "\r\nFrom: a@example.com\r\n") {
+		t.Fatalf("original headers missing: %q", out)
+	}
+}
+
+func TestFileSignerReloadsRotatedKey(t *testing.T) {
+	keyPath := filepath.Join(t.TempDir(), "dkim.pem")
+	if err := writeTestKey(keyPath); err != nil {
+		t.Fatalf("write key1: %v", err)
+	}
+	s, err := NewFileSigner("example.com", "s1", keyPath, "from")
+	if err != nil {
+		t.Fatalf("new signer: %v", err)
+	}
+	msg := []byte("From: a@example.com\r\n\r\nhello")
+	first, err := s.Sign(msg)
+	if err != nil {
+		t.Fatalf("sign first: %v", err)
+	}
+	time.Sleep(1100 * time.Millisecond)
+	if err := writeTestKey(keyPath); err != nil {
+		t.Fatalf("write key2: %v", err)
+	}
+	second, err := s.Sign(msg)
+	if err != nil {
+		t.Fatalf("sign second: %v", err)
+	}
+	if string(first) == string(second) {
+		t.Fatal("signature should change after key rotation")
+	}
+}
+
+func writeTestKey(path string) error {
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		return err
+	}
+	der := x509.MarshalPKCS1PrivateKey(key)
+	block := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: der}
+	return os.WriteFile(path, pem.EncodeToMemory(block), 0o600)
+}


### PR DESCRIPTION
## Summary
- Issue #28 の対応として、送信時 DKIM 署名を実装しました。
- 鍵ファイルの更新を検知して再読み込みする仕組みを入れ、無停止ローテーションの基盤を追加しました。

## Changes
- DKIM signer を追加 (`internal/dkim`)
  - `FileSigner` を実装
  - `relaxed/relaxed` canonicalization で `rsa-sha256` 署名
  - 署名ヘッダ `DKIM-Signature` をメッセージ先頭に注入
  - 秘密鍵ファイルの `mtime` を監視し、変更時に自動リロード
- Delivery 統合 (`internal/delivery/smtp_client.go`)
  - 送信時（MX / relay / local_spool）に DKIM 署名を適用
  - 署名失敗時は配送エラーとして返却
- Config 追加 (`internal/config`)
  - `MTA_DKIM_SIGN_DOMAIN`
  - `MTA_DKIM_SIGN_SELECTOR`
  - `MTA_DKIM_PRIVATE_KEY_FILE`
  - `MTA_DKIM_SIGN_HEADERS`
- Tests
  - `internal/dkim/signer_test.go`: 署名注入と鍵ローテーション再読込
  - `internal/delivery/modes_test.go`: local_spool 経由で署名反映と署名失敗時エラー
  - `internal/config/config_test.go`: DKIM設定読み込み
- README
  - DKIM署名用の環境変数を追記

## Validation
- `go vet ./...`
- `go test ./...`
- `go test -race ./...`

## Risks / Follow-ups
- 本PRは単一ドメイン/単一鍵ファイルを前提にした基盤実装です。
- Issue本文にある KMS/HSM 連携と複数ドメイン・複数テナント鍵管理は次段で拡張が必要です。

Closes #28
