### PR TITLE
SLO/SLI評価エンドポイントと監視ルール雛形の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ go run ./cmd/mta
 - `MTA_SUBMISSION_ENFORCE_SENDER_IDENTITY` (default: `true`, requires `MAIL FROM` domain to match authenticated user domain)
 - `MTA_LOG_LEVEL` (default: `info`, values: `debug` / `info` / `warn` / `error`, logs are JSON via `slog`)
 - `MTA_OBSERVABILITY_ADDR` (default: `:9090`)
+- `MTA_SLO_MIN_DELIVERY_SUCCESS_RATE` (default: `0.99`)
+- `MTA_SLO_MAX_RETRY_RATE` (default: `0.20`)
+- `MTA_SLO_MAX_QUEUE_BACKLOG` (default: `50000`)
 - `MTA_HOSTNAME` (default: `orinoco.local`)
 - `MTA_QUEUE_DIR` (default: `./var/queue`)
 - `MTA_QUEUE_BACKEND` (default: `local`, values: `local` / `kafka`)
@@ -158,3 +161,10 @@ DNS を含む `docker compose` 環境を用意しています。
 ```
 
 詳細は `test/integration/README.md` を参照してください。
+
+## SLO/SLI Monitoring
+
+- `/metrics`: Prometheus metrics
+- `/slo`: 現在の SLI/SLO 判定結果（JSON, breach時は HTTP 503）
+
+Prometheus alert rule の雛形は [orinoco_slo_rules.yml](/home/tamago/ghq/github.com/tamago/orinoco-mta/deploy/monitoring/prometheus/orinoco_slo_rules.yml) に配置しています。

--- a/deploy/monitoring/prometheus/orinoco_slo_rules.yml
+++ b/deploy/monitoring/prometheus/orinoco_slo_rules.yml
@@ -1,0 +1,47 @@
+groups:
+  - name: orinoco-slo
+    rules:
+      - alert: OrinocoDeliverySuccessRateLow
+        expr: |
+          (
+            rate(worker_delivery_success_total[5m]) /
+            clamp_min(
+              rate(worker_delivery_success_total[5m]) +
+              rate(worker_temporary_failure_total[5m]) +
+              rate(worker_permanent_bounce_total[5m]),
+              1e-9
+            )
+          ) < 0.99
+        for: 10m
+        labels:
+          severity: page
+        annotations:
+          summary: "Orinoco delivery success rate is below SLO"
+          runbook: "docs/runbooks/slo_delivery.md"
+
+      - alert: OrinocoRetryRateHigh
+        expr: |
+          (
+            rate(worker_temporary_failure_total[10m]) /
+            clamp_min(
+              rate(worker_delivery_success_total[10m]) +
+              rate(worker_temporary_failure_total[10m]) +
+              rate(worker_permanent_bounce_total[10m]),
+              1e-9
+            )
+          ) > 0.20
+        for: 15m
+        labels:
+          severity: page
+        annotations:
+          summary: "Orinoco retry rate is above SLO"
+          runbook: "docs/runbooks/slo_retry.md"
+
+      - alert: OrinocoQueueBacklogHigh
+        expr: (smtp_queued_messages_total - worker_ack_sent_total - worker_mark_failed_total) > 50000
+        for: 10m
+        labels:
+          severity: ticket
+        annotations:
+          summary: "Orinoco queue backlog exceeds threshold"
+          runbook: "docs/runbooks/slo_backlog.md"

--- a/docs/runbooks/slo_backlog.md
+++ b/docs/runbooks/slo_backlog.md
@@ -1,0 +1,6 @@
+# SLO Runbook: Queue Backlog
+
+1. `smtp_queued_messages_total - worker_ack_sent_total - worker_mark_failed_total` を確認
+2. worker 稼働数 (`MTA_WORKER_COUNT`) とドメイン制御設定を見直す
+3. 外部依存障害（DNS, MX, TLS）を確認し、影響ドメインを切り分ける
+4. backlog 解消後に再発防止（ドメインルール/再送ポリシー）を更新

--- a/docs/runbooks/slo_delivery.md
+++ b/docs/runbooks/slo_delivery.md
@@ -1,0 +1,6 @@
+# SLO Runbook: Delivery Success Rate
+
+1. `worker_temporary_failure_total` と `worker_permanent_bounce_total` の増加ドメインを確認
+2. DNS/MX/TLS (DANE, MTA-STS) 障害有無を確認
+3. 特定ドメイン障害の場合は `MTA_DOMAIN_MAX_CONCURRENT_RULES` を一時的に絞る
+4. 復旧後は通常値へ戻し、事後分析を記録

--- a/docs/runbooks/slo_retry.md
+++ b/docs/runbooks/slo_retry.md
@@ -1,0 +1,6 @@
+# SLO Runbook: Retry Rate
+
+1. `worker_temporary_failure_total` 増加時刻と対象ドメインを特定
+2. 4xx 応答の主要要因（接続拒否/レート制限/TLS失敗）をログで確認
+3. 必要に応じて `MTA_DOMAIN_PENALTY_MAX` と並行度を調整
+4. 改善後に再試行遅延とDLQ流入率を確認

--- a/internal/observability/server.go
+++ b/internal/observability/server.go
@@ -23,6 +23,21 @@ func RunServer(ctx context.Context, addr string, m *Metrics) error {
 		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
 		_, _ = w.Write([]byte(m.RenderPrometheus()))
 	})
+	mux.HandleFunc("/slo", func(w http.ResponseWriter, r *http.Request) {
+		targets := LoadSLOTargetsFromEnv()
+		snapshot := map[string]uint64{}
+		if m != nil {
+			snapshot = m.Snapshot()
+		}
+		report := EvaluateSLO(snapshot, targets)
+		w.Header().Set("Content-Type", "application/json")
+		if report.Status == "breach" {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+		_, _ = w.Write(report.JSON())
+	})
 
 	srv := &http.Server{Addr: addr, Handler: mux}
 	go func() {

--- a/internal/observability/server_test.go
+++ b/internal/observability/server_test.go
@@ -11,6 +11,7 @@ import (
 func TestRunServerMetricsEndpoint(t *testing.T) {
 	m := NewMetrics()
 	m.Counter("smtp_connections").Inc()
+	m.Counter("worker_delivery_success").Add(10)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -37,5 +38,21 @@ func TestRunServerMetricsEndpoint(t *testing.T) {
 			t.Fatalf("metrics endpoint not ready: %v", err)
 		}
 		time.Sleep(50 * time.Millisecond)
+	}
+
+	t.Setenv("MTA_SLO_MIN_DELIVERY_SUCCESS_RATE", "0.5")
+	t.Setenv("MTA_SLO_MAX_RETRY_RATE", "0.5")
+	t.Setenv("MTA_SLO_MAX_QUEUE_BACKLOG", "10000")
+	resp, err := http.Get("http://" + addr + "/slo")
+	if err != nil {
+		t.Fatalf("slo endpoint not ready: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("slo status=%d want=%d", resp.StatusCode, http.StatusOK)
+	}
+	b, _ := io.ReadAll(resp.Body)
+	if len(b) == 0 {
+		t.Fatal("empty slo body")
 	}
 }

--- a/internal/observability/slo.go
+++ b/internal/observability/slo.go
@@ -1,0 +1,132 @@
+package observability
+
+import (
+	"encoding/json"
+	"math"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type SLOTargets struct {
+	MinDeliverySuccessRate float64
+	MaxRetryRate           float64
+	MaxQueueBacklog        uint64
+}
+
+type SLOReport struct {
+	Timestamp time.Time         `json:"timestamp"`
+	Targets   SLOTargets        `json:"targets"`
+	SLI       SLIValues         `json:"sli"`
+	Breaches  []SLOBreach       `json:"breaches"`
+	Status    string            `json:"status"`
+	Raw       map[string]uint64 `json:"raw,omitempty"`
+}
+
+type SLIValues struct {
+	DeliverySuccessRate float64 `json:"delivery_success_rate"`
+	RetryRate           float64 `json:"retry_rate"`
+	QueueBacklog        uint64  `json:"queue_backlog"`
+}
+
+type SLOBreach struct {
+	Name     string  `json:"name"`
+	Value    float64 `json:"value"`
+	Target   float64 `json:"target"`
+	Operator string  `json:"operator"`
+}
+
+func LoadSLOTargetsFromEnv() SLOTargets {
+	return SLOTargets{
+		MinDeliverySuccessRate: envFloat("MTA_SLO_MIN_DELIVERY_SUCCESS_RATE", 0.99),
+		MaxRetryRate:           envFloat("MTA_SLO_MAX_RETRY_RATE", 0.20),
+		MaxQueueBacklog:        envUint64("MTA_SLO_MAX_QUEUE_BACKLOG", 50000),
+	}
+}
+
+func EvaluateSLO(snapshot map[string]uint64, targets SLOTargets) SLOReport {
+	success := snapshot["worker_delivery_success_total"]
+	tempFail := snapshot["worker_temporary_failure_total"]
+	permFail := snapshot["worker_permanent_bounce_total"]
+	totalAttempts := success + tempFail + permFail
+
+	successRate := 1.0
+	retryRate := 0.0
+	if totalAttempts > 0 {
+		successRate = float64(success) / float64(totalAttempts)
+		retryRate = float64(tempFail) / float64(totalAttempts)
+	}
+
+	queued := snapshot["smtp_queued_messages_total"]
+	acked := snapshot["worker_ack_sent_total"]
+	failed := snapshot["worker_mark_failed_total"]
+	backlog := uint64(0)
+	if queued > acked+failed {
+		backlog = queued - acked - failed
+	}
+
+	report := SLOReport{
+		Timestamp: time.Now().UTC(),
+		Targets:   targets,
+		SLI: SLIValues{
+			DeliverySuccessRate: round4(successRate),
+			RetryRate:           round4(retryRate),
+			QueueBacklog:        backlog,
+		},
+		Raw:    snapshot,
+		Status: "ok",
+	}
+	if successRate < targets.MinDeliverySuccessRate {
+		report.Breaches = append(report.Breaches, SLOBreach{
+			Name: "delivery_success_rate", Value: round4(successRate), Target: round4(targets.MinDeliverySuccessRate), Operator: ">=",
+		})
+	}
+	if retryRate > targets.MaxRetryRate {
+		report.Breaches = append(report.Breaches, SLOBreach{
+			Name: "retry_rate", Value: round4(retryRate), Target: round4(targets.MaxRetryRate), Operator: "<=",
+		})
+	}
+	if backlog > targets.MaxQueueBacklog {
+		report.Breaches = append(report.Breaches, SLOBreach{
+			Name: "queue_backlog", Value: float64(backlog), Target: float64(targets.MaxQueueBacklog), Operator: "<=",
+		})
+	}
+	if len(report.Breaches) > 0 {
+		report.Status = "breach"
+	}
+	return report
+}
+
+func (r SLOReport) JSON() []byte {
+	b, _ := json.Marshal(r)
+	return b
+}
+
+func round4(v float64) float64 {
+	return math.Round(v*10000) / 10000
+}
+
+func envFloat(k string, def float64) float64 {
+	v := strings.TrimSpace(os.Getenv(k))
+	if v == "" {
+		return def
+	}
+	n, err := strconv.ParseFloat(v, 64)
+	if err != nil {
+		return def
+	}
+	return n
+}
+
+func envUint64(k string, def uint64) uint64 {
+	v := strings.TrimSpace(os.Getenv(k))
+	if v == "" {
+		return def
+	}
+	n, err := strconv.ParseUint(v, 10, 64)
+	if err != nil {
+		return def
+	}
+	return n
+}

--- a/internal/observability/slo_test.go
+++ b/internal/observability/slo_test.go
@@ -1,0 +1,46 @@
+package observability
+
+import "testing"
+
+func TestEvaluateSLOOK(t *testing.T) {
+	snap := map[string]uint64{
+		"worker_delivery_success_total":  90,
+		"worker_temporary_failure_total": 5,
+		"worker_permanent_bounce_total":  5,
+		"smtp_queued_messages_total":     100,
+		"worker_ack_sent_total":          90,
+		"worker_mark_failed_total":       10,
+	}
+	targets := SLOTargets{
+		MinDeliverySuccessRate: 0.85,
+		MaxRetryRate:           0.10,
+		MaxQueueBacklog:        10,
+	}
+	r := EvaluateSLO(snap, targets)
+	if r.Status != "ok" {
+		t.Fatalf("status=%s breaches=%v", r.Status, r.Breaches)
+	}
+}
+
+func TestEvaluateSLOBreach(t *testing.T) {
+	snap := map[string]uint64{
+		"worker_delivery_success_total":  10,
+		"worker_temporary_failure_total": 20,
+		"worker_permanent_bounce_total":  10,
+		"smtp_queued_messages_total":     100,
+		"worker_ack_sent_total":          5,
+		"worker_mark_failed_total":       1,
+	}
+	targets := SLOTargets{
+		MinDeliverySuccessRate: 0.80,
+		MaxRetryRate:           0.20,
+		MaxQueueBacklog:        50,
+	}
+	r := EvaluateSLO(snap, targets)
+	if r.Status != "breach" {
+		t.Fatalf("status=%s want=breach", r.Status)
+	}
+	if len(r.Breaches) == 0 {
+		t.Fatal("expected breaches")
+	}
+}


### PR DESCRIPTION
## Summary
- Issue #31 の対応として、SLI/SLOの評価基盤と監視運用の雛形を追加しました。

## Changes
- `/slo` endpoint 追加 (`internal/observability/server.go`)
  - 現在のメトリクススナップショットから SLI/SLO を評価
  - `status=ok` は HTTP 200、`status=breach` は HTTP 503
- SLO評価ロジック追加 (`internal/observability/slo.go`)
  - SLI: delivery success rate / retry rate / queue backlog
  - SLO target:
    - `MTA_SLO_MIN_DELIVERY_SUCCESS_RATE` (default `0.99`)
    - `MTA_SLO_MAX_RETRY_RATE` (default `0.20`)
    - `MTA_SLO_MAX_QUEUE_BACKLOG` (default `50000`)
- テスト追加
  - `internal/observability/slo_test.go` (OK/Breach判定)
  - `internal/observability/server_test.go` に `/slo` 結合テストを追加
- 監視運用雛形
  - Prometheus alert rules: `deploy/monitoring/prometheus/orinoco_slo_rules.yml`
  - Runbook 雛形:
    - `docs/runbooks/slo_delivery.md`
    - `docs/runbooks/slo_retry.md`
    - `docs/runbooks/slo_backlog.md`
- README更新
  - SLO関連環境変数と `/slo` エンドポイント説明を追記

## Validation
- `go vet ./...`
- `go test ./...`
- `go test -race ./...`

## Risks / Follow-ups
- `/slo` はプロセス内カウンタベース評価です。長期時系列の厳密SLO判定はPrometheus/Grafana側で補完が必要です。
- queue backlogは近似式（queued - ack - failed）で算出しており、分散環境での厳密値は別途メトリクス設計が必要です。

Closes #31
