### PR TITLE
HAリファレンス構成とフェイルオーバー手順の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,3 +168,10 @@ DNS を含む `docker compose` 環境を用意しています。
 - `/slo`: 現在の SLI/SLO 判定結果（JSON, breach時は HTTP 503）
 
 Prometheus alert rule の雛形は [orinoco_slo_rules.yml](/home/tamago/ghq/github.com/tamago/orinoco-mta/deploy/monitoring/prometheus/orinoco_slo_rules.yml) に配置しています。
+
+## HA Reference
+
+- リファレンス構成とフェイルオーバー手順:
+  [ha_reference.md](/home/tamago/ghq/github.com/tamago/orinoco-mta/docs/architecture/ha_reference.md)
+- 障害注入ドリル補助スクリプト:
+  `scripts/chaos/run_ha_drill.sh`

--- a/docs/architecture/ha_reference.md
+++ b/docs/architecture/ha_reference.md
@@ -1,0 +1,83 @@
+# Orinoco MTA HA Reference Architecture
+
+## 目標
+
+- RTO: 5分以内（単一AZ障害）
+- RPO: 1分以内（キューレプリケーション前提）
+- 単一コンポーネント障害で配送停止しない
+
+## 構成（マルチAZ, Active-Active）
+
+```text
+                     +-------------------------------+
+                     |      Global DNS / LB          |
+                     +---------------+---------------+
+                                     |
+                     +---------------+---------------+
+                     |                               |
+             +-------v-------+               +-------v-------+
+             |   AZ-A Ingress|               |   AZ-B Ingress|
+             |  SMTP/Submit  |               |  SMTP/Submit  |
+             +-------+-------+               +-------+-------+
+                     |                               |
+             +-------v-------+               +-------v-------+
+             |   Queue Broker|<--replicate-->|   Queue Broker|
+             |  (cluster A)  |               |  (cluster B)  |
+             +-------+-------+               +-------+-------+
+                     |                               |
+             +-------v-------+               +-------v-------+
+             | Worker Pool A |               | Worker Pool B |
+             +-------+-------+               +-------+-------+
+                     |                               |
+                     +---------------+---------------+
+                                     |
+                           +---------v---------+
+                           | External MX hosts |
+                           +-------------------+
+
+        Observability(Prometheus/Grafana/Alertmanager) は各AZに配置し相互監視
+```
+
+## Active-Active / Active-Standby 比較
+
+| 項目 | Active-Active | Active-Standby |
+| --- | --- | --- |
+| 平常時コスト | 高い | 低い |
+| 障害時RTO | 低い（秒〜分） | 高い（分〜十数分） |
+| 運用複雑度 | 高い | 中 |
+| 推奨用途 | 高スループット本番 | 小規模/段階導入 |
+
+採用方針:
+- 本番基準は Active-Active（本ドキュメントの前提）
+- コスト制約時は Active-Standby を暫定採用し、段階的にActive-Activeへ移行
+
+## フェイルオーバー判定条件
+
+- Ingress:
+  - `/healthz` の連続失敗（3回/30秒）
+  - 5xx率 > 20% が5分継続
+- Queue:
+  - broker quorum 喪失
+  - produce/consume エラー率 > 30% が5分継続
+- Worker:
+  - `worker_delivery_success_total` 低下 + `worker_temporary_failure_total` 急増
+- DNS:
+  - authoritative DNS 応答失敗、または解決遅延しきい値超過
+
+## フェイルオーバー手順
+
+1. Alertmanager で重大度 `page` 通知を確認
+2. 影響スコープ（AZ単位/全体）を判定
+3. DNS/LB 重みを健全AZへ寄せる（または不健全AZを切離し）
+4. Queue 健全性確認（under-replicated partitions, lag）
+5. Worker 容量を健全AZで一時増強
+6. `/slo` と `/metrics` で復旧判定（SLO breach 解消）
+7. 事後に元構成へ段階復帰
+
+## 障害注入テスト計画
+
+- AZ断（Ingress/Worker停止）
+- Broker断（片系 broker kill）
+- DNS障害（名前解決失敗/遅延）
+
+各シナリオの実行は `scripts/chaos/run_ha_drill.sh` を参照。

--- a/scripts/chaos/run_ha_drill.sh
+++ b/scripts/chaos/run_ha_drill.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# HA drill helper for Issue #26.
+# This script is intentionally explicit and non-destructive by default.
+# It prints commands to run and can execute only when --apply is given.
+
+SCENARIO="${1:-}"
+APPLY="${2:-}"
+
+if [[ -z "${SCENARIO}" ]]; then
+  cat <<'USAGE'
+Usage:
+  scripts/chaos/run_ha_drill.sh <scenario> [--apply]
+
+Scenarios:
+  az-a-down       Stop AZ-A ingress/worker (simulated)
+  broker-a-down   Stop broker A (simulated)
+  dns-failure     Break DNS resolution for test container (simulated)
+
+Default behavior is dry-run (print only).
+USAGE
+  exit 1
+fi
+
+run() {
+  local cmd="$1"
+  if [[ "${APPLY}" == "--apply" ]]; then
+    echo "+ ${cmd}"
+    eval "${cmd}"
+  else
+    echo "[dry-run] ${cmd}"
+  fi
+}
+
+echo "Scenario: ${SCENARIO}"
+echo "Mode: ${APPLY:---dry-run--}"
+
+case "${SCENARIO}" in
+  az-a-down)
+    run "docker compose stop orinoco-ingress-a"
+    run "docker compose stop orinoco-worker-a"
+    ;;
+  broker-a-down)
+    run "docker compose stop kafka-a"
+    ;;
+  dns-failure)
+    run "docker compose exec -T orinoco-worker-a sh -lc 'echo nameserver 203.0.113.1 > /etc/resolv.conf'"
+    ;;
+  *)
+    echo "unknown scenario: ${SCENARIO}" >&2
+    exit 2
+    ;;
+esac
+
+cat <<'CHECKS'
+Post-checks:
+  1) curl -fsS http://<observability-host>:9090/healthz
+  2) curl -fsS http://<observability-host>:9090/slo
+  3) Confirm backlog and retry metrics trend on dashboard
+  4) Validate RTO/RPO against target in docs/architecture/ha_reference.md
+CHECKS


### PR DESCRIPTION
## Summary
- Issue #26 の対応として、エンタープライズ運用向けのHAリファレンス構成と運用手順を追加しました。

## Changes
- リファレンスアーキテクチャ文書を追加
  - `docs/architecture/ha_reference.md`
  - マルチAZ Active-Active前提の構成図（テキスト図）
  - Active-Active / Active-Standby 比較
  - フェイルオーバー判定条件
  - 切替手順（RTO/RPO目標つき）
- 障害注入ドリル補助スクリプトを追加
  - `scripts/chaos/run_ha_drill.sh`
  - シナリオ: `az-a-down`, `broker-a-down`, `dns-failure`
  - デフォルトdry-run、`--apply` で実行
- README更新
  - HA Reference セクションを追加
  - ドキュメントとドリルスクリプトへの導線を追加

## Validation
- `go vet ./...`
- `go test ./...`
- `go test -race ./...`

## Risks / Follow-ups
- 本PRは運用リファレンス + ドリル雛形の追加です。実環境の compose/service 名に合わせた適用調整が必要です。
- Issue本文の「障害注入テスト追加」は、次段で CI 連携可能な実検証シナリオへ発展させる想定です。

Closes #26
