### PR TITLE
PIIマスキングとデータ保持ポリシー自動適用の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ go run ./cmd/mta
 - `MTA_SLO_MIN_DELIVERY_SUCCESS_RATE` (default: `0.99`)
 - `MTA_SLO_MAX_RETRY_RATE` (default: `0.20`)
 - `MTA_SLO_MAX_QUEUE_BACKLOG` (default: `50000`)
+- `MTA_DATA_RETENTION_SENT` (default: `720h` = 30d)
+- `MTA_DATA_RETENTION_DLQ` (default: `2160h` = 90d)
+- `MTA_DATA_RETENTION_POISON` (default: `4320h` = 180d)
+- `MTA_RETENTION_SWEEP_INTERVAL` (default: `1h`)
 - `MTA_HOSTNAME` (default: `orinoco.local`)
 - `MTA_QUEUE_DIR` (default: `./var/queue`)
 - `MTA_QUEUE_BACKEND` (default: `local`, values: `local` / `kafka`)
@@ -175,3 +179,9 @@ Prometheus alert rule の雛形は [orinoco_slo_rules.yml](/home/tamago/ghq/gith
   [ha_reference.md](/home/tamago/ghq/github.com/tamago/orinoco-mta/docs/architecture/ha_reference.md)
 - 障害注入ドリル補助スクリプト:
   `scripts/chaos/run_ha_drill.sh`
+
+## Compliance Basics
+
+- ログは `slog(JSON)` で出力
+- メールアドレス等のPIIはログ出力時にマスキング
+- `sent / mail.dlq / mail.dlq/poison` は保持期間ポリシーに基づき自動削除

--- a/cmd/mta/main.go
+++ b/cmd/mta/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/tamago0224/orinoco-mta/internal/logging"
 	"github.com/tamago0224/orinoco-mta/internal/observability"
 	"github.com/tamago0224/orinoco-mta/internal/queue"
+	"github.com/tamago0224/orinoco-mta/internal/retention"
 	"github.com/tamago0224/orinoco-mta/internal/smtp"
 	"github.com/tamago0224/orinoco-mta/internal/userauth"
 	"github.com/tamago0224/orinoco-mta/internal/worker"
@@ -24,6 +25,7 @@ import (
 func main() {
 	cfg := config.Load()
 	slog.SetDefault(logging.New(cfg.LogLevel, os.Stdout))
+	slog.Info("audit event", "component", "audit", "event", "config_loaded", "queue_backend", cfg.QueueBackend, "submission_enabled", cfg.SubmissionAddr != "", "delivery_mode", cfg.DeliveryMode)
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
@@ -61,6 +63,7 @@ func main() {
 	if submissionServer != nil {
 		workers++
 	}
+	workers++
 	errCh := make(chan error, workers)
 	go func() { errCh <- s.Run(ctx) }()
 	if submissionServer != nil {
@@ -68,6 +71,14 @@ func main() {
 	}
 	go func() { errCh <- d.Run(ctx) }()
 	go func() { errCh <- observability.RunServer(ctx, cfg.ObservabilityAddr, metrics) }()
+	go func() {
+		errCh <- retention.Run(ctx, cfg.QueueDir, retention.Policy{
+			SentTTL:   cfg.DataRetentionSent,
+			DLQTTL:    cfg.DataRetentionDLQ,
+			PoisonTTL: cfg.DataRetentionPoison,
+			Interval:  cfg.RetentionSweepInterval,
+		})
+	}()
 
 	for i := 0; i < workers; i++ {
 		err := <-errCh

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,6 +54,10 @@ type Config struct {
 	DomainAdaptiveThrottle     bool
 	DomainTempFailThreshold    float64
 	DomainPenaltyMax           time.Duration
+	DataRetentionSent          time.Duration
+	DataRetentionDLQ           time.Duration
+	DataRetentionPoison        time.Duration
+	RetentionSweepInterval     time.Duration
 }
 
 func Load() Config {
@@ -107,6 +111,10 @@ func Load() Config {
 		DomainAdaptiveThrottle:     envBool("MTA_DOMAIN_ADAPTIVE_THROTTLE", true),
 		DomainTempFailThreshold:    envFloat64("MTA_DOMAIN_TEMPFAIL_THRESHOLD", 0.3),
 		DomainPenaltyMax:           envDuration("MTA_DOMAIN_PENALTY_MAX", 5*time.Second),
+		DataRetentionSent:          envDuration("MTA_DATA_RETENTION_SENT", 30*24*time.Hour),
+		DataRetentionDLQ:           envDuration("MTA_DATA_RETENTION_DLQ", 90*24*time.Hour),
+		DataRetentionPoison:        envDuration("MTA_DATA_RETENTION_POISON", 180*24*time.Hour),
+		RetentionSweepInterval:     envDuration("MTA_RETENTION_SWEEP_INTERVAL", time.Hour),
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -137,3 +137,23 @@ func TestLoadDomainThrottleConfig(t *testing.T) {
 		t.Fatalf("penalty max=%s", cfg.DomainPenaltyMax)
 	}
 }
+
+func TestLoadRetentionConfig(t *testing.T) {
+	t.Setenv("MTA_DATA_RETENTION_SENT", "720h")
+	t.Setenv("MTA_DATA_RETENTION_DLQ", "2160h")
+	t.Setenv("MTA_DATA_RETENTION_POISON", "4320h")
+	t.Setenv("MTA_RETENTION_SWEEP_INTERVAL", "30m")
+	cfg := Load()
+	if cfg.DataRetentionSent != 720*time.Hour {
+		t.Fatalf("retention sent=%s", cfg.DataRetentionSent)
+	}
+	if cfg.DataRetentionDLQ != 2160*time.Hour {
+		t.Fatalf("retention dlq=%s", cfg.DataRetentionDLQ)
+	}
+	if cfg.DataRetentionPoison != 4320*time.Hour {
+		t.Fatalf("retention poison=%s", cfg.DataRetentionPoison)
+	}
+	if cfg.RetentionSweepInterval != 30*time.Minute {
+		t.Fatalf("retention sweep=%s", cfg.RetentionSweepInterval)
+	}
+}

--- a/internal/logging/pii.go
+++ b/internal/logging/pii.go
@@ -1,0 +1,40 @@
+package logging
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+func MaskEmail(v string) string {
+	s := strings.TrimSpace(strings.ToLower(v))
+	if s == "" {
+		return ""
+	}
+	at := strings.LastIndexByte(s, '@')
+	if at <= 0 || at == len(s)-1 {
+		return "***"
+	}
+	local := s[:at]
+	domain := s[at+1:]
+	if len(local) <= 2 {
+		return "***@" + domain
+	}
+	return local[:1] + "***" + local[len(local)-1:] + "@" + domain
+}
+
+func MaskIP(v string) string {
+	ip := net.ParseIP(strings.TrimSpace(v))
+	if ip == nil {
+		return ""
+	}
+	if ip4 := ip.To4(); ip4 != nil {
+		return fmt.Sprintf("%d.%d.x.x", ip4[0], ip4[1])
+	}
+	s := ip.String()
+	parts := strings.Split(s, ":")
+	if len(parts) < 2 {
+		return "x::"
+	}
+	return parts[0] + ":x::"
+}

--- a/internal/logging/pii_test.go
+++ b/internal/logging/pii_test.go
@@ -1,0 +1,21 @@
+package logging
+
+import "testing"
+
+func TestMaskEmail(t *testing.T) {
+	if got := MaskEmail("alice@example.com"); got != "a***e@example.com" {
+		t.Fatalf("mask email=%q", got)
+	}
+	if got := MaskEmail("ab@example.com"); got != "***@example.com" {
+		t.Fatalf("mask short email=%q", got)
+	}
+}
+
+func TestMaskIP(t *testing.T) {
+	if got := MaskIP("192.168.1.2"); got != "192.168.x.x" {
+		t.Fatalf("mask ip=%q", got)
+	}
+	if got := MaskIP("2001:db8::1"); got == "" {
+		t.Fatal("mask ipv6 should not be empty")
+	}
+}

--- a/internal/retention/retention.go
+++ b/internal/retention/retention.go
@@ -1,0 +1,92 @@
+package retention
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type Policy struct {
+	SentTTL   time.Duration
+	DLQTTL    time.Duration
+	PoisonTTL time.Duration
+	Interval  time.Duration
+}
+
+func Run(ctx context.Context, queueRoot string, p Policy) error {
+	if p.Interval <= 0 {
+		p.Interval = time.Hour
+	}
+	t := time.NewTicker(p.Interval)
+	defer t.Stop()
+	_ = sweep(queueRoot, p)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-t.C:
+			if err := sweep(queueRoot, p); err != nil {
+				slog.Error("retention sweep failed", "component", "retention", "error", err)
+			}
+		}
+	}
+}
+
+func sweep(queueRoot string, p Policy) error {
+	if queueRoot == "" {
+		return nil
+	}
+	now := time.Now().UTC()
+	deleted := 0
+	if n, err := removeOlder(filepath.Join(queueRoot, "sent"), p.SentTTL, now); err == nil {
+		deleted += n
+	} else {
+		return err
+	}
+	if n, err := removeOlder(filepath.Join(queueRoot, "mail.dlq"), p.DLQTTL, now); err == nil {
+		deleted += n
+	} else {
+		return err
+	}
+	if n, err := removeOlder(filepath.Join(queueRoot, "mail.dlq", "poison"), p.PoisonTTL, now); err == nil {
+		deleted += n
+	} else {
+		return err
+	}
+	slog.Info("retention sweep completed", "component", "retention", "deleted_files", deleted)
+	return nil
+}
+
+func removeOlder(dir string, ttl time.Duration, now time.Time) (int, error) {
+	if ttl <= 0 {
+		return 0, nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	cutoff := now.Add(-ttl)
+	removed := 0
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		st, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+		if st.ModTime().After(cutoff) {
+			continue
+		}
+		if err := os.Remove(path); err == nil {
+			removed++
+		}
+	}
+	return removed, nil
+}

--- a/internal/retention/retention_test.go
+++ b/internal/retention/retention_test.go
@@ -1,0 +1,37 @@
+package retention
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSweepRemovesExpiredFiles(t *testing.T) {
+	root := t.TempDir()
+	sentDir := filepath.Join(root, "sent")
+	if err := os.MkdirAll(sentDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	old := filepath.Join(sentDir, "old.json")
+	newf := filepath.Join(sentDir, "new.json")
+	if err := os.WriteFile(old, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write old: %v", err)
+	}
+	if err := os.WriteFile(newf, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write new: %v", err)
+	}
+	oldTime := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(old, oldTime, oldTime); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	if err := sweep(root, Policy{SentTTL: 24 * time.Hour}); err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if _, err := os.Stat(old); !os.IsNotExist(err) {
+		t.Fatalf("old file must be deleted: err=%v", err)
+	}
+	if _, err := os.Stat(newf); err != nil {
+		t.Fatalf("new file must remain: %v", err)
+	}
+}

--- a/internal/smtp/server.go
+++ b/internal/smtp/server.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/tamago0224/orinoco-mta/internal/config"
 	"github.com/tamago0224/orinoco-mta/internal/ingress"
+	"github.com/tamago0224/orinoco-mta/internal/logging"
 	"github.com/tamago0224/orinoco-mta/internal/mailauth"
 	"github.com/tamago0224/orinoco-mta/internal/model"
 	"github.com/tamago0224/orinoco-mta/internal/observability"
@@ -257,7 +258,7 @@ func (s *Server) handleConn(conn net.Conn) {
 			}
 			if remoteIP != nil && s.flexLimiter != nil && !s.flexLimiter.Allow("mailfrom", remoteIP.String(), ss.helo, mailArgs.Address, time.Now().UTC()) {
 				s.metricInc("smtp_reject_rate_limit")
-				slog.Warn("ingress rejected", "component", "smtp", "reason", "rate_rule_mailfrom", "remote_ip", remoteIP.String(), "helo", ss.helo, "mail_from", mailArgs.Address)
+				slog.Warn("ingress rejected", "component", "smtp", "reason", "rate_rule_mailfrom", "remote_ip", remoteIP.String(), "helo", ss.helo, "mail_from", logging.MaskEmail(mailArgs.Address))
 				writeResp(w, 421, "rate limit exceeded, try again later")
 				return
 			}

--- a/internal/worker/dispatcher.go
+++ b/internal/worker/dispatcher.go
@@ -11,6 +11,7 @@ import (
 	"github.com/tamago0224/orinoco-mta/internal/bounce"
 	"github.com/tamago0224/orinoco-mta/internal/config"
 	"github.com/tamago0224/orinoco-mta/internal/delivery"
+	"github.com/tamago0224/orinoco-mta/internal/logging"
 	"github.com/tamago0224/orinoco-mta/internal/model"
 	"github.com/tamago0224/orinoco-mta/internal/observability"
 	"github.com/tamago0224/orinoco-mta/internal/queue"
@@ -106,7 +107,7 @@ func (d *Dispatcher) handleMessage(ctx context.Context, msg *model.Message) {
 					d.metricInc("worker_permanent_bounce")
 					if d.sup != nil {
 						if sErr := d.sup.Add(rcpt, smtpErr.Line); sErr != nil {
-							slog.Error("suppression add failed", "component", "worker", "rcpt", rcpt, "msg_id", msg.ID, "error", sErr)
+							slog.Error("suppression add failed", "component", "worker", "rcpt", logging.MaskEmail(rcpt), "msg_id", msg.ID, "error", sErr)
 						}
 					}
 					return


### PR DESCRIPTION
## Summary
- Issue #33 の対応として、PIIマスキング基盤とデータ保持期間ポリシーの自動適用を追加しました。
- 監査ログの最小実装として、起動時に設定ロードイベントを構造化ログへ出力します。

## Changes
- PIIマスキング (`internal/logging/pii.go`)
  - `MaskEmail`, `MaskIP` を追加
  - worker/smtp のログ出力でメールアドレスをマスクして記録
- データ保持期間ポリシー (`internal/retention`)
  - `sent / mail.dlq / mail.dlq/poison` のTTLベース自動削除を実装
  - main 起動時に retention sweep goroutine を追加
- 設定追加 (`internal/config`)
  - `MTA_DATA_RETENTION_SENT`
  - `MTA_DATA_RETENTION_DLQ`
  - `MTA_DATA_RETENTION_POISON`
  - `MTA_RETENTION_SWEEP_INTERVAL`
- 監査ログ（最小実装）
  - `config_loaded` イベントを `component=audit` で出力
- テスト追加
  - `internal/logging/pii_test.go`
  - `internal/retention/retention_test.go`
  - config ロードテスト拡張
- README更新
  - 保持ポリシー設定と compliance basics を追記

## Validation
- `go vet ./...`
- `go test ./...`
- `go test -race ./...`

## Risks / Follow-ups
- 監査ログは起動イベント中心の最小実装です。操作主体（who/what/when）の完全追跡は次段で操作面APIと連携して拡張が必要です。
- 保持ポリシーはローカルファイル保存領域対象です。Kafka/外部ストレージの保持削除は別途実装が必要です。

Closes #33
