### PR TITLE
[RFC 8461] staleキャッシュ運用と再試行戦略を実装

### DIFF
--- a/internal/delivery/mta_sts.go
+++ b/internal/delivery/mta_sts.go
@@ -45,9 +45,14 @@ type MTASTSResolver struct {
 	ttl       time.Duration
 	fetchTO   time.Duration
 	fetchFunc func(ctx context.Context, domain string) (string, error)
+	nowFn     func() time.Time
 
-	mu    sync.Mutex
-	cache map[string]MTASTSPolicy
+	mu            sync.Mutex
+	cache         map[string]MTASTSPolicy
+	retryFailures map[string]int
+	retryAt       map[string]time.Time
+	minRetryDelay time.Duration
+	maxRetryDelay time.Duration
 }
 
 func NewMTASTSResolver(ttl, fetchTimeout time.Duration, fetchFunc func(ctx context.Context, domain string) (string, error)) *MTASTSResolver {
@@ -60,7 +65,17 @@ func NewMTASTSResolver(ttl, fetchTimeout time.Duration, fetchFunc func(ctx conte
 	if fetchTimeout <= 0 {
 		fetchTimeout = 5 * time.Second
 	}
-	return &MTASTSResolver{ttl: ttl, fetchTO: fetchTimeout, fetchFunc: fetchFunc, cache: map[string]MTASTSPolicy{}}
+	return &MTASTSResolver{
+		ttl:           ttl,
+		fetchTO:       fetchTimeout,
+		fetchFunc:     fetchFunc,
+		nowFn:         time.Now,
+		cache:         map[string]MTASTSPolicy{},
+		retryFailures: map[string]int{},
+		retryAt:       map[string]time.Time{},
+		minRetryDelay: time.Second,
+		maxRetryDelay: 5 * time.Minute,
+	}
 }
 
 func (r *MTASTSResolver) Lookup(ctx context.Context, domain string) (MTASTSPolicy, error) {
@@ -68,20 +83,48 @@ func (r *MTASTSResolver) Lookup(ctx context.Context, domain string) (MTASTSPolic
 	if domain == "" {
 		return MTASTSPolicy{}, errors.New("empty domain")
 	}
-	now := time.Now().UTC()
+	now := r.nowFn().UTC()
+
+	var stale MTASTSPolicy
+	hasStale := false
+
 	r.mu.Lock()
-	if p, ok := r.cache[domain]; ok && now.Before(p.ExpiresAt) {
-		r.mu.Unlock()
-		return p, nil
+	if p, ok := r.cache[domain]; ok {
+		if now.Before(p.ExpiresAt) {
+			r.mu.Unlock()
+			return p, nil
+		}
+		stale = p
+		hasStale = true
+		if ra, ok := r.retryAt[domain]; ok && now.Before(ra) {
+			r.mu.Unlock()
+			return stale, nil
+		}
 	}
 	r.mu.Unlock()
 
 	text, err := r.fetchFunc(ctx, domain)
 	if err != nil {
+		if hasStale {
+			r.mu.Lock()
+			failures := r.retryFailures[domain] + 1
+			r.retryFailures[domain] = failures
+			r.retryAt[domain] = now.Add(r.retryDelay(failures))
+			r.mu.Unlock()
+			return stale, nil
+		}
 		return MTASTSPolicy{}, err
 	}
 	p, err := parseMTASTSPolicy(text)
 	if err != nil {
+		if hasStale {
+			r.mu.Lock()
+			failures := r.retryFailures[domain] + 1
+			r.retryFailures[domain] = failures
+			r.retryAt[domain] = now.Add(r.retryDelay(failures))
+			r.mu.Unlock()
+			return stale, nil
+		}
 		return MTASTSPolicy{}, err
 	}
 	expire := now.Add(p.MaxAge)
@@ -92,8 +135,31 @@ func (r *MTASTSResolver) Lookup(ctx context.Context, domain string) (MTASTSPolic
 
 	r.mu.Lock()
 	r.cache[domain] = p
+	delete(r.retryFailures, domain)
+	delete(r.retryAt, domain)
 	r.mu.Unlock()
 	return p, nil
+}
+
+func (r *MTASTSResolver) retryDelay(failures int) time.Duration {
+	if failures <= 0 {
+		return r.minRetryDelay
+	}
+	delay := r.minRetryDelay
+	for i := 1; i < failures; i++ {
+		if delay >= r.maxRetryDelay/2 {
+			delay = r.maxRetryDelay
+			break
+		}
+		delay *= 2
+	}
+	if delay > r.maxRetryDelay {
+		return r.maxRetryDelay
+	}
+	if delay <= 0 {
+		return r.minRetryDelay
+	}
+	return delay
 }
 
 func parseMTASTSPolicy(raw string) (MTASTSPolicy, error) {

--- a/internal/delivery/mta_sts_test.go
+++ b/internal/delivery/mta_sts_test.go
@@ -2,6 +2,7 @@ package delivery
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 )
@@ -52,5 +53,75 @@ func TestMTASTSResolverCachesResult(t *testing.T) {
 	}
 	if p1.Mode != p2.Mode {
 		t.Fatalf("cached policy mismatch")
+	}
+}
+
+func TestMTASTSResolverReturnsStaleOnFetchFailure(t *testing.T) {
+	now := time.Date(2026, 3, 11, 12, 0, 0, 0, time.UTC)
+	calls := 0
+	r := NewMTASTSResolver(5*time.Minute, 2*time.Second, func(ctx context.Context, domain string) (string, error) {
+		calls++
+		return "", errors.New("fetch failed")
+	})
+	r.nowFn = func() time.Time { return now }
+	r.cache["example.com"] = MTASTSPolicy{
+		Version:   "STSv1",
+		Mode:      "enforce",
+		MX:        []string{"mx.example.net"},
+		MaxAge:    time.Hour,
+		ExpiresAt: now.Add(-time.Minute),
+	}
+
+	p, err := r.Lookup(context.Background(), "example.com")
+	if err != nil {
+		t.Fatalf("lookup should return stale policy on fetch failure: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected one fetch attempt, calls=%d", calls)
+	}
+	if p.Mode != "enforce" || len(p.MX) != 1 || p.MX[0] != "mx.example.net" {
+		t.Fatalf("unexpected stale policy: %+v", p)
+	}
+}
+
+func TestMTASTSResolverUsesCooldownBeforeRetry(t *testing.T) {
+	now := time.Date(2026, 3, 11, 12, 0, 0, 0, time.UTC)
+	calls := 0
+	r := NewMTASTSResolver(5*time.Minute, 2*time.Second, func(ctx context.Context, domain string) (string, error) {
+		calls++
+		return "", errors.New("fetch failed")
+	})
+	r.nowFn = func() time.Time { return now }
+	r.minRetryDelay = 10 * time.Second
+	r.maxRetryDelay = 10 * time.Second
+	r.cache["example.com"] = MTASTSPolicy{
+		Version:   "STSv1",
+		Mode:      "enforce",
+		MX:        []string{"mx.example.net"},
+		MaxAge:    time.Hour,
+		ExpiresAt: now.Add(-time.Minute),
+	}
+
+	if _, err := r.Lookup(context.Background(), "example.com"); err != nil {
+		t.Fatalf("first lookup: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected first fetch attempt, calls=%d", calls)
+	}
+
+	now = now.Add(5 * time.Second)
+	if _, err := r.Lookup(context.Background(), "example.com"); err != nil {
+		t.Fatalf("second lookup during cooldown: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected no fetch during cooldown, calls=%d", calls)
+	}
+
+	now = now.Add(6 * time.Second)
+	if _, err := r.Lookup(context.Background(), "example.com"); err != nil {
+		t.Fatalf("third lookup after cooldown: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected retry fetch after cooldown, calls=%d", calls)
 	}
 }


### PR DESCRIPTION
## 概要
- MTA-STS policy 取得失敗時に、期限切れでもキャッシュ済み policy（stale）を返す挙動を追加
- stale返却時にドメイン単位の再試行バックオフを導入し、連続失敗時の過剰フェッチを抑制
- 取得成功時は再試行状態をクリア

## 変更内容
- MTASTSResolver に再試行状態（retryFailures / retryAt）を追加
- Lookup を更新し、以下の順で評価
  - 有効キャッシュがあれば即返却
  - stale + クールダウン中なら stale を返却
  - fetch/parse 失敗時、stale があれば stale を返却し次回再試行時刻を更新
  - fetch 成功時はキャッシュ更新 + 再試行状態クリア
- テスト追加（TDD）
  - fetch失敗時に stale を返す
  - クールダウン中は再fetchしない
  - クールダウン経過後に再fetchする

## テスト
- go test ./internal/delivery -run MTASTS -v
- go test ./...

Closes #73