### PR TITLE
[RFC 8461] _mta-sts TXT id検証と再取得トリガーを実装

### DIFF
--- a/internal/delivery/mta_sts.go
+++ b/internal/delivery/mta_sts.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -18,6 +19,7 @@ type MTASTSPolicy struct {
 	MX        []string
 	MaxAge    time.Duration
 	ExpiresAt time.Time
+	PolicyID  string
 }
 
 func (p MTASTSPolicy) AllowsMX(host string) bool {
@@ -45,6 +47,7 @@ type MTASTSResolver struct {
 	ttl       time.Duration
 	fetchTO   time.Duration
 	fetchFunc func(ctx context.Context, domain string) (string, error)
+	lookupTXT func(ctx context.Context, name string) ([]string, error)
 	nowFn     func() time.Time
 
 	mu            sync.Mutex
@@ -69,6 +72,7 @@ func NewMTASTSResolver(ttl, fetchTimeout time.Duration, fetchFunc func(ctx conte
 		ttl:           ttl,
 		fetchTO:       fetchTimeout,
 		fetchFunc:     fetchFunc,
+		lookupTXT:     net.DefaultResolver.LookupTXT,
 		nowFn:         time.Now,
 		cache:         map[string]MTASTSPolicy{},
 		retryFailures: map[string]int{},
@@ -84,21 +88,28 @@ func (r *MTASTSResolver) Lookup(ctx context.Context, domain string) (MTASTSPolic
 		return MTASTSPolicy{}, errors.New("empty domain")
 	}
 	now := r.nowFn().UTC()
+	policyID, hasPolicyID := r.lookupPolicyID(ctx, domain)
 
 	var stale MTASTSPolicy
 	hasStale := false
 
 	r.mu.Lock()
 	if p, ok := r.cache[domain]; ok {
-		if now.Before(p.ExpiresAt) {
+		refreshByID := hasPolicyID && p.PolicyID != "" && policyID != p.PolicyID
+		if now.Before(p.ExpiresAt) && !refreshByID {
 			r.mu.Unlock()
 			return p, nil
 		}
 		stale = p
 		hasStale = true
-		if ra, ok := r.retryAt[domain]; ok && now.Before(ra) {
-			r.mu.Unlock()
-			return stale, nil
+		if !refreshByID {
+			if ra, ok := r.retryAt[domain]; ok && now.Before(ra) {
+				r.mu.Unlock()
+				return stale, nil
+			}
+		} else {
+			delete(r.retryAt, domain)
+			delete(r.retryFailures, domain)
 		}
 	}
 	r.mu.Unlock()
@@ -132,6 +143,9 @@ func (r *MTASTSResolver) Lookup(ctx context.Context, domain string) (MTASTSPolic
 		expire = ttlExpire
 	}
 	p.ExpiresAt = expire
+	if hasPolicyID {
+		p.PolicyID = policyID
+	}
 
 	r.mu.Lock()
 	r.cache[domain] = p
@@ -139,6 +153,52 @@ func (r *MTASTSResolver) Lookup(ctx context.Context, domain string) (MTASTSPolic
 	delete(r.retryAt, domain)
 	r.mu.Unlock()
 	return p, nil
+}
+
+func (r *MTASTSResolver) lookupPolicyID(ctx context.Context, domain string) (string, bool) {
+	if r.lookupTXT == nil {
+		return "", false
+	}
+	name := "_mta-sts." + domain
+	txts, err := r.lookupTXT(ctx, name)
+	if err != nil {
+		return "", false
+	}
+	return parseMTASTSPolicyID(txts)
+}
+
+func parseMTASTSPolicyID(txts []string) (string, bool) {
+	for _, txt := range txts {
+		var versionOK bool
+		var policyID string
+		parts := strings.Split(txt, ";")
+		for _, part := range parts {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			kv := strings.SplitN(part, "=", 2)
+			if len(kv) != 2 {
+				continue
+			}
+			k := strings.ToLower(strings.TrimSpace(kv[0]))
+			v := strings.TrimSpace(kv[1])
+			switch k {
+			case "v":
+				if strings.EqualFold(v, "STSv1") {
+					versionOK = true
+				}
+			case "id":
+				if v != "" {
+					policyID = v
+				}
+			}
+		}
+		if versionOK && policyID != "" {
+			return policyID, true
+		}
+	}
+	return "", false
 }
 
 func (r *MTASTSResolver) retryDelay(failures int) time.Duration {

--- a/internal/delivery/mta_sts_test.go
+++ b/internal/delivery/mta_sts_test.go
@@ -125,3 +125,82 @@ func TestMTASTSResolverUsesCooldownBeforeRetry(t *testing.T) {
 		t.Fatalf("expected retry fetch after cooldown, calls=%d", calls)
 	}
 }
+
+func TestParseMTASTSPolicyID(t *testing.T) {
+	id, ok := parseMTASTSPolicyID([]string{
+		"v=STSv1; id=20260311T120000",
+	})
+	if !ok {
+		t.Fatal("expected id to be parsed")
+	}
+	if id != "20260311T120000" {
+		t.Fatalf("unexpected id: %q", id)
+	}
+}
+
+func TestMTASTSResolverRefreshesPolicyWhenTXTIDChanges(t *testing.T) {
+	now := time.Date(2026, 3, 11, 12, 0, 0, 0, time.UTC)
+	fetchCalls := 0
+	r := NewMTASTSResolver(5*time.Minute, 2*time.Second, func(ctx context.Context, domain string) (string, error) {
+		fetchCalls++
+		return "version: STSv1\nmode: enforce\nmx: mx2.example.net\nmax_age: 120\n", nil
+	})
+	r.nowFn = func() time.Time { return now }
+	r.lookupTXT = func(context.Context, string) ([]string, error) {
+		return []string{"v=STSv1; id=new-id"}, nil
+	}
+	r.cache["example.com"] = MTASTSPolicy{
+		Version:   "STSv1",
+		Mode:      "enforce",
+		MX:        []string{"mx1.example.net"},
+		MaxAge:    time.Hour,
+		ExpiresAt: now.Add(time.Hour),
+		PolicyID:  "old-id",
+	}
+
+	p, err := r.Lookup(context.Background(), "example.com")
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if fetchCalls != 1 {
+		t.Fatalf("expected refresh fetch due to id mismatch, calls=%d", fetchCalls)
+	}
+	if len(p.MX) != 1 || p.MX[0] != "mx2.example.net" {
+		t.Fatalf("expected refreshed policy, got %+v", p)
+	}
+	if p.PolicyID != "new-id" {
+		t.Fatalf("expected policy id to update, got %q", p.PolicyID)
+	}
+}
+
+func TestMTASTSResolverKeepsCachedPolicyWhenTXTLookupFails(t *testing.T) {
+	now := time.Date(2026, 3, 11, 12, 0, 0, 0, time.UTC)
+	fetchCalls := 0
+	r := NewMTASTSResolver(5*time.Minute, 2*time.Second, func(ctx context.Context, domain string) (string, error) {
+		fetchCalls++
+		return "version: STSv1\nmode: enforce\nmx: mx2.example.net\nmax_age: 120\n", nil
+	})
+	r.nowFn = func() time.Time { return now }
+	r.lookupTXT = func(context.Context, string) ([]string, error) {
+		return nil, errors.New("dns failed")
+	}
+	r.cache["example.com"] = MTASTSPolicy{
+		Version:   "STSv1",
+		Mode:      "enforce",
+		MX:        []string{"mx1.example.net"},
+		MaxAge:    time.Hour,
+		ExpiresAt: now.Add(time.Hour),
+		PolicyID:  "old-id",
+	}
+
+	p, err := r.Lookup(context.Background(), "example.com")
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if fetchCalls != 0 {
+		t.Fatalf("expected no refresh fetch when txt lookup fails, calls=%d", fetchCalls)
+	}
+	if len(p.MX) != 1 || p.MX[0] != "mx1.example.net" {
+		t.Fatalf("expected cached policy, got %+v", p)
+	}
+}


### PR DESCRIPTION
## 概要
- MTA-STS resolver に _mta-sts.<domain> TXT レコードの id 検証を追加
- キャッシュ中 policy の id と TXT id が不一致の場合、有効期限内でも policy を再取得するよう変更
- TXT 取得に失敗した場合は既存キャッシュを優先し、不要な再取得を避ける

## 変更内容
- MTASTSPolicy に PolicyID を追加
- MTASTSResolver に TXT lookup を追加（デフォルト: net.DefaultResolver.LookupTXT）
- TXT から v=STSv1; id=... を抽出する parser を追加
- Lookup の判定順を強化
  - キャッシュ有効かつ id 一致: キャッシュ返却
  - id 不一致: 強制再取得トリガー
  - TXT lookup失敗: キャッシュ返却を維持

## テスト
- go test ./internal/delivery -run 'MTASTS|ParseMTASTSPolicyID' -v
- go test ./...

Closes #72