### PR TITLE
[RFC 8461] mode=testing の配送判定と違反レポートを実装

### DIFF
--- a/internal/delivery/smtp_client.go
+++ b/internal/delivery/smtp_client.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"os"
 	"path/filepath"
@@ -24,13 +25,14 @@ type messageSigner interface {
 }
 
 type Client struct {
-	cfg           config.Config
-	dane          *DANEResolver
-	mtaSTS        *MTASTSResolver
-	signer        messageSigner
-	resolveMXFn   func(string, time.Duration) ([]router.MXHost, error)
-	deliverHostFn func(context.Context, string, int, *model.Message, string, bool) error
-	spoolWriteFn  func(*model.Message, string) error
+	cfg                            config.Config
+	dane                           *DANEResolver
+	mtaSTS                         *MTASTSResolver
+	signer                         messageSigner
+	resolveMXFn                    func(string, time.Duration) ([]router.MXHost, error)
+	deliverHostFn                  func(context.Context, string, int, *model.Message, string, bool) error
+	spoolWriteFn                   func(*model.Message, string) error
+	reportMTASTSTestingViolationFn func(context.Context, string, string, string)
 }
 
 func NewClient(cfg config.Config) *Client {
@@ -47,6 +49,13 @@ func NewClient(cfg config.Config) *Client {
 	}
 	c.deliverHostFn = c.deliverHost
 	c.spoolWriteFn = c.writeLocalSpool
+	c.reportMTASTSTestingViolationFn = func(ctx context.Context, domain, host, reason string) {
+		slog.WarnContext(ctx, "mta-sts testing policy violation",
+			"domain", domain,
+			"host", host,
+			"reason", reason,
+		)
+	}
 	return c
 }
 
@@ -84,6 +93,7 @@ func (c *Client) deliverByMX(ctx context.Context, msg *model.Message, rcpt strin
 		return fmt.Errorf("mx lookup failed: %w", err)
 	}
 	requireTLS := false
+	var mtaSTSTestingPolicy *MTASTSPolicy
 	daneCandidates := make([]router.MXHost, 0, len(mxHosts))
 	if c.dane != nil {
 		for _, mx := range mxHosts {
@@ -114,11 +124,17 @@ func (c *Client) deliverByMX(ctx context.Context, msg *model.Message, rcpt strin
 					return &SMTPResponseError{Code: 454, Line: "mta-sts policy mismatch: no allowed mx"}
 				}
 				mxHosts = filtered
+			} else if p.Mode == "testing" {
+				cp := p
+				mtaSTSTestingPolicy = &cp
 			}
 		}
 	}
 	var lastErr error
 	for _, mx := range mxHosts {
+		if mtaSTSTestingPolicy != nil && !mtaSTSTestingPolicy.AllowsMX(mx.Host) && c.reportMTASTSTestingViolationFn != nil {
+			c.reportMTASTSTestingViolationFn(ctx, domain, mx.Host, "mx_mismatch")
+		}
 		if err := c.deliverHostFn(ctx, mx.Host, 25, msg, rcpt, requireTLS); err == nil {
 			return nil
 		} else {

--- a/internal/delivery/smtp_policy_test.go
+++ b/internal/delivery/smtp_policy_test.go
@@ -79,3 +79,65 @@ func TestDeliverByMX_FallsBackToMTASTSWhenNoUsableDANE(t *testing.T) {
 		t.Fatal("expected TLS required by MTA-STS enforce")
 	}
 }
+
+func TestDeliverByMX_MTASTSTestingModeDoesNotRejectOnMXMismatch(t *testing.T) {
+	cl := NewClient(config.Config{})
+	cl.resolveMXFn = func(string, time.Duration) ([]router.MXHost, error) {
+		return []router.MXHost{{Host: "mx1.example.net", Pref: 10}, {Host: "mx2.example.net", Pref: 20}}, nil
+	}
+	cl.mtaSTS = NewMTASTSResolver(time.Minute, time.Second, func(context.Context, string) (string, error) {
+		return "version: STSv1\nmode: testing\nmx: mx2.example.net\nmax_age: 3600\n", nil
+	})
+
+	var calledHost string
+	var requireTLS bool
+	var violationCalled bool
+	cl.deliverHostFn = func(ctx context.Context, host string, port int, msg *model.Message, rcpt string, reqTLS bool) error {
+		calledHost = host
+		requireTLS = reqTLS
+		return nil
+	}
+	cl.reportMTASTSTestingViolationFn = func(context.Context, string, string, string) {
+		violationCalled = true
+	}
+
+	err := cl.deliverByMX(context.Background(), &model.Message{MailFrom: "sender@example.org", Data: []byte("x")}, "user@example.org")
+	if err != nil {
+		t.Fatalf("deliverByMX: %v", err)
+	}
+	if calledHost != "mx1.example.net" {
+		t.Fatalf("expected first MX host to be used without hard enforcement, got %q", calledHost)
+	}
+	if requireTLS {
+		t.Fatal("testing mode must not require TLS")
+	}
+	if !violationCalled {
+		t.Fatal("expected testing mode violation report on mx mismatch")
+	}
+}
+
+func TestDeliverByMX_MTASTSTestingModeNoViolationWhenMXMatches(t *testing.T) {
+	cl := NewClient(config.Config{})
+	cl.resolveMXFn = func(string, time.Duration) ([]router.MXHost, error) {
+		return []router.MXHost{{Host: "mx1.example.net", Pref: 10}}, nil
+	}
+	cl.mtaSTS = NewMTASTSResolver(time.Minute, time.Second, func(context.Context, string) (string, error) {
+		return "version: STSv1\nmode: testing\nmx: mx1.example.net\nmax_age: 3600\n", nil
+	})
+
+	var violationCalled bool
+	cl.deliverHostFn = func(ctx context.Context, host string, port int, msg *model.Message, rcpt string, reqTLS bool) error {
+		return nil
+	}
+	cl.reportMTASTSTestingViolationFn = func(context.Context, string, string, string) {
+		violationCalled = true
+	}
+
+	err := cl.deliverByMX(context.Background(), &model.Message{MailFrom: "sender@example.org", Data: []byte("x")}, "user@example.org")
+	if err != nil {
+		t.Fatalf("deliverByMX: %v", err)
+	}
+	if violationCalled {
+		t.Fatal("did not expect testing mode violation report when mx matches policy")
+	}
+}


### PR DESCRIPTION
## 概要
- MTA-STS mode=testing 時の配送判定を明確化
- testing では配送を拒否せず、ポリシー不一致を違反レポートとして記録

## 変更内容
- Client に reportMTASTSTestingViolationFn を追加（デフォルトは slog.WarnContext）
- deliverByMX の MTA-STS 分岐を更新
  - mode=enforce: 既存どおり TLS 必須 + MX フィルタを厳格適用
  - mode=testing: TLS 強制/配送拒否は行わない
  - 実際に配送を試みる MX が policy 不一致の場合、違反レポートを発火
- テスト追加
  - testing で MX 不一致でも reject しない
  - MX 不一致時に違反レポートが呼ばれる
  - MX 一致時は違反レポートが呼ばれない

## テスト
- go test ./internal/delivery -run MTASTS -v
- go test ./...

Closes #74