### PR TITLE
[RFC 8461] ポリシー更新時の安全ロールオーバー手順を実装

### DIFF
--- a/internal/delivery/mta_sts.go
+++ b/internal/delivery/mta_sts.go
@@ -56,6 +56,13 @@ type MTASTSResolver struct {
 	retryAt       map[string]time.Time
 	minRetryDelay time.Duration
 	maxRetryDelay time.Duration
+	rollovers     map[string]mtaSTSRolloverState
+	rolloverNeed  int
+}
+
+type mtaSTSRolloverState struct {
+	policy        MTASTSPolicy
+	confirmations int
 }
 
 func NewMTASTSResolver(ttl, fetchTimeout time.Duration, fetchFunc func(ctx context.Context, domain string) (string, error)) *MTASTSResolver {
@@ -79,6 +86,8 @@ func NewMTASTSResolver(ttl, fetchTimeout time.Duration, fetchFunc func(ctx conte
 		retryAt:       map[string]time.Time{},
 		minRetryDelay: time.Second,
 		maxRetryDelay: 5 * time.Minute,
+		rollovers:     map[string]mtaSTSRolloverState{},
+		rolloverNeed:  2,
 	}
 }
 
@@ -148,11 +157,41 @@ func (r *MTASTSResolver) Lookup(ctx context.Context, domain string) (MTASTSPolic
 	}
 
 	r.mu.Lock()
-	r.cache[domain] = p
 	delete(r.retryFailures, domain)
 	delete(r.retryAt, domain)
+	if hasStale && stale.PolicyID != "" && p.PolicyID != "" && p.PolicyID != stale.PolicyID {
+		if !r.observeRolloverLocked(domain, p) {
+			r.mu.Unlock()
+			return stale, nil
+		}
+	} else {
+		delete(r.rollovers, domain)
+	}
+	r.cache[domain] = p
+	delete(r.rollovers, domain)
 	r.mu.Unlock()
 	return p, nil
+}
+
+func (r *MTASTSResolver) observeRolloverLocked(domain string, p MTASTSPolicy) bool {
+	if r.rolloverNeed <= 1 {
+		return true
+	}
+	st, ok := r.rollovers[domain]
+	if !ok || st.policy.PolicyID != p.PolicyID {
+		r.rollovers[domain] = mtaSTSRolloverState{
+			policy:        p,
+			confirmations: 1,
+		}
+		return false
+	}
+	st.confirmations++
+	st.policy = p
+	if st.confirmations >= r.rolloverNeed {
+		return true
+	}
+	r.rollovers[domain] = st
+	return false
 }
 
 func (r *MTASTSResolver) lookupPolicyID(ctx context.Context, domain string) (string, bool) {

--- a/internal/delivery/mta_sts_test.go
+++ b/internal/delivery/mta_sts_test.go
@@ -158,18 +158,29 @@ func TestMTASTSResolverRefreshesPolicyWhenTXTIDChanges(t *testing.T) {
 		PolicyID:  "old-id",
 	}
 
-	p, err := r.Lookup(context.Background(), "example.com")
+	p1, err := r.Lookup(context.Background(), "example.com")
 	if err != nil {
-		t.Fatalf("lookup: %v", err)
+		t.Fatalf("lookup1: %v", err)
 	}
 	if fetchCalls != 1 {
 		t.Fatalf("expected refresh fetch due to id mismatch, calls=%d", fetchCalls)
 	}
-	if len(p.MX) != 1 || p.MX[0] != "mx2.example.net" {
-		t.Fatalf("expected refreshed policy, got %+v", p)
+	if len(p1.MX) != 1 || p1.MX[0] != "mx1.example.net" {
+		t.Fatalf("expected previous policy at first rollover observation, got %+v", p1)
 	}
-	if p.PolicyID != "new-id" {
-		t.Fatalf("expected policy id to update, got %q", p.PolicyID)
+
+	p2, err := r.Lookup(context.Background(), "example.com")
+	if err != nil {
+		t.Fatalf("lookup2: %v", err)
+	}
+	if fetchCalls != 2 {
+		t.Fatalf("expected second fetch confirmation, calls=%d", fetchCalls)
+	}
+	if len(p2.MX) != 1 || p2.MX[0] != "mx2.example.net" {
+		t.Fatalf("expected refreshed policy after confirmation, got %+v", p2)
+	}
+	if p2.PolicyID != "new-id" {
+		t.Fatalf("expected policy id to update, got %q", p2.PolicyID)
 	}
 }
 
@@ -202,5 +213,75 @@ func TestMTASTSResolverKeepsCachedPolicyWhenTXTLookupFails(t *testing.T) {
 	}
 	if len(p.MX) != 1 || p.MX[0] != "mx1.example.net" {
 		t.Fatalf("expected cached policy, got %+v", p)
+	}
+}
+
+func TestMTASTSResolverSafeRolloverRequiresTwoConsistentFetches(t *testing.T) {
+	now := time.Date(2026, 3, 11, 12, 0, 0, 0, time.UTC)
+	fetchCalls := 0
+	r := NewMTASTSResolver(5*time.Minute, 2*time.Second, func(ctx context.Context, domain string) (string, error) {
+		fetchCalls++
+		return "version: STSv1\nmode: enforce\nmx: mx-new.example.net\nmax_age: 120\n", nil
+	})
+	r.nowFn = func() time.Time { return now }
+	r.lookupTXT = func(context.Context, string) ([]string, error) {
+		return []string{"v=STSv1; id=new-id"}, nil
+	}
+	r.cache["example.com"] = MTASTSPolicy{
+		Version:   "STSv1",
+		Mode:      "enforce",
+		MX:        []string{"mx-old.example.net"},
+		MaxAge:    time.Hour,
+		ExpiresAt: now.Add(time.Hour),
+		PolicyID:  "old-id",
+	}
+
+	p1, err := r.Lookup(context.Background(), "example.com")
+	if err != nil {
+		t.Fatalf("lookup1: %v", err)
+	}
+	if fetchCalls != 1 {
+		t.Fatalf("expected first fetch, calls=%d", fetchCalls)
+	}
+	if len(p1.MX) != 1 || p1.MX[0] != "mx-old.example.net" {
+		t.Fatalf("expected old policy on first observed rollover, got %+v", p1)
+	}
+
+	p2, err := r.Lookup(context.Background(), "example.com")
+	if err != nil {
+		t.Fatalf("lookup2: %v", err)
+	}
+	if fetchCalls != 2 {
+		t.Fatalf("expected second fetch confirmation, calls=%d", fetchCalls)
+	}
+	if len(p2.MX) != 1 || p2.MX[0] != "mx-new.example.net" {
+		t.Fatalf("expected new policy after confirmation, got %+v", p2)
+	}
+	if p2.PolicyID != "new-id" {
+		t.Fatalf("expected switched policy id, got %q", p2.PolicyID)
+	}
+}
+
+func TestMTASTSResolverSafeRolloverAppliesImmediatelyWithoutPreviousPolicy(t *testing.T) {
+	now := time.Date(2026, 3, 11, 12, 0, 0, 0, time.UTC)
+	fetchCalls := 0
+	r := NewMTASTSResolver(5*time.Minute, 2*time.Second, func(ctx context.Context, domain string) (string, error) {
+		fetchCalls++
+		return "version: STSv1\nmode: enforce\nmx: mx-new.example.net\nmax_age: 120\n", nil
+	})
+	r.nowFn = func() time.Time { return now }
+	r.lookupTXT = func(context.Context, string) ([]string, error) {
+		return []string{"v=STSv1; id=new-id"}, nil
+	}
+
+	p, err := r.Lookup(context.Background(), "example.com")
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if fetchCalls != 1 {
+		t.Fatalf("expected single fetch, calls=%d", fetchCalls)
+	}
+	if len(p.MX) != 1 || p.MX[0] != "mx-new.example.net" {
+		t.Fatalf("expected immediate apply when no previous policy, got %+v", p)
 	}
 }


### PR DESCRIPTION
## 概要
- MTA-STS policy id 更新時に即時切替せず、同一新idを2回連続で取得確認してから切替える安全ロールオーバーを追加
- 既存policyがある場合は確認完了まで従来policyを継続利用
- 既存policyがない初回取得では即時適用

## 変更内容
- MTASTSResolver にロールオーバー確認状態（rollovers）を追加
- rolloverNeed（既定2）を導入し、id変更時の段階的切替を実装
- retry state と併存するように Lookup の更新フローを調整
- テスト追加/更新
  - id変更時は初回取得で旧policy継続
  - 2回目確認で新policyへ切替
  - 既存policyなしは即時適用

## テスト
- go test ./internal/delivery -run 'MTASTS|ParseMTASTSPolicyID|SafeRollover' -v
- go test ./...

Closes #76