### PR TITLE
[RFC 8461] HTTPS証明書検証と失効系エラー判定を強化

### DIFF
--- a/internal/delivery/mta_sts.go
+++ b/internal/delivery/mta_sts.go
@@ -2,11 +2,14 @@ package delivery
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -309,7 +312,7 @@ func parseMTASTSPolicy(raw string) (MTASTSPolicy, error) {
 }
 
 func fetchMTASTSPolicyTextHTTP(timeout time.Duration) func(context.Context, string) (string, error) {
-	client := &http.Client{Timeout: timeout}
+	client := newMTASTSHTTPClient(timeout)
 	return func(ctx context.Context, domain string) (string, error) {
 		url := fmt.Sprintf("https://mta-sts.%s/.well-known/mta-sts.txt", domain)
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -318,6 +321,9 @@ func fetchMTASTSPolicyTextHTTP(timeout time.Duration) func(context.Context, stri
 		}
 		resp, err := client.Do(req)
 		if err != nil {
+			if isMTASTSCertificateValidationError(err) {
+				return "", fmt.Errorf("mta-sts https certificate validation failed: %w", err)
+			}
 			return "", err
 		}
 		defer resp.Body.Close()
@@ -330,4 +336,42 @@ func fetchMTASTSPolicyTextHTTP(timeout time.Duration) func(context.Context, stri
 		}
 		return string(b), nil
 	}
+}
+
+func newMTASTSHTTPClient(timeout time.Duration) *http.Client {
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+	return &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12},
+		},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return errors.New("redirect is not allowed for mta-sts policy fetch")
+		},
+	}
+}
+
+func isMTASTSCertificateValidationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var uErr *url.Error
+	if errors.As(err, &uErr) {
+		err = uErr.Err
+	}
+	var uaErr *x509.UnknownAuthorityError
+	if errors.As(err, &uaErr) {
+		return true
+	}
+	var hnErr *x509.HostnameError
+	if errors.As(err, &hnErr) {
+		return true
+	}
+	var ciErr *x509.CertificateInvalidError
+	if errors.As(err, &ciErr) {
+		return true
+	}
+	return false
 }

--- a/internal/delivery/mta_sts_test.go
+++ b/internal/delivery/mta_sts_test.go
@@ -2,7 +2,10 @@ package delivery
 
 import (
 	"context"
+	"crypto/x509"
 	"errors"
+	"net/http"
+	"net/url"
 	"testing"
 	"time"
 )
@@ -283,5 +286,48 @@ func TestMTASTSResolverSafeRolloverAppliesImmediatelyWithoutPreviousPolicy(t *te
 	}
 	if len(p.MX) != 1 || p.MX[0] != "mx-new.example.net" {
 		t.Fatalf("expected immediate apply when no previous policy, got %+v", p)
+	}
+}
+
+func TestNewMTASTSHTTPClientSetsStrictTLSAndNoRedirect(t *testing.T) {
+	cl := newMTASTSHTTPClient(3 * time.Second)
+	if cl.Timeout != 3*time.Second {
+		t.Fatalf("unexpected timeout: %v", cl.Timeout)
+	}
+	if cl.CheckRedirect == nil {
+		t.Fatal("expected redirect policy to be set")
+	}
+	req, _ := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	if err := cl.CheckRedirect(req, []*http.Request{req}); err == nil {
+		t.Fatal("expected redirect to be rejected")
+	}
+	tr, ok := cl.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("unexpected transport type: %T", cl.Transport)
+	}
+	if tr.TLSClientConfig == nil {
+		t.Fatal("expected tls config")
+	}
+	if tr.TLSClientConfig.MinVersion != 0x0303 {
+		t.Fatalf("expected TLS1.2 min version, got %x", tr.TLSClientConfig.MinVersion)
+	}
+}
+
+func TestIsMTASTSCertificateValidationError(t *testing.T) {
+	if !isMTASTSCertificateValidationError(&x509.UnknownAuthorityError{}) {
+		t.Fatal("expected unknown authority as cert validation error")
+	}
+	if !isMTASTSCertificateValidationError(&x509.HostnameError{}) {
+		t.Fatal("expected hostname error as cert validation error")
+	}
+	if !isMTASTSCertificateValidationError(&x509.CertificateInvalidError{}) {
+		t.Fatal("expected certificate invalid error as cert validation error")
+	}
+	uErr := &url.Error{Err: &x509.UnknownAuthorityError{}}
+	if !isMTASTSCertificateValidationError(uErr) {
+		t.Fatal("expected wrapped x509 error to be detected")
+	}
+	if isMTASTSCertificateValidationError(errors.New("timeout")) {
+		t.Fatal("did not expect generic error to be cert validation error")
 	}
 }


### PR DESCRIPTION
## 概要
- MTA-STS policy HTTPS取得のTLS設定を厳格化
- 証明書検証エラーを判定して明示的なエラーメッセージへ分類
- リダイレクトを拒否し、policy取得経路の予期しない遷移を防止

## 変更内容
- MTA-STS用HTTPクライアントを専用化
  - TLS最小バージョンを TLS 1.2 に固定
  - redirect を明示的に拒否
- x509 の証明書検証エラー判定ヘルパーを追加
  - UnknownAuthority / HostnameError / CertificateInvalid を検出
  - url.Error でラップされたケースも検出
- 証明書検証失敗時に専用メッセージを返却

## テスト
- go test ./internal/delivery -run 'NewMTASTSHTTPClient|IsMTASTSCertificateValidationError|MTASTS' -v
- go test ./...

Closes #75