### PR TITLE
[RFC 7672] 主要TLSAプロファイル（2 0 1 / 2 1 1 / 3 0 1 / 3 1 1）対応を追加

### DIFF
--- a/internal/delivery/dane.go
+++ b/internal/delivery/dane.go
@@ -33,11 +33,33 @@ func (r DANEResult) HasUsableTLSA() bool {
 		return false
 	}
 	for _, rec := range r.Records {
-		if rec.Usage == 3 && rec.Selector == 1 && rec.MatchingType == 1 && len(rec.CertificateAssociation) > 0 {
+		if isSupportedTLSAProfile(rec) {
 			return true
 		}
 	}
 	return false
+}
+
+func isSupportedTLSAProfile(rec TLSARecord) bool {
+	if len(rec.CertificateAssociation) == 0 {
+		return false
+	}
+	switch rec.Usage {
+	case 2, 3: // DANE-TA, DANE-EE
+	default:
+		return false
+	}
+	switch rec.Selector {
+	case 0, 1: // Full cert, SPKI
+	default:
+		return false
+	}
+	switch rec.MatchingType {
+	case 1, 2: // SHA-256, SHA-512
+		return true
+	default:
+		return false
+	}
 }
 
 type DANEResolver struct {

--- a/internal/delivery/dane_test.go
+++ b/internal/delivery/dane_test.go
@@ -6,15 +6,62 @@ import (
 )
 
 func TestDANEResultHasUsableTLSA(t *testing.T) {
-	ok := DANEResult{
-		AuthenticatedData: true,
-		Records:           []TLSARecord{{Usage: 3, Selector: 1, MatchingType: 1, CertificateAssociation: []byte{0xaa}}},
+	cases := []struct {
+		name   string
+		record TLSARecord
+		want   bool
+	}{
+		{
+			name:   "3-1-1 (DANE-EE SPKI SHA-256)",
+			record: TLSARecord{Usage: 3, Selector: 1, MatchingType: 1, CertificateAssociation: []byte{0xaa}},
+			want:   true,
+		},
+		{
+			name:   "3-0-1 (DANE-EE Cert SHA-256)",
+			record: TLSARecord{Usage: 3, Selector: 0, MatchingType: 1, CertificateAssociation: []byte{0xaa}},
+			want:   true,
+		},
+		{
+			name:   "2-0-1 (DANE-TA Cert SHA-256)",
+			record: TLSARecord{Usage: 2, Selector: 0, MatchingType: 1, CertificateAssociation: []byte{0xaa}},
+			want:   true,
+		},
+		{
+			name:   "2-1-1 (DANE-TA SPKI SHA-256)",
+			record: TLSARecord{Usage: 2, Selector: 1, MatchingType: 1, CertificateAssociation: []byte{0xaa}},
+			want:   true,
+		},
+		{
+			name:   "unsupported matching type",
+			record: TLSARecord{Usage: 3, Selector: 1, MatchingType: 0, CertificateAssociation: []byte{0xaa}},
+			want:   false,
+		},
+		{
+			name:   "unsupported usage",
+			record: TLSARecord{Usage: 1, Selector: 1, MatchingType: 1, CertificateAssociation: []byte{0xaa}},
+			want:   false,
+		},
+		{
+			name:   "empty association",
+			record: TLSARecord{Usage: 3, Selector: 1, MatchingType: 1, CertificateAssociation: nil},
+			want:   false,
+		},
 	}
-	if !ok.HasUsableTLSA() {
-		t.Fatal("expected usable tlsa")
-	}
-	if (DANEResult{AuthenticatedData: false, Records: ok.Records}).HasUsableTLSA() {
-		t.Fatal("dnssec ad=false must not be treated as usable")
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := DANEResult{
+				AuthenticatedData: true,
+				Records:           []TLSARecord{tc.record},
+			}
+			got := res.HasUsableTLSA()
+			if got != tc.want {
+				t.Fatalf("HasUsableTLSA()=%v want=%v record=%+v", got, tc.want, tc.record)
+			}
+			if (DANEResult{AuthenticatedData: false, Records: []TLSARecord{tc.record}}).HasUsableTLSA() {
+				t.Fatal("dnssec ad=false must not be treated as usable")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## 概要
- DANE 判定で利用可能とみなす TLSA プロファイルを拡張しました
- これまでの 3 1 1 のみから、主要プロファイルを包括的に評価します

## 変更内容
- HasUsableTLSA の判定を共通関数化
- 対応プロファイルを追加
  - usage: 2(DANE-TA), 3(DANE-EE)
  - selector: 0(Full cert), 1(SPKI)
  - matching type: 1(SHA-256), 2(SHA-512)
- DNSSEC AD=false は従来どおり unusable 判定
- empty association/未対応usage/未対応matching typeは unusable 判定

## テスト
- TestDANEResultHasUsableTLSA をテーブル駆動で拡張
  - 3-1-1 / 3-0-1 / 2-0-1 / 2-1-1 を検証
  - 未対応ケース・AD=false も検証
- go test ./internal/delivery -run 'TestDANEResultHasUsableTLSA|TestParseTLSAResponse' -v
- go test ./...

Closes #78