### PR TITLE
[RFC 7672] DANE DNSSEC信頼モデル（AD依存/非署名許容）を実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ go run ./cmd/mta
 - `MTA_RATE_LIMIT_RULES` (default: unset, format: `event:key:limit:window;...`)
 - `MTA_DNSBL_ZONES` (default: unset, comma-separated)
 - `MTA_DNSBL_CACHE_TTL` (default: `5m`)
+- `MTA_DANE_DNSSEC_TRUST_MODEL` (default: `ad_required`, values: `ad_required` / `insecure_allow_unsigned`)
 - `MTA_MTA_STS_CACHE_TTL` (default: `1h`)
 - `MTA_MTA_STS_FETCH_TIMEOUT` (default: `5s`)
 - `MTA_DELIVERY_MODE` (default: `mx`, values: `mx` / `local_spool` / `relay`)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	RateLimitRules             string
 	DNSBLZones                 []string
 	DNSBLCacheTTL              time.Duration
+	DANEDNSSECTrustModel       string
 	MTASTSCacheTTL             time.Duration
 	MTASTSFetchTimeout         time.Duration
 	DeliveryMode               string
@@ -84,6 +85,11 @@ func Load() Config {
 		RateLimitRules:     env("MTA_RATE_LIMIT_RULES", ""),
 		DNSBLZones:         envCSV("MTA_DNSBL_ZONES", []string{}),
 		DNSBLCacheTTL:      envDuration("MTA_DNSBL_CACHE_TTL", 5*time.Minute),
+		DANEDNSSECTrustModel: envEnum(
+			"MTA_DANE_DNSSEC_TRUST_MODEL",
+			"ad_required",
+			[]string{"ad_required", "insecure_allow_unsigned"},
+		),
 		MTASTSCacheTTL:     envDuration("MTA_MTA_STS_CACHE_TTL", time.Hour),
 		MTASTSFetchTimeout: envDuration("MTA_MTA_STS_FETCH_TIMEOUT", 5*time.Second),
 		DeliveryMode:       env("MTA_DELIVERY_MODE", "mx"),
@@ -116,6 +122,19 @@ func Load() Config {
 		DataRetentionPoison:        envDuration("MTA_DATA_RETENTION_POISON", 180*24*time.Hour),
 		RetentionSweepInterval:     envDuration("MTA_RETENTION_SWEEP_INTERVAL", time.Hour),
 	}
+}
+
+func envEnum(k, def string, allowed []string) string {
+	v := strings.TrimSpace(strings.ToLower(os.Getenv(k)))
+	if v == "" {
+		return def
+	}
+	for _, a := range allowed {
+		if v == strings.ToLower(strings.TrimSpace(a)) {
+			return v
+		}
+	}
+	return def
 }
 
 func env(k, def string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -171,3 +171,17 @@ func TestLoadRetentionConfig(t *testing.T) {
 		t.Fatalf("retention sweep=%s", cfg.RetentionSweepInterval)
 	}
 }
+
+func TestLoadDANEDNSSECTrustModel(t *testing.T) {
+	t.Setenv("MTA_DANE_DNSSEC_TRUST_MODEL", "insecure_allow_unsigned")
+	cfg := Load()
+	if cfg.DANEDNSSECTrustModel != "insecure_allow_unsigned" {
+		t.Fatalf("trust model=%q", cfg.DANEDNSSECTrustModel)
+	}
+
+	t.Setenv("MTA_DANE_DNSSEC_TRUST_MODEL", "invalid")
+	cfg = Load()
+	if cfg.DANEDNSSECTrustModel != "ad_required" {
+		t.Fatalf("invalid trust model should fallback, got=%q", cfg.DANEDNSSECTrustModel)
+	}
+}

--- a/internal/delivery/dane.go
+++ b/internal/delivery/dane.go
@@ -29,8 +29,22 @@ type DANEResult struct {
 }
 
 func (r DANEResult) HasUsableTLSA() bool {
-	if !r.AuthenticatedData {
-		return false
+	return r.HasUsableTLSAWithTrustModel("ad_required")
+}
+
+func (r DANEResult) HasUsableTLSAWithTrustModel(trustModel string) bool {
+	trustModel = strings.ToLower(strings.TrimSpace(trustModel))
+	switch trustModel {
+	case "", "ad_required":
+		if !r.AuthenticatedData {
+			return false
+		}
+	case "insecure_allow_unsigned":
+		// allow AD=false and evaluate only TLSA profile validity.
+	default:
+		if !r.AuthenticatedData {
+			return false
+		}
 	}
 	for _, rec := range r.Records {
 		if isSupportedTLSAProfile(rec) {

--- a/internal/delivery/dane_test.go
+++ b/internal/delivery/dane_test.go
@@ -65,6 +65,20 @@ func TestDANEResultHasUsableTLSA(t *testing.T) {
 	}
 }
 
+func TestDANEResultHasUsableTLSAWithTrustModel(t *testing.T) {
+	rec := TLSARecord{Usage: 3, Selector: 1, MatchingType: 1, CertificateAssociation: []byte{0xaa}}
+
+	adRequired := DANEResult{AuthenticatedData: false, Records: []TLSARecord{rec}}
+	if adRequired.HasUsableTLSAWithTrustModel("ad_required") {
+		t.Fatal("ad_required must reject AD=false")
+	}
+
+	insecureAllowed := DANEResult{AuthenticatedData: false, Records: []TLSARecord{rec}}
+	if !insecureAllowed.HasUsableTLSAWithTrustModel("insecure_allow_unsigned") {
+		t.Fatal("insecure_allow_unsigned should allow AD=false when profile is otherwise usable")
+	}
+}
+
 func TestParseTLSAResponse(t *testing.T) {
 	queryID := uint16(0x1234)
 	packet := []byte{

--- a/internal/delivery/smtp_client.go
+++ b/internal/delivery/smtp_client.go
@@ -101,7 +101,7 @@ func (c *Client) deliverByMX(ctx context.Context, msg *model.Message, rcpt strin
 			if lErr != nil {
 				continue
 			}
-			if res.HasUsableTLSA() {
+			if res.HasUsableTLSAWithTrustModel(c.cfg.DANEDNSSECTrustModel) {
 				daneCandidates = append(daneCandidates, mx)
 			}
 		}

--- a/internal/delivery/smtp_policy_test.go
+++ b/internal/delivery/smtp_policy_test.go
@@ -141,3 +141,30 @@ func TestDeliverByMX_MTASTSTestingModeNoViolationWhenMXMatches(t *testing.T) {
 		t.Fatal("did not expect testing mode violation report when mx matches policy")
 	}
 }
+
+func TestDeliverByMX_DANETrustModelAllowsUnsignedWhenConfigured(t *testing.T) {
+	cl := NewClient(config.Config{DANEDNSSECTrustModel: "insecure_allow_unsigned"})
+	cl.resolveMXFn = func(string, time.Duration) ([]router.MXHost, error) {
+		return []router.MXHost{{Host: "mx1.example.net", Pref: 10}}, nil
+	}
+	cl.dane = NewDANEResolver(time.Second, func(_ context.Context, host string, _ int) (DANEResult, error) {
+		return DANEResult{
+			AuthenticatedData: false,
+			Records:           []TLSARecord{{Usage: 3, Selector: 1, MatchingType: 1, CertificateAssociation: []byte{0x01}}},
+		}, nil
+	})
+
+	var requireTLS bool
+	cl.deliverHostFn = func(ctx context.Context, host string, port int, msg *model.Message, rcpt string, reqTLS bool) error {
+		requireTLS = reqTLS
+		return nil
+	}
+
+	err := cl.deliverByMX(context.Background(), &model.Message{MailFrom: "sender@example.org", Data: []byte("x")}, "user@example.org")
+	if err != nil {
+		t.Fatalf("deliverByMX: %v", err)
+	}
+	if !requireTLS {
+		t.Fatal("expected TLS required when insecure_allow_unsigned trust model is configured")
+	}
+}


### PR DESCRIPTION
## 概要
- DANEのDNSSEC信頼モデルを設定で選択できるようにしました
- 既定は従来どおり AD必須 (ad_required)
- 運用選択として ADなしでもTLSAを評価する insecure_allow_unsigned を追加

## 変更内容
- 設定追加
  - MTA_DANE_DNSSEC_TRUST_MODEL
  - 値: ad_required / insecure_allow_unsigned
  - 無効値は ad_required にフォールバック
- DANE判定拡張
  - DANEResult.HasUsableTLSAWithTrustModel(trustModel) を追加
  - smtp_client の DANE候補判定で trust model を反映
- テスト追加
  - configで trust model 読み込み/フォールバックを検証
  - DANE判定で AD=false の扱いがモードで変わることを検証
  - delivery経路で insecure_allow_unsigned 時に DANE優先が有効になることを検証
- README更新
  - MTA_DANE_DNSSEC_TRUST_MODEL を環境変数一覧に追加

## テスト
- go test ./internal/config ./internal/delivery -run 'DANE|TrustModel' -v
- go test ./...

Closes #79