### PR TITLE
[RFC 7672] CNAME/MX経由時のTLSA探索ルールを厳密化

### DIFF
--- a/internal/delivery/dane.go
+++ b/internal/delivery/dane.go
@@ -77,8 +77,9 @@ func isSupportedTLSAProfile(rec TLSARecord) bool {
 }
 
 type DANEResolver struct {
-	timeout  time.Duration
-	lookupFn func(context.Context, string, int) (DANEResult, error)
+	timeout       time.Duration
+	lookupFn      func(context.Context, string, int) (DANEResult, error)
+	lookupCNAMEFn func(context.Context, string) (string, error)
 }
 
 func NewDANEResolver(timeout time.Duration, lookupFn func(context.Context, string, int) (DANEResult, error)) *DANEResolver {
@@ -88,7 +89,11 @@ func NewDANEResolver(timeout time.Duration, lookupFn func(context.Context, strin
 	if lookupFn == nil {
 		lookupFn = lookupTLSAUDP(timeout)
 	}
-	return &DANEResolver{timeout: timeout, lookupFn: lookupFn}
+	return &DANEResolver{
+		timeout:       timeout,
+		lookupFn:      lookupFn,
+		lookupCNAMEFn: lookupCNAME,
+	}
 }
 
 func (r *DANEResolver) LookupHost(ctx context.Context, host string, port int) (DANEResult, error) {
@@ -99,7 +104,60 @@ func (r *DANEResolver) LookupHost(ctx context.Context, host string, port int) (D
 	if port <= 0 {
 		port = 25
 	}
-	return r.lookupFn(ctx, host, port)
+	candidates := r.expandDANECandidates(ctx, host)
+	merged := DANEResult{}
+	var lastErr error
+	for _, cand := range candidates {
+		res, err := r.lookupFn(ctx, cand, port)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if res.AuthenticatedData {
+			merged.AuthenticatedData = true
+		}
+		if len(res.Records) > 0 {
+			merged.Records = append(merged.Records, res.Records...)
+		}
+	}
+	if len(merged.Records) > 0 {
+		return merged, nil
+	}
+	if lastErr != nil {
+		return DANEResult{}, lastErr
+	}
+	return DANEResult{}, nil
+}
+
+func (r *DANEResolver) expandDANECandidates(ctx context.Context, host string) []string {
+	out := []string{host}
+	if r.lookupCNAMEFn == nil {
+		return out
+	}
+	seen := map[string]struct{}{host: {}}
+	current := host
+	const maxDepth = 5
+	for i := 0; i < maxDepth; i++ {
+		cname, err := r.lookupCNAMEFn(ctx, current)
+		if err != nil {
+			break
+		}
+		cname = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(cname)), ".")
+		if cname == "" || cname == current {
+			break
+		}
+		if _, ok := seen[cname]; ok {
+			break
+		}
+		seen[cname] = struct{}{}
+		out = append(out, cname)
+		current = cname
+	}
+	return out
+}
+
+func lookupCNAME(ctx context.Context, host string) (string, error) {
+	return net.DefaultResolver.LookupCNAME(ctx, host)
 }
 
 func lookupTLSAUDP(timeout time.Duration) func(context.Context, string, int) (DANEResult, error) {

--- a/internal/delivery/dane_test.go
+++ b/internal/delivery/dane_test.go
@@ -1,8 +1,12 @@
 package delivery
 
 import (
+	"context"
 	"encoding/binary"
+	"errors"
+	"reflect"
 	"testing"
+	"time"
 )
 
 func TestDANEResultHasUsableTLSA(t *testing.T) {
@@ -121,5 +125,63 @@ func TestParseTLSAResponse(t *testing.T) {
 	}
 	if binary.BigEndian.Uint16(r.CertificateAssociation) != 0xdead {
 		t.Fatalf("unexpected cert association: %x", r.CertificateAssociation)
+	}
+}
+
+func TestDANEResolverLookupHost_FollowsCNAMEForTLSA(t *testing.T) {
+	var lookedUp []string
+	r := NewDANEResolver(time.Second, func(_ context.Context, host string, _ int) (DANEResult, error) {
+		lookedUp = append(lookedUp, host)
+		if host == "mx.real.example.net" {
+			return DANEResult{
+				AuthenticatedData: true,
+				Records:           []TLSARecord{{Usage: 3, Selector: 1, MatchingType: 1, CertificateAssociation: []byte{0xaa}}},
+			}, nil
+		}
+		return DANEResult{}, nil
+	})
+	r.lookupCNAMEFn = func(_ context.Context, host string) (string, error) {
+		if host == "mx.alias.example.net" {
+			return "mx.real.example.net.", nil
+		}
+		return "", errors.New("no cname")
+	}
+
+	res, err := r.LookupHost(context.Background(), "mx.alias.example.net", 25)
+	if err != nil {
+		t.Fatalf("LookupHost: %v", err)
+	}
+	if !res.HasUsableTLSA() {
+		t.Fatalf("expected usable TLSA through CNAME, got %+v", res)
+	}
+	wantHosts := []string{"mx.alias.example.net", "mx.real.example.net"}
+	if !reflect.DeepEqual(lookedUp, wantHosts) {
+		t.Fatalf("lookup hosts mismatch got=%v want=%v", lookedUp, wantHosts)
+	}
+}
+
+func TestDANEResolverLookupHost_CNAMEChainLoopStops(t *testing.T) {
+	var lookedUp []string
+	r := NewDANEResolver(time.Second, func(_ context.Context, host string, _ int) (DANEResult, error) {
+		lookedUp = append(lookedUp, host)
+		return DANEResult{}, nil
+	})
+	r.lookupCNAMEFn = func(_ context.Context, host string) (string, error) {
+		switch host {
+		case "mx1.example.net":
+			return "mx2.example.net.", nil
+		case "mx2.example.net":
+			return "mx1.example.net.", nil
+		default:
+			return "", errors.New("no cname")
+		}
+	}
+
+	_, err := r.LookupHost(context.Background(), "mx1.example.net", 25)
+	if err != nil {
+		t.Fatalf("LookupHost should stop loop and return no-record result: %v", err)
+	}
+	if len(lookedUp) > 2 {
+		t.Fatalf("expected loop detection to stop exploration, looked up=%v", lookedUp)
 	}
 }


### PR DESCRIPTION
## 概要
- DANE(TLSA) 探索で CNAME 連鎖を考慮するようにしました
- _25._tcp.<mx> だけでなく、CNAME 解決先も候補として探索します
- ループ検知と探索深さ上限を設け、安全に探索を打ち切ります

## 変更内容
- DANEResolver に CNAME lookup 注入点を追加
  - 既定は net.DefaultResolver.LookupCNAME
- LookupHost の探索を拡張
  - CNAME候補列を展開して順にTLSA照会
  - レコードはマージして返却
  - すべて未取得でもエラーがなければ空結果を返却
- CNAME探索制御
  - ループ検知
  - 最大深さ 5

## テスト
- CNAME経由でTLSAを取得できること
- CNAMEループ時に無限探索しないこと
- go test ./internal/delivery -run 'CNAME|LookupHost|DANEResolver' -v
- go test ./...

Closes #80