### PR TITLE
[RFC 7672] DANE照合失敗時の配送判定（hard/temporary）を実装

### DIFF
--- a/internal/delivery/smtp_client.go
+++ b/internal/delivery/smtp_client.go
@@ -93,6 +93,7 @@ func (c *Client) deliverByMX(ctx context.Context, msg *model.Message, rcpt strin
 		return fmt.Errorf("mx lookup failed: %w", err)
 	}
 	requireTLS := false
+	daneActive := false
 	var mtaSTSTestingPolicy *MTASTSPolicy
 	daneCandidates := make([]router.MXHost, 0, len(mxHosts))
 	if c.dane != nil {
@@ -109,6 +110,7 @@ func (c *Client) deliverByMX(ctx context.Context, msg *model.Message, rcpt strin
 	if len(daneCandidates) > 0 {
 		// RFC 7672 precedence: if usable DANE is available, apply it before MTA-STS.
 		requireTLS = true
+		daneActive = true
 		mxHosts = daneCandidates
 	} else if c.mtaSTS != nil {
 		if p, pErr := c.mtaSTS.Lookup(ctx, domain); pErr == nil {
@@ -135,7 +137,11 @@ func (c *Client) deliverByMX(ctx context.Context, msg *model.Message, rcpt strin
 		if mtaSTSTestingPolicy != nil && !mtaSTSTestingPolicy.AllowsMX(mx.Host) && c.reportMTASTSTestingViolationFn != nil {
 			c.reportMTASTSTestingViolationFn(ctx, domain, mx.Host, "mx_mismatch")
 		}
-		if err := c.deliverHostFn(ctx, mx.Host, 25, msg, rcpt, requireTLS); err == nil {
+		err := c.deliverHostFn(ctx, mx.Host, 25, msg, rcpt, requireTLS)
+		if daneActive {
+			err = classifyDANEFailure(err)
+		}
+		if err == nil {
 			return nil
 		} else {
 			lastErr = err
@@ -145,6 +151,21 @@ func (c *Client) deliverByMX(ctx context.Context, msg *model.Message, rcpt strin
 		lastErr = errors.New("no mx targets")
 	}
 	return lastErr
+}
+
+func classifyDANEFailure(err error) error {
+	if err == nil {
+		return nil
+	}
+	var smtpErr *SMTPResponseError
+	if !errors.As(err, &smtpErr) {
+		return err
+	}
+	line := strings.ToLower(strings.TrimSpace(smtpErr.Line))
+	if smtpErr.Temporary() && (line == "starttls handshake failed" || line == "mta-sts enforce requires starttls") {
+		return &SMTPResponseError{Code: 550, Line: "dane authentication failed"}
+	}
+	return err
 }
 
 func (c *Client) deliverHost(ctx context.Context, host string, port int, msg *model.Message, rcpt string, requireTLS bool) error {

--- a/internal/delivery/smtp_policy_test.go
+++ b/internal/delivery/smtp_policy_test.go
@@ -2,6 +2,7 @@ package delivery
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -166,5 +167,58 @@ func TestDeliverByMX_DANETrustModelAllowsUnsignedWhenConfigured(t *testing.T) {
 	}
 	if !requireTLS {
 		t.Fatal("expected TLS required when insecure_allow_unsigned trust model is configured")
+	}
+}
+
+func TestDeliverByMX_DANEFailureBecomesHardFailOnTLSAuthError(t *testing.T) {
+	cl := NewClient(config.Config{})
+	cl.resolveMXFn = func(string, time.Duration) ([]router.MXHost, error) {
+		return []router.MXHost{{Host: "mx1.example.net", Pref: 10}}, nil
+	}
+	cl.dane = NewDANEResolver(time.Second, func(_ context.Context, host string, _ int) (DANEResult, error) {
+		return DANEResult{
+			AuthenticatedData: true,
+			Records:           []TLSARecord{{Usage: 3, Selector: 1, MatchingType: 1, CertificateAssociation: []byte{0x01}}},
+		}, nil
+	})
+	cl.deliverHostFn = func(ctx context.Context, host string, port int, msg *model.Message, rcpt string, reqTLS bool) error {
+		return &SMTPResponseError{Code: 454, Line: "starttls handshake failed"}
+	}
+
+	err := cl.deliverByMX(context.Background(), &model.Message{MailFrom: "sender@example.org", Data: []byte("x")}, "user@example.org")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var smtpErr *SMTPResponseError
+	if !errors.As(err, &smtpErr) {
+		t.Fatalf("expected SMTPResponseError, got %T", err)
+	}
+	if !smtpErr.Permanent() {
+		t.Fatalf("expected hard/permanent fail, got code=%d line=%q", smtpErr.Code, smtpErr.Line)
+	}
+}
+
+func TestDeliverByMX_DANEFailureKeepsTemporaryForNetworkError(t *testing.T) {
+	cl := NewClient(config.Config{})
+	cl.resolveMXFn = func(string, time.Duration) ([]router.MXHost, error) {
+		return []router.MXHost{{Host: "mx1.example.net", Pref: 10}}, nil
+	}
+	cl.dane = NewDANEResolver(time.Second, func(_ context.Context, host string, _ int) (DANEResult, error) {
+		return DANEResult{
+			AuthenticatedData: true,
+			Records:           []TLSARecord{{Usage: 3, Selector: 1, MatchingType: 1, CertificateAssociation: []byte{0x01}}},
+		}, nil
+	})
+	cl.deliverHostFn = func(ctx context.Context, host string, port int, msg *model.Message, rcpt string, reqTLS bool) error {
+		return errors.New("dial timeout")
+	}
+
+	err := cl.deliverByMX(context.Background(), &model.Message{MailFrom: "sender@example.org", Data: []byte("x")}, "user@example.org")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var smtpErr *SMTPResponseError
+	if errors.As(err, &smtpErr) && smtpErr.Permanent() {
+		t.Fatalf("expected temporary/non-permanent failure for network error, got code=%d", smtpErr.Code)
 	}
 }


### PR DESCRIPTION
## 概要
- DANE有効時のTLS認証失敗を hard fail として扱う判定を追加しました
- 一方でネットワーク障害などは temporary 扱いを維持します

## 変更内容
- deliverByMX で DANE 経路（daneActive）を明示
- DANE経路の配送失敗を classifyDANEFailure で分類
  - STARTTLSハンドシェイク失敗
  - STARTTLS非対応（TLS必須条件）
  - 上記は 550 dane authentication failed に昇格
- 非SMTPエラー（例: dial timeout）は従来どおり temporary 扱い

## テスト
- DANE有効 + TLS認証失敗が permanent になること
- DANE有効 + ネットワークエラーは permanent 化しないこと
- 既存DANE優先・信頼モデルテストの回帰確認
- go test ./internal/delivery -run 'DANEFailure|DANETakesPrecedence|DANETrustModel' -v
- go test ./...

Closes #81