### PR TITLE
[RFC 7672] TLSハンドシェイク証明書とTLSA照合を実装

### DIFF
--- a/internal/delivery/dane.go
+++ b/internal/delivery/dane.go
@@ -2,6 +2,10 @@ package delivery
 
 import (
 	"context"
+	"crypto/sha256"
+	"crypto/sha512"
+	"crypto/subtle"
+	"crypto/x509"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -74,6 +78,63 @@ func isSupportedTLSAProfile(rec TLSARecord) bool {
 	default:
 		return false
 	}
+}
+
+func verifyPeerCertificatesWithTLSA(peerCerts []*x509.Certificate, records []TLSARecord) error {
+	if len(peerCerts) == 0 {
+		return errors.New("no peer certificates")
+	}
+	if len(records) == 0 {
+		return errors.New("no tlsa records")
+	}
+	for _, rec := range records {
+		if !isSupportedTLSAProfile(rec) {
+			continue
+		}
+		candidates := peerCertCandidatesForUsage(peerCerts, rec.Usage)
+		for _, cert := range candidates {
+			if matchTLSARecord(cert, rec) {
+				return nil
+			}
+		}
+	}
+	return errors.New("no matching tlsa record for peer certificates")
+}
+
+func peerCertCandidatesForUsage(peerCerts []*x509.Certificate, usage uint8) []*x509.Certificate {
+	switch usage {
+	case 3: // DANE-EE: leaf certificate.
+		return peerCerts[:1]
+	case 2: // DANE-TA: trust anchor candidates from chain.
+		return peerCerts
+	default:
+		return nil
+	}
+}
+
+func matchTLSARecord(cert *x509.Certificate, rec TLSARecord) bool {
+	var selected []byte
+	switch rec.Selector {
+	case 0:
+		selected = cert.Raw
+	case 1:
+		selected = cert.RawSubjectPublicKeyInfo
+	default:
+		return false
+	}
+
+	var digested []byte
+	switch rec.MatchingType {
+	case 1:
+		sum := sha256.Sum256(selected)
+		digested = sum[:]
+	case 2:
+		sum := sha512.Sum512(selected)
+		digested = sum[:]
+	default:
+		return false
+	}
+	return subtle.ConstantTimeCompare(digested, rec.CertificateAssociation) == 1
 }
 
 type DANEResolver struct {

--- a/internal/delivery/dane_test.go
+++ b/internal/delivery/dane_test.go
@@ -2,8 +2,15 @@ package delivery
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/sha512"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/binary"
 	"errors"
+	"math/big"
 	"reflect"
 	"testing"
 	"time"
@@ -183,5 +190,87 @@ func TestDANEResolverLookupHost_CNAMEChainLoopStops(t *testing.T) {
 	}
 	if len(lookedUp) > 2 {
 		t.Fatalf("expected loop detection to stop exploration, looked up=%v", lookedUp)
+	}
+}
+
+func TestVerifyPeerCertificatesWithTLSA_Match(t *testing.T) {
+	cert := mustCreateTestCert(t)
+	cases := []TLSARecord{
+		{
+			Usage:                  3,
+			Selector:               1,
+			MatchingType:           1,
+			CertificateAssociation: digestTLSA(cert, 1, 1),
+		},
+		{
+			Usage:                  3,
+			Selector:               0,
+			MatchingType:           2,
+			CertificateAssociation: digestTLSA(cert, 0, 2),
+		},
+	}
+	for i, rec := range cases {
+		if err := verifyPeerCertificatesWithTLSA([]*x509.Certificate{cert}, []TLSARecord{rec}); err != nil {
+			t.Fatalf("case %d expected match: %v", i, err)
+		}
+	}
+}
+
+func TestVerifyPeerCertificatesWithTLSA_NoMatch(t *testing.T) {
+	cert := mustCreateTestCert(t)
+	rec := TLSARecord{
+		Usage:                  3,
+		Selector:               1,
+		MatchingType:           1,
+		CertificateAssociation: []byte{0x00, 0x01, 0x02},
+	}
+	if err := verifyPeerCertificatesWithTLSA([]*x509.Certificate{cert}, []TLSARecord{rec}); err == nil {
+		t.Fatal("expected mismatch error")
+	}
+}
+
+func mustCreateTestCert(t *testing.T) *x509.Certificate {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "mx.example.net"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse cert: %v", err)
+	}
+	return cert
+}
+
+func digestTLSA(cert *x509.Certificate, selector, matchingType uint8) []byte {
+	var selected []byte
+	switch selector {
+	case 0:
+		selected = cert.Raw
+	case 1:
+		selected = cert.RawSubjectPublicKeyInfo
+	default:
+		return nil
+	}
+	switch matchingType {
+	case 1:
+		sum := sha256.Sum256(selected)
+		return sum[:]
+	case 2:
+		sum := sha512.Sum512(selected)
+		return sum[:]
+	default:
+		return nil
 	}
 }

--- a/internal/delivery/modes_test.go
+++ b/internal/delivery/modes_test.go
@@ -42,7 +42,7 @@ func TestDeliverRelayUsesConfiguredTarget(t *testing.T) {
 	cfg := config.Config{DeliveryMode: "relay", RelayHost: "relay.example.net", RelayPort: 2525, RelayRequireTLS: true}
 	cl := NewClient(cfg)
 	called := false
-	cl.deliverHostFn = func(ctx context.Context, host string, port int, msg *model.Message, rcpt string, requireTLS bool) error {
+	cl.deliverHostFn = func(ctx context.Context, host string, port int, msg *model.Message, rcpt string, requireTLS bool, _ *DANEResult) error {
 		called = true
 		if host != "relay.example.net" || port != 2525 {
 			t.Fatalf("unexpected relay target host=%s port=%d", host, port)

--- a/internal/delivery/smtp_client.go
+++ b/internal/delivery/smtp_client.go
@@ -30,7 +30,7 @@ type Client struct {
 	mtaSTS                         *MTASTSResolver
 	signer                         messageSigner
 	resolveMXFn                    func(string, time.Duration) ([]router.MXHost, error)
-	deliverHostFn                  func(context.Context, string, int, *model.Message, string, bool) error
+	deliverHostFn                  func(context.Context, string, int, *model.Message, string, bool, *DANEResult) error
 	spoolWriteFn                   func(*model.Message, string) error
 	reportMTASTSTestingViolationFn func(context.Context, string, string, string)
 }
@@ -77,7 +77,7 @@ func (c *Client) Deliver(ctx context.Context, msg *model.Message, rcpt string) e
 		if port <= 0 {
 			port = 25
 		}
-		return c.deliverHostFn(ctx, c.cfg.RelayHost, port, msg, rcpt, c.cfg.RelayRequireTLS)
+		return c.deliverHostFn(ctx, c.cfg.RelayHost, port, msg, rcpt, c.cfg.RelayRequireTLS, nil)
 	default:
 		return fmt.Errorf("unknown delivery mode: %s", mode)
 	}
@@ -94,6 +94,7 @@ func (c *Client) deliverByMX(ctx context.Context, msg *model.Message, rcpt strin
 	}
 	requireTLS := false
 	daneActive := false
+	daneByHost := map[string]DANEResult{}
 	var mtaSTSTestingPolicy *MTASTSPolicy
 	daneCandidates := make([]router.MXHost, 0, len(mxHosts))
 	if c.dane != nil {
@@ -104,6 +105,7 @@ func (c *Client) deliverByMX(ctx context.Context, msg *model.Message, rcpt strin
 			}
 			if res.HasUsableTLSAWithTrustModel(c.cfg.DANEDNSSECTrustModel) {
 				daneCandidates = append(daneCandidates, mx)
+				daneByHost[mx.Host] = res
 			}
 		}
 	}
@@ -137,7 +139,14 @@ func (c *Client) deliverByMX(ctx context.Context, msg *model.Message, rcpt strin
 		if mtaSTSTestingPolicy != nil && !mtaSTSTestingPolicy.AllowsMX(mx.Host) && c.reportMTASTSTestingViolationFn != nil {
 			c.reportMTASTSTestingViolationFn(ctx, domain, mx.Host, "mx_mismatch")
 		}
-		err := c.deliverHostFn(ctx, mx.Host, 25, msg, rcpt, requireTLS)
+		var daneRes *DANEResult
+		if daneActive {
+			if res, ok := daneByHost[mx.Host]; ok {
+				cp := res
+				daneRes = &cp
+			}
+		}
+		err := c.deliverHostFn(ctx, mx.Host, 25, msg, rcpt, requireTLS, daneRes)
 		if daneActive {
 			err = classifyDANEFailure(err)
 		}
@@ -168,7 +177,7 @@ func classifyDANEFailure(err error) error {
 	return err
 }
 
-func (c *Client) deliverHost(ctx context.Context, host string, port int, msg *model.Message, rcpt string, requireTLS bool) error {
+func (c *Client) deliverHost(ctx context.Context, host string, port int, msg *model.Message, rcpt string, requireTLS bool, daneRes *DANEResult) error {
 	if port <= 0 {
 		port = 25
 	}
@@ -216,6 +225,12 @@ func (c *Client) deliverHost(ctx context.Context, host string, port int, msg *mo
 					return &SMTPResponseError{Code: 454, Line: "starttls handshake failed"}
 				}
 				return err
+			}
+			if daneRes != nil {
+				state := tlsConn.ConnectionState()
+				if err := verifyPeerCertificatesWithTLSA(state.PeerCertificates, daneRes.Records); err != nil {
+					return &SMTPResponseError{Code: 550, Line: "dane authentication failed"}
+				}
 			}
 			conn = tlsConn
 			r = bufio.NewReader(conn)

--- a/internal/delivery/smtp_policy_test.go
+++ b/internal/delivery/smtp_policy_test.go
@@ -31,7 +31,7 @@ func TestDeliverByMX_DANETakesPrecedenceOverMTASTS(t *testing.T) {
 
 	var calledHost string
 	var requireTLS bool
-	cl.deliverHostFn = func(ctx context.Context, host string, port int, msg *model.Message, rcpt string, reqTLS bool) error {
+	cl.deliverHostFn = func(ctx context.Context, host string, port int, msg *model.Message, rcpt string, reqTLS bool, _ *DANEResult) error {
 		calledHost = host
 		requireTLS = reqTLS
 		return nil
@@ -63,7 +63,7 @@ func TestDeliverByMX_FallsBackToMTASTSWhenNoUsableDANE(t *testing.T) {
 
 	var calledHost string
 	var requireTLS bool
-	cl.deliverHostFn = func(ctx context.Context, host string, port int, msg *model.Message, rcpt string, reqTLS bool) error {
+	cl.deliverHostFn = func(ctx context.Context, host string, port int, msg *model.Message, rcpt string, reqTLS bool, _ *DANEResult) error {
 		calledHost = host
 		requireTLS = reqTLS
 		return nil
@@ -93,7 +93,7 @@ func TestDeliverByMX_MTASTSTestingModeDoesNotRejectOnMXMismatch(t *testing.T) {
 	var calledHost string
 	var requireTLS bool
 	var violationCalled bool
-	cl.deliverHostFn = func(ctx context.Context, host string, port int, msg *model.Message, rcpt string, reqTLS bool) error {
+	cl.deliverHostFn = func(ctx context.Context, host string, port int, msg *model.Message, rcpt string, reqTLS bool, _ *DANEResult) error {
 		calledHost = host
 		requireTLS = reqTLS
 		return nil
@@ -127,7 +127,7 @@ func TestDeliverByMX_MTASTSTestingModeNoViolationWhenMXMatches(t *testing.T) {
 	})
 
 	var violationCalled bool
-	cl.deliverHostFn = func(ctx context.Context, host string, port int, msg *model.Message, rcpt string, reqTLS bool) error {
+	cl.deliverHostFn = func(ctx context.Context, host string, port int, msg *model.Message, rcpt string, reqTLS bool, _ *DANEResult) error {
 		return nil
 	}
 	cl.reportMTASTSTestingViolationFn = func(context.Context, string, string, string) {
@@ -156,7 +156,7 @@ func TestDeliverByMX_DANETrustModelAllowsUnsignedWhenConfigured(t *testing.T) {
 	})
 
 	var requireTLS bool
-	cl.deliverHostFn = func(ctx context.Context, host string, port int, msg *model.Message, rcpt string, reqTLS bool) error {
+	cl.deliverHostFn = func(ctx context.Context, host string, port int, msg *model.Message, rcpt string, reqTLS bool, _ *DANEResult) error {
 		requireTLS = reqTLS
 		return nil
 	}
@@ -181,7 +181,7 @@ func TestDeliverByMX_DANEFailureBecomesHardFailOnTLSAuthError(t *testing.T) {
 			Records:           []TLSARecord{{Usage: 3, Selector: 1, MatchingType: 1, CertificateAssociation: []byte{0x01}}},
 		}, nil
 	})
-	cl.deliverHostFn = func(ctx context.Context, host string, port int, msg *model.Message, rcpt string, reqTLS bool) error {
+	cl.deliverHostFn = func(ctx context.Context, host string, port int, msg *model.Message, rcpt string, reqTLS bool, _ *DANEResult) error {
 		return &SMTPResponseError{Code: 454, Line: "starttls handshake failed"}
 	}
 
@@ -209,7 +209,7 @@ func TestDeliverByMX_DANEFailureKeepsTemporaryForNetworkError(t *testing.T) {
 			Records:           []TLSARecord{{Usage: 3, Selector: 1, MatchingType: 1, CertificateAssociation: []byte{0x01}}},
 		}, nil
 	})
-	cl.deliverHostFn = func(ctx context.Context, host string, port int, msg *model.Message, rcpt string, reqTLS bool) error {
+	cl.deliverHostFn = func(ctx context.Context, host string, port int, msg *model.Message, rcpt string, reqTLS bool, _ *DANEResult) error {
 		return errors.New("dial timeout")
 	}
 

--- a/internal/delivery/testing_hooks_integration.go
+++ b/internal/delivery/testing_hooks_integration.go
@@ -34,12 +34,12 @@ func (c *Client) ResolveForTest(
 }
 
 func (c *Client) DeliverHostForTest(
-	fn func(host string, port int, msg *model.Message, rcpt string, requireTLS bool) error,
+	fn func(host string, port int, msg *model.Message, rcpt string, requireTLS bool, _ *DANEResult) error,
 ) {
 	if fn == nil {
 		return
 	}
-	c.deliverHostFn = func(_ context.Context, host string, port int, msg *model.Message, rcpt string, requireTLS bool) error {
-		return fn(host, port, msg, rcpt, requireTLS)
+	c.deliverHostFn = func(_ context.Context, host string, port int, msg *model.Message, rcpt string, requireTLS bool, _ *DANEResult) error {
+		return fn(host, port, msg, rcpt, requireTLS, nil)
 	}
 }


### PR DESCRIPTION
## 概要
- SMTP送信時のTLSハンドシェイク後に、取得した証明書チェーンとTLSAレコードを照合する処理を追加しました
- DANE有効時に証明書照合に失敗した場合は配送失敗とします

## 変更内容
- TLSA照合ロジックを追加
  - usage: 3(DANE-EE), 2(DANE-TA)
  - selector: 0(証明書全体), 1(SPKI)
  - matching type: 1(SHA-256), 2(SHA-512)
- deliverByMX から各MXの DANE結果を deliverHost へ渡すよう変更
- deliverHost で STARTTLS ハンドシェイク成功後に証明書/TLSA照合を実行
  - 不一致時は 550 dane authentication failed を返却
- CNAME探索・DANE判定系テストとの整合を保つため、テストフック/モックのシグネチャを更新

## テスト
- DANE/TLSA照合のユニットテストを追加
  - match / mismatch
- 既存 DANE 系テスト（優先順位、失敗分類、CNAME探索）を回帰確認
- go test ./internal/delivery -run 'DANE|TLSA|LookupHost|VerifyPeer' -v
- go test ./...

Closes #77