### PR TITLE
[RFC 3464] multipart/report(delivery-status)全フィールド厳密パースを実装

### DIFF
--- a/internal/bounce/dsn.go
+++ b/internal/bounce/dsn.go
@@ -3,62 +3,168 @@ package bounce
 import (
 	"bufio"
 	"bytes"
+	"errors"
+	"fmt"
+	"net/mail"
+	"regexp"
 	"strings"
 )
 
 type DSNReport struct {
-	Recipient      string
-	Action         string
-	Status         string
-	DiagnosticCode string
+	Recipient         string
+	OriginalRecipient string
+	Action            string
+	Status            string
+	RemoteMTA         string
+	DiagnosticCode    string
+	LastAttemptDate   string
+	FinalLogID        string
+	WillRetryUntil    string
+	ReportingMTA      string
+	DSNGateway        string
+	ReceivedFromMTA   string
+	ArrivalDate       string
 }
 
+var dsnStatusPattern = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+
 func ParseDSN(raw []byte) ([]DSNReport, error) {
-	s := bufio.NewScanner(bytes.NewReader(raw))
-	var reports []DSNReport
-	cur := DSNReport{}
-	hasAny := false
-	flush := func() {
-		if cur.Recipient == "" && cur.Action == "" && cur.Status == "" && cur.DiagnosticCode == "" {
-			return
-		}
-		reports = append(reports, cur)
-		cur = DSNReport{}
+	blocks, err := splitDSNBlocks(raw)
+	if err != nil {
+		return nil, err
 	}
+	if len(blocks) == 0 {
+		return nil, nil
+	}
+
+	msgLevel, err := parseDSNBlock(blocks[0])
+	if err != nil {
+		return nil, err
+	}
+	base := DSNReport{
+		ReportingMTA:    parseTypedValue(msgLevel["reporting-mta"]),
+		DSNGateway:      parseTypedValue(msgLevel["dsn-gateway"]),
+		ReceivedFromMTA: parseTypedValue(msgLevel["received-from-mta"]),
+		ArrivalDate:     strings.TrimSpace(msgLevel["arrival-date"]),
+	}
+	if base.ArrivalDate != "" {
+		if _, err := mail.ParseDate(base.ArrivalDate); err != nil {
+			return nil, fmt.Errorf("invalid arrival-date: %w", err)
+		}
+	}
+
+	var reports []DSNReport
+	for i := 1; i < len(blocks); i++ {
+		fields, err := parseDSNBlock(blocks[i])
+		if err != nil {
+			return nil, err
+		}
+		r := base
+		r.Recipient = parseRecipient(fields["final-recipient"])
+		r.OriginalRecipient = parseRecipient(fields["original-recipient"])
+		r.Action = strings.ToLower(strings.TrimSpace(fields["action"]))
+		r.Status = strings.TrimSpace(fields["status"])
+		r.RemoteMTA = parseTypedValue(fields["remote-mta"])
+		r.DiagnosticCode = parseTypedValue(fields["diagnostic-code"])
+		r.LastAttemptDate = strings.TrimSpace(fields["last-attempt-date"])
+		r.FinalLogID = parseTypedValue(fields["final-log-id"])
+		r.WillRetryUntil = strings.TrimSpace(fields["will-retry-until"])
+
+		if err := validateDSNRecipientReport(r); err != nil {
+			return nil, fmt.Errorf("recipient block %d: %w", i, err)
+		}
+		reports = append(reports, r)
+	}
+	return reports, nil
+}
+
+func splitDSNBlocks(raw []byte) ([][]string, error) {
+	s := bufio.NewScanner(bytes.NewReader(raw))
+	var blocks [][]string
+	cur := make([]string, 0, 16)
 	for s.Scan() {
-		line := strings.TrimSpace(s.Text())
-		if line == "" {
-			flush()
-			hasAny = false
+		line := strings.TrimRight(s.Text(), "\r")
+		if strings.TrimSpace(line) == "" {
+			if len(cur) > 0 {
+				blocks = append(blocks, cur)
+				cur = make([]string, 0, 16)
+			}
+			continue
+		}
+		cur = append(cur, line)
+	}
+	if len(cur) > 0 {
+		blocks = append(blocks, cur)
+	}
+	return blocks, s.Err()
+}
+
+func parseDSNBlock(lines []string) (map[string]string, error) {
+	fields := map[string]string{}
+	var lastKey string
+	for _, line := range lines {
+		if strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t") {
+			if lastKey == "" {
+				return nil, errors.New("invalid folded line without previous header")
+			}
+			fields[lastKey] = fields[lastKey] + " " + strings.TrimSpace(line)
 			continue
 		}
 		idx := strings.Index(line, ":")
 		if idx <= 0 {
-			continue
+			return nil, fmt.Errorf("invalid header line: %q", line)
 		}
 		key := strings.ToLower(strings.TrimSpace(line[:idx]))
 		val := strings.TrimSpace(line[idx+1:])
-		hasAny = true
-		switch key {
-		case "final-recipient":
-			cur.Recipient = parseRecipient(val)
-		case "action":
-			cur.Action = strings.ToLower(val)
-		case "status":
-			cur.Status = val
-		case "diagnostic-code":
-			cur.DiagnosticCode = val
+		fields[key] = val
+		lastKey = key
+	}
+	return fields, nil
+}
+
+func validateDSNRecipientReport(r DSNReport) error {
+	if r.Recipient == "" {
+		return errors.New("final-recipient is required")
+	}
+	switch r.Action {
+	case "failed", "delayed", "delivered", "relayed", "expanded":
+	default:
+		return fmt.Errorf("invalid action: %q", r.Action)
+	}
+	if !dsnStatusPattern.MatchString(r.Status) {
+		return fmt.Errorf("invalid status: %q", r.Status)
+	}
+	if r.LastAttemptDate != "" {
+		if _, err := mail.ParseDate(r.LastAttemptDate); err != nil {
+			return fmt.Errorf("invalid last-attempt-date: %w", err)
 		}
 	}
-	if hasAny {
-		flush()
+	if r.WillRetryUntil != "" {
+		if _, err := mail.ParseDate(r.WillRetryUntil); err != nil {
+			return fmt.Errorf("invalid will-retry-until: %w", err)
+		}
 	}
-	return reports, s.Err()
+	return nil
 }
 
 func parseRecipient(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return ""
+	}
 	if i := strings.Index(v, ";"); i >= 0 {
 		v = v[i+1:]
 	}
 	return strings.ToLower(strings.TrimSpace(v))
+}
+
+func parseTypedValue(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return ""
+	}
+	if i := strings.Index(v, ";"); i >= 0 {
+		return strings.TrimSpace(v[i+1:])
+	}
+	return v
 }

--- a/internal/bounce/dsn_test.go
+++ b/internal/bounce/dsn_test.go
@@ -3,7 +3,15 @@ package bounce
 import "testing"
 
 func TestParseDSN(t *testing.T) {
-	raw := []byte("Final-Recipient: rfc822; user@example.com\r\nAction: failed\r\nStatus: 5.1.1\r\nDiagnostic-Code: smtp; 550 5.1.1 User unknown\r\n")
+	raw := []byte(
+		"Reporting-MTA: dns; mx.example.net\r\n" +
+			"Arrival-Date: Tue, 12 Mar 2024 09:30:00 +0000\r\n" +
+			"\r\n" +
+			"Final-Recipient: rfc822; user@example.com\r\n" +
+			"Action: failed\r\n" +
+			"Status: 5.1.1\r\n" +
+			"Diagnostic-Code: smtp; 550 5.1.1 User unknown\r\n",
+	)
 	reports, err := ParseDSN(raw)
 	if err != nil {
 		t.Fatalf("parse dsn: %v", err)
@@ -14,5 +22,67 @@ func TestParseDSN(t *testing.T) {
 	r := reports[0]
 	if r.Recipient != "user@example.com" || r.Action != "failed" || r.Status != "5.1.1" {
 		t.Fatalf("unexpected report: %+v", r)
+	}
+	if r.ReportingMTA != "mx.example.net" {
+		t.Fatalf("unexpected reporting-mta: %+v", r)
+	}
+}
+
+func TestParseDSN_MultipleRecipientBlocks(t *testing.T) {
+	raw := []byte(
+		"Reporting-MTA: dns; mx.example.net\r\n" +
+			"\r\n" +
+			"Final-Recipient: rfc822; user1@example.com\r\n" +
+			"Action: failed\r\n" +
+			"Status: 5.1.1\r\n" +
+			"\r\n" +
+			"Final-Recipient: rfc822; user2@example.com\r\n" +
+			"Action: delayed\r\n" +
+			"Status: 4.2.0\r\n",
+	)
+	reports, err := ParseDSN(raw)
+	if err != nil {
+		t.Fatalf("parse dsn: %v", err)
+	}
+	if len(reports) != 2 {
+		t.Fatalf("len=%d", len(reports))
+	}
+	if reports[1].Recipient != "user2@example.com" || reports[1].Action != "delayed" || reports[1].Status != "4.2.0" {
+		t.Fatalf("unexpected second report: %+v", reports[1])
+	}
+}
+
+func TestParseDSN_StrictValidationError(t *testing.T) {
+	raw := []byte(
+		"Reporting-MTA: dns; mx.example.net\r\n" +
+			"\r\n" +
+			"Final-Recipient: rfc822; user@example.com\r\n" +
+			"Action: invalid-action\r\n" +
+			"Status: bad-status\r\n",
+	)
+	if _, err := ParseDSN(raw); err == nil {
+		t.Fatal("expected strict validation error")
+	}
+}
+
+func TestParseDSN_FoldedHeader(t *testing.T) {
+	raw := []byte(
+		"Reporting-MTA: dns; mx.example.net\r\n" +
+			"\r\n" +
+			"Final-Recipient: rfc822; user@example.com\r\n" +
+			"Action: failed\r\n" +
+			"Status: 5.1.1\r\n" +
+			"Diagnostic-Code: smtp; 550 5.1.1\r\n" +
+			" User unknown\r\n",
+	)
+	reports, err := ParseDSN(raw)
+	if err != nil {
+		t.Fatalf("parse dsn: %v", err)
+	}
+	if len(reports) != 1 {
+		t.Fatalf("len=%d", len(reports))
+	}
+	if reports[0].DiagnosticCode != "550 5.1.1 User unknown" {
+		t.Fatalf("unexpected diagnostic-code: %q", reports[0].DiagnosticCode)
 	}
 }


### PR DESCRIPTION
## 概要
- DSN parser を厳密化し、message-level / recipient-level の主要フィールドを網羅的にパース
- 折り返し行（folded header）をサポート
- recipient block の必須項目・構文を検証し、不正DSNをエラー化

## 変更内容
- DSNReport を拡張
  - message-level: Reporting-MTA, DSN-Gateway, Received-From-MTA, Arrival-Date
  - recipient-level: Final/Original-Recipient, Action, Status, Remote-MTA, Diagnostic-Code, Last-Attempt-Date, Final-Log-ID, Will-Retry-Until
- ParseDSN の処理を再設計
  - block 分割
  - ヘッダ継続行のunfold
  - recipient block ごとの必須検証（Final-Recipient/Action/Status）
  - Action 値、Status 形式、Date 形式の検証
- テスト追加
  - 複数 recipient block
  - strict validation error
  - folded header

## テスト
- go test ./internal/bounce -run DSN -v
- go test ./...

Closes #82