### PR TITLE
[RFC 3464] RFC 3463拡張ステータスコードとの整合処理を実装

### DIFF
--- a/internal/bounce/dsn.go
+++ b/internal/bounce/dsn.go
@@ -134,6 +134,9 @@ func validateDSNRecipientReport(r DSNReport) error {
 	if !dsnStatusPattern.MatchString(r.Status) {
 		return fmt.Errorf("invalid status: %q", r.Status)
 	}
+	if err := validateActionStatusAlignment(r.Action, r.Status); err != nil {
+		return err
+	}
 	if r.LastAttemptDate != "" {
 		if _, err := mail.ParseDate(r.LastAttemptDate); err != nil {
 			return fmt.Errorf("invalid last-attempt-date: %w", err)
@@ -142,6 +145,25 @@ func validateDSNRecipientReport(r DSNReport) error {
 	if r.WillRetryUntil != "" {
 		if _, err := mail.ParseDate(r.WillRetryUntil); err != nil {
 			return fmt.Errorf("invalid will-retry-until: %w", err)
+		}
+	}
+	return nil
+}
+
+func validateActionStatusAlignment(action, status string) error {
+	statusClass := strings.SplitN(strings.TrimSpace(status), ".", 2)[0]
+	switch strings.TrimSpace(strings.ToLower(action)) {
+	case "failed":
+		if statusClass != "5" {
+			return fmt.Errorf("action/status mismatch: failed requires 5.x.x, got %q", status)
+		}
+	case "delayed":
+		if statusClass != "4" {
+			return fmt.Errorf("action/status mismatch: delayed requires 4.x.x, got %q", status)
+		}
+	case "delivered", "relayed", "expanded":
+		if statusClass != "2" {
+			return fmt.Errorf("action/status mismatch: %s requires 2.x.x, got %q", action, status)
 		}
 	}
 	return nil

--- a/internal/bounce/dsn_test.go
+++ b/internal/bounce/dsn_test.go
@@ -65,6 +65,19 @@ func TestParseDSN_StrictValidationError(t *testing.T) {
 	}
 }
 
+func TestParseDSN_ActionStatusAlignmentError(t *testing.T) {
+	raw := []byte(
+		"Reporting-MTA: dns; mx.example.net\r\n" +
+			"\r\n" +
+			"Final-Recipient: rfc822; user@example.com\r\n" +
+			"Action: failed\r\n" +
+			"Status: 4.1.1\r\n",
+	)
+	if _, err := ParseDSN(raw); err == nil {
+		t.Fatal("expected action/status alignment error")
+	}
+}
+
 func TestParseDSN_FoldedHeader(t *testing.T) {
 	raw := []byte(
 		"Reporting-MTA: dns; mx.example.net\r\n" +


### PR DESCRIPTION
## 概要
- DSN recipient block の Action と RFC 3463 拡張ステータスコードの整合を検証する処理を追加
- 不整合なDSNを strict parse でエラーにします

## 変更内容
- validateActionStatusAlignment を追加
  - failed -> 5.x.x
  - delayed -> 4.x.x
  - delivered/relayed/expanded -> 2.x.x
- 既存の strict validation フローに整合チェックを統合
- テスト追加
  - Action=failed + Status=4.x.x を不正として検出

## テスト
- go test ./internal/bounce -run 'DSN|Alignment' -v
- go test ./...

Closes #83