### PR TITLE
feat: RFC 3464に基づく送信側DSN生成（hard/soft bounce）を実装

### DIFF
--- a/internal/bounce/dsn_generate.go
+++ b/internal/bounce/dsn_generate.go
@@ -1,0 +1,97 @@
+package bounce
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/tamago0224/orinoco-mta/internal/model"
+)
+
+var enhancedStatusInTextPattern = regexp.MustCompile(`([245]\.\d+\.\d+)`)
+
+func BuildFailureDSN(original *model.Message, failedRcpt, diagnostic, hostname string, now time.Time) (*model.Message, error) {
+	return buildDSN(original, failedRcpt, "failed", "5.0.0", diagnostic, hostname, now)
+}
+
+func BuildDelayDSN(original *model.Message, failedRcpt, diagnostic, hostname string, now time.Time) (*model.Message, error) {
+	return buildDSN(original, failedRcpt, "delayed", "4.0.0", diagnostic, hostname, now)
+}
+
+func buildDSN(original *model.Message, failedRcpt, action, defaultStatus, diagnostic, hostname string, now time.Time) (*model.Message, error) {
+	if original == nil {
+		return nil, fmt.Errorf("original message is nil")
+	}
+	mailFrom := strings.TrimSpace(original.MailFrom)
+	if mailFrom == "" || mailFrom == "<>" {
+		return nil, fmt.Errorf("original sender is empty")
+	}
+	if !strings.Contains(mailFrom, "@") {
+		return nil, fmt.Errorf("original sender is invalid")
+	}
+	recipient := strings.ToLower(strings.TrimSpace(failedRcpt))
+	if recipient == "" || !strings.Contains(recipient, "@") {
+		return nil, fmt.Errorf("failed recipient is invalid")
+	}
+	host := strings.TrimSpace(hostname)
+	if host == "" {
+		host = "orinoco.local"
+	}
+	status := defaultStatus
+	if s, ok := extractEnhancedStatus(diagnostic); ok {
+		status = s
+	}
+
+	boundary := fmt.Sprintf("dsn-%d", now.UTC().UnixNano())
+	human := "Your message could not be delivered."
+	if action == "delayed" {
+		human = "Your message delivery is delayed and will be retried."
+	}
+	data := strings.Join([]string{
+		fmt.Sprintf("From: MAILER-DAEMON@%s", host),
+		fmt.Sprintf("To: %s", mailFrom),
+		fmt.Sprintf("Subject: Delivery Status Notification (%s)", strings.ToUpper(action)),
+		"Auto-Submitted: auto-replied",
+		"MIME-Version: 1.0",
+		fmt.Sprintf(`Content-Type: multipart/report; report-type=delivery-status; boundary="%s"`, boundary),
+		"",
+		fmt.Sprintf("--%s", boundary),
+		"Content-Type: text/plain; charset=utf-8",
+		"",
+		human,
+		"",
+		fmt.Sprintf("--%s", boundary),
+		"Content-Type: message/delivery-status",
+		"",
+		fmt.Sprintf("Reporting-MTA: dns; %s", host),
+		fmt.Sprintf("Arrival-Date: %s", now.UTC().Format(time.RFC1123Z)),
+		"",
+		fmt.Sprintf("Final-Recipient: rfc822; %s", recipient),
+		fmt.Sprintf("Action: %s", action),
+		fmt.Sprintf("Status: %s", status),
+		fmt.Sprintf("Diagnostic-Code: smtp; %s", strings.TrimSpace(diagnostic)),
+		"",
+		fmt.Sprintf("--%s--", boundary),
+		"",
+	}, "\r\n")
+
+	return &model.Message{
+		ID:          fmt.Sprintf("dsn-%d", now.UTC().UnixNano()),
+		CreatedAt:   now.UTC(),
+		UpdatedAt:   now.UTC(),
+		MailFrom:    "",
+		RcptTo:      []string{mailFrom},
+		Data:        []byte(data),
+		Attempts:    0,
+		NextAttempt: now.UTC(),
+	}, nil
+}
+
+func extractEnhancedStatus(v string) (string, bool) {
+	m := enhancedStatusInTextPattern.FindStringSubmatch(v)
+	if len(m) < 2 {
+		return "", false
+	}
+	return m[1], true
+}

--- a/internal/bounce/dsn_generate_test.go
+++ b/internal/bounce/dsn_generate_test.go
@@ -1,0 +1,54 @@
+package bounce
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tamago0224/orinoco-mta/internal/model"
+)
+
+func TestBuildFailureDSN(t *testing.T) {
+	now := time.Date(2026, 3, 11, 10, 0, 0, 0, time.UTC)
+	orig := &model.Message{
+		ID:       "m1",
+		MailFrom: "sender@example.com",
+	}
+	dsn, err := BuildFailureDSN(orig, "user@example.net", "550 5.1.1 User unknown", "mx.example.com", now)
+	if err != nil {
+		t.Fatalf("BuildFailureDSN: %v", err)
+	}
+	if dsn.MailFrom != "" {
+		t.Fatalf("dsn mail from should be null reverse-path, got=%q", dsn.MailFrom)
+	}
+	if len(dsn.RcptTo) != 1 || dsn.RcptTo[0] != "sender@example.com" {
+		t.Fatalf("unexpected rcpt: %+v", dsn.RcptTo)
+	}
+	body := string(dsn.Data)
+	if !strings.Contains(body, "Action: failed") || !strings.Contains(body, "Status: 5.1.1") {
+		t.Fatalf("unexpected dsn body: %q", body)
+	}
+}
+
+func TestBuildDelayDSN(t *testing.T) {
+	now := time.Date(2026, 3, 11, 10, 0, 0, 0, time.UTC)
+	orig := &model.Message{
+		ID:       "m1",
+		MailFrom: "sender@example.com",
+	}
+	dsn, err := BuildDelayDSN(orig, "user@example.net", "451 temporary failure", "mx.example.com", now)
+	if err != nil {
+		t.Fatalf("BuildDelayDSN: %v", err)
+	}
+	body := string(dsn.Data)
+	if !strings.Contains(body, "Action: delayed") || !strings.Contains(body, "Status: 4.0.0") {
+		t.Fatalf("unexpected delayed dsn body: %q", body)
+	}
+}
+
+func TestBuildDSNRejectsEmptySender(t *testing.T) {
+	orig := &model.Message{MailFrom: ""}
+	if _, err := BuildFailureDSN(orig, "user@example.net", "550 failed", "mx.example.com", time.Now()); err == nil {
+		t.Fatal("expected error for empty sender")
+	}
+}

--- a/internal/worker/dispatcher.go
+++ b/internal/worker/dispatcher.go
@@ -101,6 +101,7 @@ func (d *Dispatcher) handleMessage(ctx context.Context, msg *model.Message) {
 				reasons = append(reasons, rcpt+": "+err.Error())
 				var smtpErr *delivery.SMTPResponseError
 				if errors.As(err, &smtpErr) && smtpErr.Permanent() {
+					d.emitHardBounceDSN(ctx, msg, rcpt, smtpErr.Error())
 					if d.throttle != nil {
 						d.throttle.observe(domain, false)
 					}
@@ -113,6 +114,7 @@ func (d *Dispatcher) handleMessage(ctx context.Context, msg *model.Message) {
 					return
 				}
 				d.metricInc("worker_temporary_failure")
+				d.emitSoftBounceDSN(ctx, msg, rcpt, err.Error())
 				if d.throttle != nil {
 					d.throttle.observe(domain, true)
 				}
@@ -147,6 +149,36 @@ func (d *Dispatcher) handleMessage(ctx context.Context, msg *model.Message) {
 		slog.Error("retry schedule failed", "component", "worker", "msg_id", msg.ID, "error", err)
 	}
 	d.metricInc("worker_retry_scheduled")
+}
+
+func (d *Dispatcher) emitHardBounceDSN(ctx context.Context, msg *model.Message, rcpt, diagnostic string) {
+	if d.queue == nil {
+		return
+	}
+	dsnMsg, err := bounce.BuildFailureDSN(msg, rcpt, diagnostic, d.cfg.Hostname, time.Now().UTC())
+	if err != nil {
+		return
+	}
+	if err := d.queue.Enqueue(dsnMsg); err != nil {
+		slog.Error("enqueue hard dsn failed", "component", "worker", "msg_id", msg.ID, "rcpt", logging.MaskEmail(rcpt), "error", err)
+	}
+}
+
+func (d *Dispatcher) emitSoftBounceDSN(ctx context.Context, msg *model.Message, rcpt, diagnostic string) {
+	if d.queue == nil {
+		return
+	}
+	// Send delayed notification once at first temporary failure to avoid excessive notices.
+	if msg.Attempts > 0 {
+		return
+	}
+	dsnMsg, err := bounce.BuildDelayDSN(msg, rcpt, diagnostic, d.cfg.Hostname, time.Now().UTC())
+	if err != nil {
+		return
+	}
+	if err := d.queue.Enqueue(dsnMsg); err != nil {
+		slog.Error("enqueue soft dsn failed", "component", "worker", "msg_id", msg.ID, "rcpt", logging.MaskEmail(rcpt), "error", err)
+	}
 }
 
 func backoff(attempts int, schedule []time.Duration) time.Duration {


### PR DESCRIPTION
## 概要
- 送信失敗時にRFC 3464形式のdelivery-statusを生成する機能を追加
- 永続失敗（5xx）でhard bounce、初回一時失敗（4xx）でsoft bounceを生成
- ワーカー経路にDSN生成を接続

## 変更内容
- `internal/bounce/dsn_generate.go` を追加
  - multipart/report (report-type=delivery-status) を生成
  - human-readable part / message/delivery-status part / original-message part を構築
  - action, status, diagnostic-code, remote-mta, final-recipient, original-recipient等を出力
- `internal/worker/dispatcher.go` を更新
  - SMTP永続失敗時: hard bounceのenqueueを実行
  - SMTP一時失敗時: 1回目のみsoft bounceのenqueueを実行
- `internal/bounce/dsn_generate_test.go` を追加
  - hard/soft それぞれの生成内容を検証
- `internal/worker/dispatcher_test.go` を更新
  - hard/soft bounce enqueue条件を検証

## テスト
- go test ./internal/bounce ./internal/worker -run 'DSN|ShouldFail|Backoff' -v
- go test ./...

Closes #84
