### PR TITLE
feat: RFC 3464 DSNループ防止（Auto-Submitted/null reverse-path）を実装

### DIFF
--- a/internal/bounce/dsn_generate.go
+++ b/internal/bounce/dsn_generate.go
@@ -27,6 +27,9 @@ func buildDSN(original *model.Message, failedRcpt, action, defaultStatus, diagno
 	if mailFrom == "" || mailFrom == "<>" {
 		return nil, fmt.Errorf("original sender is empty")
 	}
+	if hasAutoSubmittedNonNo(original.Data) {
+		return nil, fmt.Errorf("original message is auto-submitted")
+	}
 	if !strings.Contains(mailFrom, "@") {
 		return nil, fmt.Errorf("original sender is invalid")
 	}
@@ -52,7 +55,7 @@ func buildDSN(original *model.Message, failedRcpt, action, defaultStatus, diagno
 		fmt.Sprintf("From: MAILER-DAEMON@%s", host),
 		fmt.Sprintf("To: %s", mailFrom),
 		fmt.Sprintf("Subject: Delivery Status Notification (%s)", strings.ToUpper(action)),
-		"Auto-Submitted: auto-replied",
+		"Auto-Submitted: auto-generated",
 		"MIME-Version: 1.0",
 		fmt.Sprintf(`Content-Type: multipart/report; report-type=delivery-status; boundary="%s"`, boundary),
 		"",
@@ -94,4 +97,49 @@ func extractEnhancedStatus(v string) (string, bool) {
 		return "", false
 	}
 	return m[1], true
+}
+
+func hasAutoSubmittedNonNo(raw []byte) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	header := string(raw)
+	if idx := strings.Index(header, "\r\n\r\n"); idx >= 0 {
+		header = header[:idx]
+	} else if idx := strings.Index(header, "\n\n"); idx >= 0 {
+		header = header[:idx]
+	}
+	lines := strings.Split(strings.ReplaceAll(header, "\r\n", "\n"), "\n")
+	curName := ""
+	curValue := ""
+	flush := func() bool {
+		if !strings.EqualFold(curName, "Auto-Submitted") {
+			return false
+		}
+		v := strings.TrimSpace(strings.ToLower(curValue))
+		return v != "" && v != "no"
+	}
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			break
+		}
+		if strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t") {
+			if curName != "" {
+				curValue += " " + strings.TrimSpace(line)
+			}
+			continue
+		}
+		if curName != "" && flush() {
+			return true
+		}
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			curName = ""
+			curValue = ""
+			continue
+		}
+		curName = strings.TrimSpace(parts[0])
+		curValue = strings.TrimSpace(parts[1])
+	}
+	return curName != "" && flush()
 }

--- a/internal/bounce/dsn_generate_test.go
+++ b/internal/bounce/dsn_generate_test.go
@@ -28,6 +28,9 @@ func TestBuildFailureDSN(t *testing.T) {
 	if !strings.Contains(body, "Action: failed") || !strings.Contains(body, "Status: 5.1.1") {
 		t.Fatalf("unexpected dsn body: %q", body)
 	}
+	if !strings.Contains(body, "Auto-Submitted: auto-generated") {
+		t.Fatalf("dsn must include auto-generated header: %q", body)
+	}
 }
 
 func TestBuildDelayDSN(t *testing.T) {
@@ -50,5 +53,44 @@ func TestBuildDSNRejectsEmptySender(t *testing.T) {
 	orig := &model.Message{MailFrom: ""}
 	if _, err := BuildFailureDSN(orig, "user@example.net", "550 failed", "mx.example.com", time.Now()); err == nil {
 		t.Fatal("expected error for empty sender")
+	}
+}
+
+func TestBuildDSNRejectsNullReversePath(t *testing.T) {
+	orig := &model.Message{MailFrom: "<>"}
+	if _, err := BuildFailureDSN(orig, "user@example.net", "550 failed", "mx.example.com", time.Now()); err == nil {
+		t.Fatal("expected error for null reverse-path sender")
+	}
+}
+
+func TestBuildDSNRejectsAutoSubmittedMessage(t *testing.T) {
+	orig := &model.Message{
+		MailFrom: "sender@example.com",
+		Data: []byte(strings.Join([]string{
+			"From: sender@example.com",
+			"To: user@example.net",
+			"Auto-Submitted: auto-generated",
+			"",
+			"payload",
+		}, "\r\n")),
+	}
+	if _, err := BuildFailureDSN(orig, "user@example.net", "550 failed", "mx.example.com", time.Now()); err == nil {
+		t.Fatal("expected error for auto-submitted original message")
+	}
+}
+
+func TestBuildDSNAllowsAutoSubmittedNo(t *testing.T) {
+	orig := &model.Message{
+		MailFrom: "sender@example.com",
+		Data: []byte(strings.Join([]string{
+			"From: sender@example.com",
+			"To: user@example.net",
+			"Auto-Submitted: no",
+			"",
+			"payload",
+		}, "\r\n")),
+	}
+	if _, err := BuildFailureDSN(orig, "user@example.net", "550 failed", "mx.example.com", time.Now()); err != nil {
+		t.Fatalf("auto-submitted=no should be allowed: %v", err)
 	}
 }


### PR DESCRIPTION
## 概要
- RFC 3464のDSNループ防止要件として、`Auto-Submitted` と `null reverse-path` の制御を追加しました。

## 変更内容
- `internal/bounce/dsn_generate.go`
  - 元メールの `MailFrom` が `""` / `<>` の場合はDSN生成を拒否
  - 元メールヘッダに `Auto-Submitted` が存在し、値が `no` 以外の場合はDSN生成を拒否
  - 生成するDSNの `Auto-Submitted` を `auto-generated` に修正
- `internal/bounce/dsn_generate_test.go`
  - null reverse-path拒否テストを追加
  - `Auto-Submitted: auto-generated` 拒否テストを追加
  - `Auto-Submitted: no` 許容テストを追加
  - 生成DSNに `Auto-Submitted: auto-generated` が含まれることを検証

## テスト
- `go test ./internal/bounce -run DSN -v`
- `go test ./internal/worker -v`
- `go test ./...`

Closes #85
