### PR TITLE
feat: RFC 7208 SPFのexists/ptr/redirect/expを実装

### DIFF
--- a/internal/mailauth/spf.go
+++ b/internal/mailauth/spf.go
@@ -22,6 +22,9 @@ var (
 	spfLookupMX = func(ctx context.Context, domain string) ([]*net.MX, error) {
 		return net.DefaultResolver.LookupMX(ctx, domain)
 	}
+	spfLookupAddr = func(ctx context.Context, addr string) ([]string, error) {
+		return net.DefaultResolver.LookupAddr(ctx, addr)
+	}
 )
 
 func EvalSPF(remoteIP net.IP, mailFrom, helo string) SPFResult {
@@ -58,6 +61,24 @@ func evalSPFDomain(ctx context.Context, remoteIP net.IP, domain, sender, helo st
 	if len(terms) == 0 || strings.ToLower(terms[0]) != "v=spf1" {
 		return "permerror", "invalid spf header"
 	}
+	redirectDomain := ""
+	explanationDomain := ""
+	for _, t := range terms[1:] {
+		if t == "" || !strings.Contains(t, "=") {
+			continue
+		}
+		k, v, ok := strings.Cut(t, "=")
+		if !ok {
+			continue
+		}
+		switch strings.ToLower(strings.TrimSpace(k)) {
+		case "redirect":
+			redirectDomain = expandSPFMacros(strings.TrimSpace(v), sender, domain, helo, remoteIP)
+		case "exp":
+			explanationDomain = expandSPFMacros(strings.TrimSpace(v), sender, domain, helo, remoteIP)
+		}
+	}
+
 	for _, t := range terms[1:] {
 		if t == "" {
 			continue
@@ -80,8 +101,21 @@ func evalSPFDomain(ctx context.Context, remoteIP net.IP, domain, sender, helo st
 			continue
 		}
 		if match {
-			return qualifierResult(qualifier), fmt.Sprintf("matched %s", name)
+			result := qualifierResult(qualifier)
+			if result == "fail" && explanationDomain != "" {
+				if exp, ok := lookupSPFExplanation(ctx, explanationDomain); ok {
+					return result, exp
+				}
+			}
+			return result, fmt.Sprintf("matched %s", name)
 		}
+	}
+	if redirectDomain != "" {
+		res, reason := evalSPFDomain(ctx, remoteIP, redirectDomain, sender, helo, depth+1)
+		if res == "none" {
+			return "permerror", "redirect target has no spf record"
+		}
+		return res, reason
 	}
 	return "neutral", "no mechanism matched"
 }
@@ -164,6 +198,19 @@ func matchMechanism(ctx context.Context, remoteIP net.IP, domain, sender, helo, 
 			return true, true, nil
 		}
 		return false, true, nil
+	case "exists":
+		if arg == "" {
+			return false, true, nil
+		}
+		ok, err := matchExists(ctx, arg)
+		return ok, true, err
+	case "ptr":
+		host := domain
+		if arg != "" {
+			host = arg
+		}
+		ok, err := matchPTR(ctx, remoteIP, host)
+		return ok, true, err
 	default:
 		return false, false, nil
 	}
@@ -226,6 +273,55 @@ func matchMX(ctx context.Context, remoteIP net.IP, domain string, prefix int) (b
 		}
 	}
 	return false, nil
+}
+
+func matchExists(ctx context.Context, host string) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, 4*time.Second)
+	defer cancel()
+	ips, err := spfLookupIP(ctx, host)
+	if err != nil {
+		return false, err
+	}
+	return len(ips) > 0, nil
+}
+
+func matchPTR(ctx context.Context, remoteIP net.IP, targetDomain string) (bool, error) {
+	if remoteIP == nil {
+		return false, nil
+	}
+	ctx, cancel := context.WithTimeout(ctx, 4*time.Second)
+	defer cancel()
+	names, err := spfLookupAddr(ctx, remoteIP.String())
+	if err != nil {
+		return false, err
+	}
+	targetDomain = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(targetDomain), "."))
+	for _, n := range names {
+		host := strings.ToLower(strings.TrimSuffix(strings.TrimSpace(n), "."))
+		if !domainMatches(host, targetDomain) {
+			continue
+		}
+		ips, err := spfLookupIP(ctx, host)
+		if err != nil {
+			continue
+		}
+		for _, ip := range ips {
+			if ip.Equal(remoteIP) {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func domainMatches(host, domain string) bool {
+	if host == "" || domain == "" {
+		return false
+	}
+	if host == domain {
+		return true
+	}
+	return strings.HasSuffix(host, "."+domain)
 }
 
 func expandSPFMacros(spec, sender, domain, helo string, remoteIP net.IP) string {
@@ -330,4 +426,24 @@ func matchPrefix(a, b net.IP, p int) bool {
 	}
 	pref := netip.PrefixFrom(aa.Unmap(), p)
 	return pref.Contains(bb.Unmap())
+}
+
+func lookupSPFExplanation(ctx context.Context, domain string) (string, bool) {
+	ctx, cancel := context.WithTimeout(ctx, 4*time.Second)
+	defer cancel()
+	txt, err := spfLookupTXT(ctx, domain)
+	if err != nil || len(txt) == 0 {
+		return "", false
+	}
+	for _, v := range txt {
+		s := strings.TrimSpace(v)
+		if s == "" {
+			continue
+		}
+		if strings.HasPrefix(strings.ToLower(s), "v=spf1") {
+			continue
+		}
+		return s, true
+	}
+	return "", false
 }

--- a/internal/mailauth/spf_macro_test.go
+++ b/internal/mailauth/spf_macro_test.go
@@ -44,6 +44,144 @@ func TestEvalSPF_MacroExpansionForAAndInclude(t *testing.T) {
 	}
 }
 
+func TestEvalSPF_ExistsMechanism(t *testing.T) {
+	origTXT := spfLookupTXT
+	origIP := spfLookupIP
+	origMX := spfLookupMX
+	origAddr := spfLookupAddr
+	t.Cleanup(func() {
+		spfLookupTXT = origTXT
+		spfLookupIP = origIP
+		spfLookupMX = origMX
+		spfLookupAddr = origAddr
+	})
+
+	spfLookupTXT = func(_ context.Context, domain string) ([]string, error) {
+		if strings.EqualFold(domain, "example.com") {
+			return []string{"v=spf1 exists:%{l}.exists.example.net -all"}, nil
+		}
+		return nil, nil
+	}
+	spfLookupIP = func(_ context.Context, host string) ([]net.IP, error) {
+		if strings.EqualFold(host, "sender.exists.example.net") {
+			return []net.IP{net.ParseIP("203.0.113.10")}, nil
+		}
+		return nil, nil
+	}
+	spfLookupMX = func(_ context.Context, domain string) ([]*net.MX, error) { return nil, nil }
+	spfLookupAddr = func(_ context.Context, addr string) ([]string, error) { return nil, nil }
+
+	res := EvalSPF(net.ParseIP("192.0.2.1"), "sender@example.com", "mx.example.com")
+	if res.Result != "pass" {
+		t.Fatalf("result=%q reason=%q", res.Result, res.Reason)
+	}
+}
+
+func TestEvalSPF_PTRMechanism(t *testing.T) {
+	origTXT := spfLookupTXT
+	origIP := spfLookupIP
+	origMX := spfLookupMX
+	origAddr := spfLookupAddr
+	t.Cleanup(func() {
+		spfLookupTXT = origTXT
+		spfLookupIP = origIP
+		spfLookupMX = origMX
+		spfLookupAddr = origAddr
+	})
+
+	spfLookupTXT = func(_ context.Context, domain string) ([]string, error) {
+		if strings.EqualFold(domain, "example.com") {
+			return []string{"v=spf1 ptr:trusted.example.net -all"}, nil
+		}
+		return nil, nil
+	}
+	spfLookupAddr = func(_ context.Context, addr string) ([]string, error) {
+		if addr == "198.51.100.10" {
+			return []string{"mx.trusted.example.net."}, nil
+		}
+		return nil, nil
+	}
+	spfLookupIP = func(_ context.Context, host string) ([]net.IP, error) {
+		if strings.EqualFold(host, "mx.trusted.example.net") {
+			return []net.IP{net.ParseIP("198.51.100.10")}, nil
+		}
+		return nil, nil
+	}
+	spfLookupMX = func(_ context.Context, domain string) ([]*net.MX, error) { return nil, nil }
+
+	res := EvalSPF(net.ParseIP("198.51.100.10"), "sender@example.com", "mx.example.com")
+	if res.Result != "pass" {
+		t.Fatalf("result=%q reason=%q", res.Result, res.Reason)
+	}
+}
+
+func TestEvalSPF_RedirectModifier(t *testing.T) {
+	origTXT := spfLookupTXT
+	origIP := spfLookupIP
+	origMX := spfLookupMX
+	origAddr := spfLookupAddr
+	t.Cleanup(func() {
+		spfLookupTXT = origTXT
+		spfLookupIP = origIP
+		spfLookupMX = origMX
+		spfLookupAddr = origAddr
+	})
+
+	spfLookupTXT = func(_ context.Context, domain string) ([]string, error) {
+		switch strings.ToLower(domain) {
+		case "example.com":
+			return []string{"v=spf1 redirect=spf.redirect.example.net"}, nil
+		case "spf.redirect.example.net":
+			return []string{"v=spf1 ip4:203.0.113.9 -all"}, nil
+		default:
+			return nil, nil
+		}
+	}
+	spfLookupIP = func(_ context.Context, host string) ([]net.IP, error) { return nil, nil }
+	spfLookupMX = func(_ context.Context, domain string) ([]*net.MX, error) { return nil, nil }
+	spfLookupAddr = func(_ context.Context, addr string) ([]string, error) { return nil, nil }
+
+	res := EvalSPF(net.ParseIP("203.0.113.9"), "sender@example.com", "mx.example.com")
+	if res.Result != "pass" {
+		t.Fatalf("result=%q reason=%q", res.Result, res.Reason)
+	}
+}
+
+func TestEvalSPF_ExpModifierForFail(t *testing.T) {
+	origTXT := spfLookupTXT
+	origIP := spfLookupIP
+	origMX := spfLookupMX
+	origAddr := spfLookupAddr
+	t.Cleanup(func() {
+		spfLookupTXT = origTXT
+		spfLookupIP = origIP
+		spfLookupMX = origMX
+		spfLookupAddr = origAddr
+	})
+
+	spfLookupTXT = func(_ context.Context, domain string) ([]string, error) {
+		switch strings.ToLower(domain) {
+		case "example.com":
+			return []string{"v=spf1 -all exp=explain.example.com"}, nil
+		case "explain.example.com":
+			return []string{"Mail from this source is not permitted."}, nil
+		default:
+			return nil, nil
+		}
+	}
+	spfLookupIP = func(_ context.Context, host string) ([]net.IP, error) { return nil, nil }
+	spfLookupMX = func(_ context.Context, domain string) ([]*net.MX, error) { return nil, nil }
+	spfLookupAddr = func(_ context.Context, addr string) ([]string, error) { return nil, nil }
+
+	res := EvalSPF(net.ParseIP("203.0.113.77"), "sender@example.com", "mx.example.com")
+	if res.Result != "fail" {
+		t.Fatalf("result=%q reason=%q", res.Result, res.Reason)
+	}
+	if !strings.Contains(res.Reason, "not permitted") {
+		t.Fatalf("unexpected exp reason=%q", res.Reason)
+	}
+}
+
 func TestExpandSPFMacros_BasicTokens(t *testing.T) {
 	ip := net.ParseIP("203.0.113.7")
 	got := expandSPFMacros("%{s}/%{l}/%{o}/%{d}/%{h}/%{i}/%{v}/%%/%_/%-", "Alice@Example.com", "example.com", "Mail.EXAMPLE.com", ip)


### PR DESCRIPTION
## 概要
- RFC 7208 の未対応要素だった `exists` / `ptr` メカニズム、および `redirect` / `exp` modifier を実装しました。

## 変更内容
- `internal/mailauth/spf.go`
  - `exists` メカニズムを実装
  - `ptr` メカニズムを実装（PTR逆引き + 前引き一致確認）
  - `redirect=` modifier を実装（未一致時のポリシー委譲）
  - `exp=` modifier を実装（fail時の説明文反映）
  - DNS解決関数を差し替え可能にし、テスト容易性を向上
  - modifierを先に解釈する2パス評価に変更
- `internal/mailauth/spf_macro_test.go`
  - `exists`/`ptr`/`redirect`/`exp` のユニットテストを追加

## テスト
- `go test ./internal/mailauth -run SPF -v`
- `go test ./...`

Closes #52
