### PR TITLE
feat: RFC7208 include/redirect循環時のpermerror判定を精緻化

### DIFF
--- a/internal/mailauth/spf.go
+++ b/internal/mailauth/spf.go
@@ -21,6 +21,7 @@ const (
 var (
 	errSPFLookupLimit     = errors.New("spf dns lookup limit exceeded")
 	errSPFVoidLookupLimit = errors.New("spf void lookup limit exceeded")
+	errSPFCyclicReference = errors.New("spf cyclic include/redirect detected")
 )
 
 var (
@@ -62,8 +63,21 @@ func evalSPFDomain(ctx context.Context, remoteIP net.IP, domain, sender, helo st
 	if depth > 10 {
 		return "permerror", "include recursion too deep"
 	}
+	domain = strings.ToLower(strings.TrimSpace(domain))
+	if domain == "" {
+		return "permerror", "invalid domain"
+	}
+	if !st.enterDomain(domain) {
+		return "permerror", errSPFCyclicReference.Error()
+	}
+	defer st.leaveDomain(domain)
+
 	record, ok, err := lookupSPFRecord(ctx, domain, st)
 	if err != nil {
+		var rerr *spfResultError
+		if errors.As(err, &rerr) {
+			return rerr.Result, rerr.Reason
+		}
 		if errors.Is(err, errSPFLookupLimit) || errors.Is(err, errSPFVoidLookupLimit) {
 			return "permerror", err.Error()
 		}
@@ -110,6 +124,10 @@ func evalSPFDomain(ctx context.Context, remoteIP net.IP, domain, sender, helo st
 		arg = expandSPFMacros(arg, sender, domain, helo, remoteIP)
 		match, ok, err := matchMechanism(ctx, remoteIP, domain, sender, helo, name, arg, prefix, depth, st)
 		if err != nil {
+			var rerr *spfResultError
+			if errors.As(err, &rerr) {
+				return rerr.Result, rerr.Reason
+			}
 			if errors.Is(err, errSPFLookupLimit) || errors.Is(err, errSPFVoidLookupLimit) {
 				return "permerror", err.Error()
 			}
@@ -211,9 +229,12 @@ func matchMechanism(ctx context.Context, remoteIP net.IP, domain, sender, helo, 
 		if arg == "" {
 			return false, true, nil
 		}
-		res, _ := evalSPFDomain(ctx, remoteIP, arg, sender, helo, depth+1, st)
+		res, reason := evalSPFDomain(ctx, remoteIP, arg, sender, helo, depth+1, st)
 		if res == "pass" {
 			return true, true, nil
+		}
+		if res == "permerror" || res == "temperror" {
+			return false, true, &spfResultError{Result: res, Reason: reason}
 		}
 		return false, true, nil
 	case "exists":
@@ -469,6 +490,37 @@ func lookupSPFExplanation(ctx context.Context, domain string) (string, bool) {
 type spfEvalState struct {
 	lookups     int
 	voidLookups int
+	active      map[string]struct{}
+}
+
+type spfResultError struct {
+	Result string
+	Reason string
+}
+
+func (e *spfResultError) Error() string {
+	return e.Result + ": " + e.Reason
+}
+
+func (s *spfEvalState) enterDomain(domain string) bool {
+	if s == nil {
+		return true
+	}
+	if s.active == nil {
+		s.active = map[string]struct{}{}
+	}
+	if _, exists := s.active[domain]; exists {
+		return false
+	}
+	s.active[domain] = struct{}{}
+	return true
+}
+
+func (s *spfEvalState) leaveDomain(domain string) {
+	if s == nil || s.active == nil {
+		return
+	}
+	delete(s.active, domain)
 }
 
 func (s *spfEvalState) consumeLookup() error {

--- a/internal/mailauth/spf_macro_test.go
+++ b/internal/mailauth/spf_macro_test.go
@@ -2,6 +2,7 @@ package mailauth
 
 import (
 	"context"
+	"errors"
 	"net"
 	"strings"
 	"testing"
@@ -253,6 +254,144 @@ func TestEvalSPF_VoidLookupLimitExceeded(t *testing.T) {
 		t.Fatalf("result=%q reason=%q", res.Result, res.Reason)
 	}
 	if !strings.Contains(strings.ToLower(res.Reason), "void lookup") {
+		t.Fatalf("unexpected reason=%q", res.Reason)
+	}
+}
+
+func TestEvalSPF_IncludePermerrorPropagates(t *testing.T) {
+	origTXT := spfLookupTXT
+	origIP := spfLookupIP
+	origMX := spfLookupMX
+	origAddr := spfLookupAddr
+	t.Cleanup(func() {
+		spfLookupTXT = origTXT
+		spfLookupIP = origIP
+		spfLookupMX = origMX
+		spfLookupAddr = origAddr
+	})
+
+	spfLookupTXT = func(_ context.Context, domain string) ([]string, error) {
+		switch strings.ToLower(domain) {
+		case "example.com":
+			return []string{"v=spf1 include:bad.example.net -all"}, nil
+		case "bad.example.net":
+			return []string{"v=spf1x -all"}, nil
+		default:
+			return nil, nil
+		}
+	}
+	spfLookupIP = func(_ context.Context, host string) ([]net.IP, error) { return nil, nil }
+	spfLookupMX = func(_ context.Context, domain string) ([]*net.MX, error) { return nil, nil }
+	spfLookupAddr = func(_ context.Context, addr string) ([]string, error) { return nil, nil }
+
+	res := EvalSPF(net.ParseIP("203.0.113.10"), "sender@example.com", "mx.example.com")
+	if res.Result != "permerror" {
+		t.Fatalf("result=%q reason=%q", res.Result, res.Reason)
+	}
+}
+
+func TestEvalSPF_IncludeTemperrorPropagates(t *testing.T) {
+	origTXT := spfLookupTXT
+	origIP := spfLookupIP
+	origMX := spfLookupMX
+	origAddr := spfLookupAddr
+	t.Cleanup(func() {
+		spfLookupTXT = origTXT
+		spfLookupIP = origIP
+		spfLookupMX = origMX
+		spfLookupAddr = origAddr
+	})
+
+	spfLookupTXT = func(_ context.Context, domain string) ([]string, error) {
+		switch strings.ToLower(domain) {
+		case "example.com":
+			return []string{"v=spf1 include:tmp.example.net -all"}, nil
+		case "tmp.example.net":
+			return nil, errors.New("dns timeout")
+		default:
+			return nil, nil
+		}
+	}
+	spfLookupIP = func(_ context.Context, host string) ([]net.IP, error) { return nil, nil }
+	spfLookupMX = func(_ context.Context, domain string) ([]*net.MX, error) { return nil, nil }
+	spfLookupAddr = func(_ context.Context, addr string) ([]string, error) { return nil, nil }
+
+	res := EvalSPF(net.ParseIP("203.0.113.10"), "sender@example.com", "mx.example.com")
+	if res.Result != "temperror" {
+		t.Fatalf("result=%q reason=%q", res.Result, res.Reason)
+	}
+}
+
+func TestEvalSPF_CyclicIncludeReturnsPermerror(t *testing.T) {
+	origTXT := spfLookupTXT
+	origIP := spfLookupIP
+	origMX := spfLookupMX
+	origAddr := spfLookupAddr
+	t.Cleanup(func() {
+		spfLookupTXT = origTXT
+		spfLookupIP = origIP
+		spfLookupMX = origMX
+		spfLookupAddr = origAddr
+	})
+
+	spfLookupTXT = func(_ context.Context, domain string) ([]string, error) {
+		switch strings.ToLower(domain) {
+		case "example.com":
+			return []string{"v=spf1 include:a.example.net -all"}, nil
+		case "a.example.net":
+			return []string{"v=spf1 include:b.example.net -all"}, nil
+		case "b.example.net":
+			return []string{"v=spf1 include:a.example.net -all"}, nil
+		default:
+			return nil, nil
+		}
+	}
+	spfLookupIP = func(_ context.Context, host string) ([]net.IP, error) { return nil, nil }
+	spfLookupMX = func(_ context.Context, domain string) ([]*net.MX, error) { return nil, nil }
+	spfLookupAddr = func(_ context.Context, addr string) ([]string, error) { return nil, nil }
+
+	res := EvalSPF(net.ParseIP("203.0.113.10"), "sender@example.com", "mx.example.com")
+	if res.Result != "permerror" {
+		t.Fatalf("result=%q reason=%q", res.Result, res.Reason)
+	}
+	if !strings.Contains(strings.ToLower(res.Reason), "cyclic") {
+		t.Fatalf("unexpected reason=%q", res.Reason)
+	}
+}
+
+func TestEvalSPF_CyclicRedirectReturnsPermerror(t *testing.T) {
+	origTXT := spfLookupTXT
+	origIP := spfLookupIP
+	origMX := spfLookupMX
+	origAddr := spfLookupAddr
+	t.Cleanup(func() {
+		spfLookupTXT = origTXT
+		spfLookupIP = origIP
+		spfLookupMX = origMX
+		spfLookupAddr = origAddr
+	})
+
+	spfLookupTXT = func(_ context.Context, domain string) ([]string, error) {
+		switch strings.ToLower(domain) {
+		case "example.com":
+			return []string{"v=spf1 redirect=a.example.net"}, nil
+		case "a.example.net":
+			return []string{"v=spf1 redirect=b.example.net"}, nil
+		case "b.example.net":
+			return []string{"v=spf1 redirect=a.example.net"}, nil
+		default:
+			return nil, nil
+		}
+	}
+	spfLookupIP = func(_ context.Context, host string) ([]net.IP, error) { return nil, nil }
+	spfLookupMX = func(_ context.Context, domain string) ([]*net.MX, error) { return nil, nil }
+	spfLookupAddr = func(_ context.Context, addr string) ([]string, error) { return nil, nil }
+
+	res := EvalSPF(net.ParseIP("203.0.113.10"), "sender@example.com", "mx.example.com")
+	if res.Result != "permerror" {
+		t.Fatalf("result=%q reason=%q", res.Result, res.Reason)
+	}
+	if !strings.Contains(strings.ToLower(res.Reason), "cyclic") {
 		t.Fatalf("unexpected reason=%q", res.Reason)
 	}
 }


### PR DESCRIPTION
## 概要
- RFC 7208に沿って、`include`/`redirect`/循環参照時の判定を精緻化しました。

## 変更内容
- `internal/mailauth/spf.go`
  - SPF評価状態に `active domain` 追跡を追加し、循環参照（include/redirect loop）を検出して `permerror` を返す
  - `include` 評価時に、子評価の `permerror` / `temperror` を上位へ正しく伝播
  - 再帰評価ドメインを正規化（lowercase/trim）
  - SPF内部結果を伝播するための内部エラー型を追加
- `internal/mailauth/spf_macro_test.go`
  - include先の `permerror` 伝播テストを追加
  - include先の `temperror` 伝播テストを追加
  - include循環参照の `permerror` テストを追加
  - redirect循環参照の `permerror` テストを追加

## テスト
- `go test ./internal/mailauth -run SPF -v`
- `go test ./...`

Closes #54
