### PR TITLE
feat: RFC7208 HELO/MAIL FROM SPFポリシー分離を実装

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,8 @@ type Config struct {
 	DKIMSignSelector           string
 	DKIMPrivateKeyFile         string
 	DKIMSignHeaders            string
+	SPFHeloPolicy              string
+	SPFMailFromPolicy          string
 	DomainMaxConcurrentDefault int
 	DomainMaxConcurrentRules   string
 	DomainAdaptiveThrottle     bool
@@ -112,6 +114,8 @@ func Load() Config {
 		DKIMSignSelector:           env("MTA_DKIM_SIGN_SELECTOR", ""),
 		DKIMPrivateKeyFile:         env("MTA_DKIM_PRIVATE_KEY_FILE", ""),
 		DKIMSignHeaders:            env("MTA_DKIM_SIGN_HEADERS", "from:to:subject:date:message-id"),
+		SPFHeloPolicy:              envEnum("MTA_SPF_HELO_POLICY", "advisory", []string{"off", "advisory", "enforce"}),
+		SPFMailFromPolicy:          envEnum("MTA_SPF_MAILFROM_POLICY", "advisory", []string{"off", "advisory", "enforce"}),
 		DomainMaxConcurrentDefault: envInt("MTA_DOMAIN_MAX_CONCURRENT_DEFAULT", 8),
 		DomainMaxConcurrentRules:   env("MTA_DOMAIN_MAX_CONCURRENT_RULES", ""),
 		DomainAdaptiveThrottle:     envBool("MTA_DOMAIN_ADAPTIVE_THROTTLE", true),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -128,6 +128,28 @@ func TestLoadDKIMSigningConfig(t *testing.T) {
 	}
 }
 
+func TestLoadSPFPolicyConfig(t *testing.T) {
+	t.Setenv("MTA_SPF_HELO_POLICY", "off")
+	t.Setenv("MTA_SPF_MAILFROM_POLICY", "advisory")
+	cfg := Load()
+	if cfg.SPFHeloPolicy != "off" {
+		t.Fatalf("helo policy=%q", cfg.SPFHeloPolicy)
+	}
+	if cfg.SPFMailFromPolicy != "advisory" {
+		t.Fatalf("mailfrom policy=%q", cfg.SPFMailFromPolicy)
+	}
+
+	t.Setenv("MTA_SPF_HELO_POLICY", "invalid")
+	t.Setenv("MTA_SPF_MAILFROM_POLICY", "invalid")
+	cfg = Load()
+	if cfg.SPFHeloPolicy != "advisory" {
+		t.Fatalf("helo invalid should fallback, got=%q", cfg.SPFHeloPolicy)
+	}
+	if cfg.SPFMailFromPolicy != "advisory" {
+		t.Fatalf("mailfrom invalid should fallback, got=%q", cfg.SPFMailFromPolicy)
+	}
+}
+
 func TestLoadDomainThrottleConfig(t *testing.T) {
 	t.Setenv("MTA_DOMAIN_MAX_CONCURRENT_DEFAULT", "4")
 	t.Setenv("MTA_DOMAIN_MAX_CONCURRENT_RULES", "gmail.com:2,yahoo.com:1")

--- a/internal/mailauth/pipeline.go
+++ b/internal/mailauth/pipeline.go
@@ -6,7 +6,32 @@ import (
 	"strings"
 )
 
+type SPFPolicy struct {
+	HeloMode     string
+	MailFromMode string
+}
+
+func DefaultSPFPolicy() SPFPolicy {
+	return SPFPolicy{
+		HeloMode:     "advisory",
+		MailFromMode: "advisory",
+	}
+}
+
+func normalizeSPFMode(v, def string) string {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "off", "advisory", "enforce":
+		return strings.ToLower(strings.TrimSpace(v))
+	default:
+		return def
+	}
+}
+
 func Evaluate(remoteIP net.IP, helo, mailFrom string, raw []byte) Result {
+	return EvaluateWithPolicy(remoteIP, helo, mailFrom, raw, DefaultSPFPolicy())
+}
+
+func EvaluateWithPolicy(remoteIP net.IP, helo, mailFrom string, raw []byte, policy SPFPolicy) Result {
 	headerPart, bodyPart, err := SplitMessage(raw)
 	if err != nil {
 		return Result{Action: ActionReject, Reason: "invalid message format"}
@@ -16,13 +41,46 @@ func Evaluate(remoteIP net.IP, helo, mailFrom string, raw []byte) Result {
 		return Result{Action: ActionReject, Reason: "invalid headers"}
 	}
 
-	spf := EvalSPF(remoteIP, mailFrom, helo)
+	heloMode := normalizeSPFMode(policy.HeloMode, "advisory")
+	mailFromMode := normalizeSPFMode(policy.MailFromMode, "advisory")
+
+	spfHelo := SPFResult{Result: "none", Reason: "helo spf disabled"}
+	if heloMode != "off" {
+		spfHelo = EvalSPFHelo(remoteIP, helo)
+	}
+	spfMailFrom := SPFResult{Result: "none", Reason: "mailfrom spf disabled"}
+	if mailFromMode != "off" {
+		spfMailFrom = EvalSPFMailFrom(remoteIP, mailFrom, helo)
+	}
+	effectiveSPF := spfMailFrom
+	if strings.TrimSpace(mailFrom) == "" || mailFromMode == "off" {
+		effectiveSPF = spfHelo
+	}
+
 	dkim := EvalDKIM(headers, bodyPart)
 	arc := EvalARC(headers)
 	fromDomain := ExtractFromDomain(headers)
-	dmarc := EvalDMARC(fromDomain, spf, dkim)
+	dmarc := EvalDMARC(fromDomain, effectiveSPF, dkim)
 
-	result := Result{SPF: spf, DKIM: dkim, ARC: arc, DMARC: dmarc, Action: ActionAccept}
+	result := Result{
+		SPF:         effectiveSPF,
+		SPFHelo:     spfHelo,
+		SPFMailFrom: spfMailFrom,
+		DKIM:        dkim,
+		ARC:         arc,
+		DMARC:       dmarc,
+		Action:      ActionAccept,
+	}
+	if heloMode == "enforce" && spfRejected(spfHelo.Result) {
+		result.Action = ActionReject
+		result.Reason = "spf helo policy"
+		return result
+	}
+	if mailFromMode == "enforce" && strings.TrimSpace(mailFrom) != "" && spfRejected(spfMailFrom.Result) {
+		result.Action = ActionReject
+		result.Reason = "spf mailfrom policy"
+		return result
+	}
 	switch strings.ToLower(dmarc.Result) {
 	case "pass", "none":
 		result.Action = ActionAccept
@@ -41,6 +99,15 @@ func Evaluate(remoteIP net.IP, helo, mailFrom string, raw []byte) Result {
 		result.Action = ActionAccept
 	}
 	return result
+}
+
+func spfRejected(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "fail", "softfail", "permerror", "temperror":
+		return true
+	default:
+		return false
+	}
 }
 
 func BuildAuthResultsHeader(hostname string, res Result, mailFrom string) string {

--- a/internal/mailauth/pipeline_test.go
+++ b/internal/mailauth/pipeline_test.go
@@ -1,6 +1,8 @@
 package mailauth
 
 import (
+	"context"
+	"net"
 	"strings"
 	"testing"
 )
@@ -42,5 +44,89 @@ func TestInjectHeaders(t *testing.T) {
 	}
 	if !strings.HasSuffix(got, "\r\n\r\nbody") {
 		t.Fatalf("body separator not preserved: %q", got)
+	}
+}
+
+func TestEvaluateWithPolicy_SeparateHeloAndMailFromModes(t *testing.T) {
+	origTXT := spfLookupTXT
+	origIP := spfLookupIP
+	origMX := spfLookupMX
+	origAddr := spfLookupAddr
+	t.Cleanup(func() {
+		spfLookupTXT = origTXT
+		spfLookupIP = origIP
+		spfLookupMX = origMX
+		spfLookupAddr = origAddr
+	})
+
+	spfLookupTXT = func(_ context.Context, domain string) ([]string, error) {
+		switch strings.ToLower(domain) {
+		case "bad-helo.example.net":
+			return []string{"v=spf1 -all"}, nil
+		case "example.com":
+			return []string{"v=spf1 ip4:192.0.2.10 -all"}, nil
+		default:
+			return nil, nil
+		}
+	}
+	spfLookupIP = func(_ context.Context, host string) ([]net.IP, error) { return nil, nil }
+	spfLookupMX = func(_ context.Context, domain string) ([]*net.MX, error) { return nil, nil }
+	spfLookupAddr = func(_ context.Context, addr string) ([]string, error) { return nil, nil }
+
+	raw := []byte("From: sender@example.com\r\nTo: rcpt@example.net\r\nSubject: x\r\n\r\nbody")
+
+	heloEnforce := EvaluateWithPolicy(net.ParseIP("192.0.2.10"), "bad-helo.example.net", "sender@example.com", raw, SPFPolicy{
+		HeloMode:     "enforce",
+		MailFromMode: "advisory",
+	})
+	if heloEnforce.Action != ActionReject || heloEnforce.Reason != "spf helo policy" {
+		t.Fatalf("helo enforce should reject, action=%s reason=%q", heloEnforce.Action, heloEnforce.Reason)
+	}
+	if heloEnforce.SPFHelo.Result != "fail" || heloEnforce.SPFMailFrom.Result != "pass" {
+		t.Fatalf("unexpected spf results: helo=%+v mailfrom=%+v", heloEnforce.SPFHelo, heloEnforce.SPFMailFrom)
+	}
+
+	heloAdvisory := EvaluateWithPolicy(net.ParseIP("192.0.2.10"), "bad-helo.example.net", "sender@example.com", raw, SPFPolicy{
+		HeloMode:     "advisory",
+		MailFromMode: "advisory",
+	})
+	if heloAdvisory.Action == ActionReject && heloAdvisory.Reason == "spf helo policy" {
+		t.Fatalf("helo advisory should not enforce reject")
+	}
+}
+
+func TestEvaluateWithPolicy_MailFromEnforce(t *testing.T) {
+	origTXT := spfLookupTXT
+	origIP := spfLookupIP
+	origMX := spfLookupMX
+	origAddr := spfLookupAddr
+	t.Cleanup(func() {
+		spfLookupTXT = origTXT
+		spfLookupIP = origIP
+		spfLookupMX = origMX
+		spfLookupAddr = origAddr
+	})
+
+	spfLookupTXT = func(_ context.Context, domain string) ([]string, error) {
+		switch strings.ToLower(domain) {
+		case "ok-helo.example.net":
+			return []string{"v=spf1 ip4:198.51.100.20 -all"}, nil
+		case "example.com":
+			return []string{"v=spf1 -all"}, nil
+		default:
+			return nil, nil
+		}
+	}
+	spfLookupIP = func(_ context.Context, host string) ([]net.IP, error) { return nil, nil }
+	spfLookupMX = func(_ context.Context, domain string) ([]*net.MX, error) { return nil, nil }
+	spfLookupAddr = func(_ context.Context, addr string) ([]string, error) { return nil, nil }
+
+	raw := []byte("From: sender@example.com\r\nTo: rcpt@example.net\r\nSubject: x\r\n\r\nbody")
+	res := EvaluateWithPolicy(net.ParseIP("198.51.100.20"), "ok-helo.example.net", "sender@example.com", raw, SPFPolicy{
+		HeloMode:     "off",
+		MailFromMode: "enforce",
+	})
+	if res.Action != ActionReject || res.Reason != "spf mailfrom policy" {
+		t.Fatalf("mailfrom enforce should reject, action=%s reason=%q", res.Action, res.Reason)
 	}
 }

--- a/internal/mailauth/spf.go
+++ b/internal/mailauth/spf.go
@@ -40,8 +40,15 @@ var (
 )
 
 func EvalSPF(remoteIP net.IP, mailFrom, helo string) SPFResult {
-	domain := spfDomain(mailFrom, helo)
-	if domain == "" {
+	if strings.TrimSpace(mailFrom) != "" {
+		return EvalSPFMailFrom(remoteIP, mailFrom, helo)
+	}
+	return EvalSPFHelo(remoteIP, helo)
+}
+
+func EvalSPFMailFrom(remoteIP net.IP, mailFrom, helo string) SPFResult {
+	domain, ok := util.DomainOf(mailFrom)
+	if !ok {
 		return SPFResult{Result: "none", Reason: "no domain"}
 	}
 	if remoteIP == nil {
@@ -49,6 +56,19 @@ func EvalSPF(remoteIP net.IP, mailFrom, helo string) SPFResult {
 	}
 	state := &spfEvalState{}
 	res, reason := evalSPFDomain(context.Background(), remoteIP, domain, mailFrom, helo, 0, state)
+	return SPFResult{Domain: domain, Result: res, Reason: reason}
+}
+
+func EvalSPFHelo(remoteIP net.IP, helo string) SPFResult {
+	domain := strings.ToLower(strings.TrimSpace(helo))
+	if domain == "" {
+		return SPFResult{Result: "none", Reason: "no domain"}
+	}
+	if remoteIP == nil {
+		return SPFResult{Domain: domain, Result: "temperror", Reason: "missing remote ip"}
+	}
+	state := &spfEvalState{}
+	res, reason := evalSPFDomain(context.Background(), remoteIP, domain, "", helo, 0, state)
 	return SPFResult{Domain: domain, Result: res, Reason: reason}
 }
 

--- a/internal/mailauth/types.go
+++ b/internal/mailauth/types.go
@@ -9,12 +9,14 @@ const (
 )
 
 type Result struct {
-	SPF    SPFResult
-	DKIM   DKIMResult
-	DMARC  DMARCResult
-	ARC    ARCResult
-	Action Action
-	Reason string
+	SPF         SPFResult
+	SPFHelo     SPFResult
+	SPFMailFrom SPFResult
+	DKIM        DKIMResult
+	DMARC       DMARCResult
+	ARC         ARCResult
+	Action      Action
+	Reason      string
 }
 
 type SPFResult struct {

--- a/internal/smtp/server.go
+++ b/internal/smtp/server.go
@@ -320,7 +320,10 @@ func (s *Server) handleConn(conn net.Conn) {
 			if msgRemoteIP == nil {
 				msgRemoteIP = parseRemoteIP(ss.remote)
 			}
-			authRes := mailauth.Evaluate(msgRemoteIP, ss.helo, ss.mailFrom, ss.data)
+			authRes := mailauth.EvaluateWithPolicy(msgRemoteIP, ss.helo, ss.mailFrom, ss.data, mailauth.SPFPolicy{
+				HeloMode:     s.cfg.SPFHeloPolicy,
+				MailFromMode: s.cfg.SPFMailFromPolicy,
+			})
 			switch authRes.Action {
 			case mailauth.ActionReject:
 				writeResp(w, 550, "message rejected by auth policy")


### PR DESCRIPTION
## 概要
- SPF評価について、HELO系とMAIL FROM系のポリシーを分離し、運用設定可能にしました。

## 変更内容
- `internal/mailauth/pipeline.go`
  - `EvaluateWithPolicy` を追加
  - `SPFPolicy`（`HeloMode`/`MailFromMode`）を導入
  - 各モード `off|advisory|enforce` を実装
  - HELO SPF と MAIL FROM SPF を個別評価し、`enforce` 時のみ拒否
- `internal/mailauth/spf.go`
  - `EvalSPFHelo` / `EvalSPFMailFrom` を追加
  - 既存 `EvalSPF` は後方互換のラッパーへ
- `internal/mailauth/types.go`
  - `Result` に `SPFHelo` / `SPFMailFrom` を追加
- `internal/config/config.go`
  - `MTA_SPF_HELO_POLICY` / `MTA_SPF_MAILFROM_POLICY` を追加
- `internal/smtp/server.go`
  - SMTP受信で `EvaluateWithPolicy` を使用
- テスト追加
  - `internal/mailauth/pipeline_test.go`
  - `internal/config/config_test.go`

## テスト
- `go test ./internal/mailauth ./internal/config ./internal/smtp -v`
- `go test ./...`

Closes #55
