### PR TITLE
feat: RFC6376 複数DKIM署名の評価ルールを整理

### DIFF
--- a/internal/mailauth/dkim.go
+++ b/internal/mailauth/dkim.go
@@ -19,19 +19,42 @@ func EvalDKIM(headers []Header, body string) DKIMResult {
 		return DKIMResult{Result: "none"}
 	}
 	results := make([]DKIMSigResult, 0, len(dkims))
-	pass := false
 	for _, sig := range dkims {
 		r := verifyDKIMSig(headers, body, sig)
-		if r.Result == "pass" {
-			pass = true
-		}
 		results = append(results, r)
 	}
-	out := "fail"
-	if pass {
-		out = "pass"
+	return DKIMResult{Result: aggregateDKIMResults(results), Sigs: results}
+}
+
+func aggregateDKIMResults(results []DKIMSigResult) string {
+	if len(results) == 0 {
+		return "none"
 	}
-	return DKIMResult{Result: out, Sigs: results}
+	hasPermerror := false
+	hasTemperror := false
+	hasNeutral := false
+	for _, r := range results {
+		switch strings.ToLower(strings.TrimSpace(r.Result)) {
+		case "pass":
+			return "pass"
+		case "temperror":
+			hasTemperror = true
+		case "permerror":
+			hasPermerror = true
+		case "none":
+			hasNeutral = true
+		}
+	}
+	if hasTemperror {
+		return "temperror"
+	}
+	if hasPermerror {
+		return "permerror"
+	}
+	if hasNeutral {
+		return "none"
+	}
+	return "fail"
 }
 
 func verifyDKIMSig(headers []Header, body, sig string) DKIMSigResult {

--- a/internal/mailauth/dkim_test.go
+++ b/internal/mailauth/dkim_test.go
@@ -1,0 +1,78 @@
+package mailauth
+
+import "testing"
+
+func TestAggregateDKIMResults(t *testing.T) {
+	tests := []struct {
+		name    string
+		results []DKIMSigResult
+		want    string
+	}{
+		{
+			name:    "empty is none",
+			results: nil,
+			want:    "none",
+		},
+		{
+			name: "any pass wins",
+			results: []DKIMSigResult{
+				{Result: "fail"},
+				{Result: "pass"},
+				{Result: "temperror"},
+			},
+			want: "pass",
+		},
+		{
+			name: "temperror beats fail",
+			results: []DKIMSigResult{
+				{Result: "fail"},
+				{Result: "temperror"},
+			},
+			want: "temperror",
+		},
+		{
+			name: "permerror beats fail",
+			results: []DKIMSigResult{
+				{Result: "fail"},
+				{Result: "permerror"},
+			},
+			want: "permerror",
+		},
+		{
+			name: "temperror beats permerror",
+			results: []DKIMSigResult{
+				{Result: "permerror"},
+				{Result: "temperror"},
+			},
+			want: "temperror",
+		},
+		{
+			name: "all fail stays fail",
+			results: []DKIMSigResult{
+				{Result: "fail"},
+				{Result: "fail"},
+			},
+			want: "fail",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if got := aggregateDKIMResults(tc.results); got != tc.want {
+				t.Fatalf("got=%q want=%q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEvalDKIMWithoutSignatureReturnsNone(t *testing.T) {
+	headers := []Header{{Name: "From", Value: "sender@example.com"}}
+	got := EvalDKIM(headers, "body")
+	if got.Result != "none" {
+		t.Fatalf("result=%q want=none", got.Result)
+	}
+	if len(got.Sigs) != 0 {
+		t.Fatalf("len(sigs)=%d want=0", len(got.Sigs))
+	}
+}


### PR DESCRIPTION
## 概要
- 複数の `DKIM-Signature` がある場合の結果合成ルールを整理し、全体判定を安定化しました。

## 変更内容
- `internal/mailauth/dkim.go`
- 複数署名の結果を合成する `aggregateDKIMResults` を追加
- 合成ルールを明示化
- `pass` が1つでもあれば全体 `pass`
- `pass` がなく `temperror` があれば全体 `temperror`
- `pass` / `temperror` がなく `permerror` があれば全体 `permerror`
- それ以外は `fail`
- `internal/mailauth/dkim_test.go`
- 合成ルールのユニットテストを追加
- 署名なしで `none` になるテストを追加

## テスト
- `go test ./internal/mailauth -run DKIM -v`
- `go test ./...`

Closes #57
