### PR TITLE
feat: RFC6376 DKIM鍵取得失敗の分類を精緻化

### DIFF
--- a/internal/mailauth/dkim.go
+++ b/internal/mailauth/dkim.go
@@ -14,6 +14,10 @@ import (
 	"time"
 )
 
+var dkimLookupTXT = func(ctx context.Context, name string) ([]string, error) {
+	return net.DefaultResolver.LookupTXT(ctx, name)
+}
+
 func EvalDKIM(headers []Header, body string) DKIMResult {
 	dkims := HeaderValues(headers, "DKIM-Signature")
 	if len(dkims) == 0 {
@@ -91,6 +95,9 @@ func verifyDKIMSig(headers []Header, body, sig string) DKIMSigResult {
 	}
 	pub, err := lookupDKIMKey(domain, selector)
 	if err != nil {
+		if lerr, ok := err.(*dkimLookupError); ok {
+			return DKIMSigResult{Domain: domain, Selector: selector, Result: lerr.Result, Reason: lerr.Reason}
+		}
 		return DKIMSigResult{Domain: domain, Selector: selector, Result: "temperror", Reason: err.Error()}
 	}
 	sigBytes, err := base64.StdEncoding.DecodeString(compactBTag(tags["b"]))
@@ -233,7 +240,7 @@ func lookupDKIMKey(domain, selector string) (*rsa.PublicKey, error) {
 	q := selector + "._domainkey." + domain
 	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
 	defer cancel()
-	txt, err := net.DefaultResolver.LookupTXT(ctx, q)
+	txt, err := dkimLookupTXT(ctx, q)
 	if err != nil {
 		return nil, err
 	}
@@ -241,19 +248,19 @@ func lookupDKIMKey(domain, selector string) (*rsa.PublicKey, error) {
 	tags := parseTagList(all)
 	p := tags["p"]
 	if p == "" {
-		return nil, fmt.Errorf("missing p tag")
+		return nil, &dkimLookupError{Result: "permerror", Reason: "missing p tag"}
 	}
 	der, err := base64.StdEncoding.DecodeString(strings.TrimSpace(p))
 	if err != nil {
-		return nil, err
+		return nil, &dkimLookupError{Result: "permerror", Reason: "invalid p tag"}
 	}
 	pubAny, err := x509.ParsePKIXPublicKey(der)
 	if err != nil {
-		return nil, err
+		return nil, &dkimLookupError{Result: "permerror", Reason: "invalid public key"}
 	}
 	pub, ok := pubAny.(*rsa.PublicKey)
 	if !ok {
-		return nil, fmt.Errorf("non-rsa dkim key")
+		return nil, &dkimLookupError{Result: "permerror", Reason: "non-rsa dkim key"}
 	}
 	return pub, nil
 }
@@ -267,6 +274,15 @@ func equalBytes(a, b []byte) bool {
 		x |= a[i] ^ b[i]
 	}
 	return x == 0
+}
+
+type dkimLookupError struct {
+	Result string
+	Reason string
+}
+
+func (e *dkimLookupError) Error() string {
+	return e.Reason
 }
 
 func validateDKIMTimeTags(tags map[string]string, now time.Time) error {

--- a/internal/mailauth/dkim_test.go
+++ b/internal/mailauth/dkim_test.go
@@ -1,6 +1,13 @@
 package mailauth
 
 import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -180,4 +187,111 @@ func TestBuildSignedDataUsesHeadersFromBottom(t *testing.T) {
 	if strings.Contains(got, "Subject:first\r\n") {
 		t.Fatalf("signed data should use bottom-most subject, got=%q", got)
 	}
+}
+
+func TestLookupDKIMKeyClassifiesDNSAndKeyErrors(t *testing.T) {
+	origLookup := dkimLookupTXT
+	t.Cleanup(func() {
+		dkimLookupTXT = origLookup
+	})
+
+	tests := []struct {
+		name    string
+		txt     []string
+		err     error
+		wantRes string
+	}{
+		{
+			name:    "dns error is temperror",
+			err:     errors.New("dns timeout"),
+			wantRes: "temperror",
+		},
+		{
+			name:    "missing p tag is permerror",
+			txt:     []string{"v=DKIM1; k=rsa;"},
+			wantRes: "permerror",
+		},
+		{
+			name:    "invalid p tag is permerror",
+			txt:     []string{"v=DKIM1; k=rsa; p=!!!"},
+			wantRes: "permerror",
+		},
+		{
+			name:    "non rsa key is permerror",
+			txt:     []string{"v=DKIM1; k=rsa; p=" + mustEncodeEd25519PublicKey(t)},
+			wantRes: "permerror",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			dkimLookupTXT = func(_ context.Context, name string) ([]string, error) {
+				return tc.txt, tc.err
+			}
+			_, err := lookupDKIMKey("example.com", "s1")
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if tc.wantRes == "temperror" {
+				if _, ok := err.(*dkimLookupError); ok {
+					t.Fatalf("dns error should remain generic, got typed error: %v", err)
+				}
+				return
+			}
+			lerr, ok := err.(*dkimLookupError)
+			if !ok {
+				t.Fatalf("expected dkimLookupError, got %T", err)
+			}
+			if lerr.Result != tc.wantRes {
+				t.Fatalf("result=%q want=%q", lerr.Result, tc.wantRes)
+			}
+		})
+	}
+}
+
+func TestLookupDKIMKeyValidRSAKey(t *testing.T) {
+	origLookup := dkimLookupTXT
+	t.Cleanup(func() {
+		dkimLookupTXT = origLookup
+	})
+
+	pubDER := mustEncodeRSAPublicKey(t)
+	dkimLookupTXT = func(_ context.Context, name string) ([]string, error) {
+		return []string{"v=DKIM1; k=rsa; p=" + pubDER}, nil
+	}
+
+	pub, err := lookupDKIMKey("example.com", "s1")
+	if err != nil {
+		t.Fatalf("lookupDKIMKey: %v", err)
+	}
+	if pub == nil {
+		t.Fatal("expected rsa public key")
+	}
+}
+
+func mustEncodeRSAPublicKey(t *testing.T) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	der, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		t.Fatalf("MarshalPKIXPublicKey: %v", err)
+	}
+	return base64.StdEncoding.EncodeToString(der)
+}
+
+func mustEncodeEd25519PublicKey(t *testing.T) string {
+	t.Helper()
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		t.Fatalf("MarshalPKIXPublicKey: %v", err)
+	}
+	return base64.StdEncoding.EncodeToString(der)
 }


### PR DESCRIPTION
## 概要
- DKIM 鍵取得時のエラー分類を整理し、DNS障害と鍵レコード不正を区別するようにしました。

## 変更内容
- `internal/mailauth/dkim.go`
- `dkimLookupTXT` を差し替え可能にしてテストしやすく変更
- 鍵取得時の分類用 `dkimLookupError` を追加
- DNS取得失敗は `temperror`
- `p=` 欠落・不正base64・不正公開鍵・非RSA鍵は `permerror`
- verifier 側で分類済みエラーを尊重するように変更
- `internal/mailauth/dkim_test.go`
- DNS失敗/鍵不正/正常鍵のテストを追加

## テスト
- `go test ./internal/mailauth -run DKIM -v`
- `go test ./...`

Closes #60
