### PR TITLE
feat: RFC7489 DMARC主要タグの処理を実装

### DIFF
--- a/internal/mailauth/dmarc.go
+++ b/internal/mailauth/dmarc.go
@@ -10,6 +10,10 @@ import (
 	"github.com/tamago0224/orinoco-mta/internal/util"
 )
 
+var dmarcLookupTXT = func(ctx context.Context, name string) ([]string, error) {
+	return net.DefaultResolver.LookupTXT(ctx, name)
+}
+
 func EvalDMARC(fromDomain string, spf SPFResult, dkim DKIMResult) DMARCResult {
 	if fromDomain == "" {
 		return DMARCResult{Result: "permerror", Reason: "missing From domain"}
@@ -19,7 +23,7 @@ func EvalDMARC(fromDomain string, spf SPFResult, dkim DKIMResult) DMARCResult {
 		return DMARCResult{Domain: fromDomain, Result: "temperror", Reason: err.Error()}
 	}
 	if !ok {
-		return DMARCResult{Domain: fromDomain, Result: "none", Policy: "none", Reason: "no dmarc record"}
+		return DMARCResult{Domain: fromDomain, Result: "none", Policy: "none", SubdomainPolicy: "none", Percent: 100, ReportInterval: 86400, Reason: "no dmarc record"}
 	}
 	pol := parseTagList(rec)
 	aspf := pol["aspf"]
@@ -34,6 +38,16 @@ func EvalDMARC(fromDomain string, spf SPFResult, dkim DKIMResult) DMARCResult {
 	if policy == "" {
 		policy = "none"
 	}
+	subPolicy := strings.ToLower(pol["sp"])
+	if subPolicy == "" {
+		subPolicy = policy
+	}
+	percent := parseDMARCInt(pol["pct"], 100)
+	ri := parseDMARCInt(pol["ri"], 86400)
+	fo := parseDMARCList(pol["fo"], []string{"0"})
+	rf := parseDMARCList(pol["rf"], []string{"afrf"})
+	rua := parseDMARCList(pol["rua"], nil)
+	ruf := parseDMARCList(pol["ruf"], nil)
 
 	spfAligned := strings.EqualFold(spf.Result, "pass") && aligned(fromDomain, spf.Domain, aspf)
 	dkimAligned := false
@@ -44,9 +58,32 @@ func EvalDMARC(fromDomain string, spf SPFResult, dkim DKIMResult) DMARCResult {
 		}
 	}
 	if spfAligned || dkimAligned {
-		return DMARCResult{Domain: fromDomain, Result: "pass", Policy: policy}
+		return DMARCResult{
+			Domain:          fromDomain,
+			Result:          "pass",
+			Policy:          policy,
+			SubdomainPolicy: subPolicy,
+			Percent:         percent,
+			FailureOptions:  fo,
+			ReportFormat:    rf,
+			ReportInterval:  ri,
+			AggregateReport: rua,
+			FailureReport:   ruf,
+		}
 	}
-	return DMARCResult{Domain: fromDomain, Result: "fail", Policy: policy, Reason: "alignment failed"}
+	return DMARCResult{
+		Domain:          fromDomain,
+		Result:          "fail",
+		Policy:          policy,
+		SubdomainPolicy: subPolicy,
+		Percent:         percent,
+		FailureOptions:  fo,
+		ReportFormat:    rf,
+		ReportInterval:  ri,
+		AggregateReport: rua,
+		FailureReport:   ruf,
+		Reason:          "alignment failed",
+	}
 }
 
 func ExtractFromDomain(headers []Header) string {
@@ -81,7 +118,7 @@ func aligned(fromDomain, authDomain, mode string) bool {
 func lookupDMARC(domain string) (string, bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
 	defer cancel()
-	txt, err := net.DefaultResolver.LookupTXT(ctx, "_dmarc."+domain)
+	txt, err := dmarcLookupTXT(ctx, "_dmarc."+domain)
 	if err != nil {
 		return "", false, err
 	}
@@ -116,4 +153,44 @@ func organizationalDomain(domain string) string {
 		return labels[len(labels)-3] + "." + publicSuffix2
 	}
 	return publicSuffix2
+}
+
+func parseDMARCInt(v string, def int) int {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return def
+	}
+	n := 0
+	for _, ch := range v {
+		if ch < '0' || ch > '9' {
+			return def
+		}
+		n = n*10 + int(ch-'0')
+	}
+	return n
+}
+
+func parseDMARCList(v string, def []string) []string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		if def == nil {
+			return nil
+		}
+		out := make([]string, len(def))
+		copy(out, def)
+		return out
+	}
+	parts := strings.Split(v, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		s := strings.TrimSpace(p)
+		if s != "" {
+			out = append(out, s)
+		}
+	}
+	if len(out) == 0 && def != nil {
+		out = make([]string, len(def))
+		copy(out, def)
+	}
+	return out
 }

--- a/internal/mailauth/dmarc_test.go
+++ b/internal/mailauth/dmarc_test.go
@@ -1,49 +1,84 @@
 package mailauth
 
-import "testing"
+import (
+	"context"
+	"reflect"
+	"testing"
+)
 
-func TestExtractFromDomain(t *testing.T) {
-	headers := []Header{{Name: "From", Value: "Alice <alice@example.com>"}}
-	if got := ExtractFromDomain(headers); got != "example.com" {
-		t.Fatalf("got=%q", got)
+func TestEvalDMARCParsesMajorTags(t *testing.T) {
+	origLookup := dmarcLookupTXT
+	t.Cleanup(func() {
+		dmarcLookupTXT = origLookup
+	})
+
+	dmarcLookupTXT = func(_ context.Context, name string) ([]string, error) {
+		return []string{"v=DMARC1; p=reject; sp=quarantine; pct=25; fo=1:d:s; rf=afrf:iodef; ri=3600; rua=mailto:agg@example.com,mailto:agg2@example.com; ruf=mailto:fail@example.com"}, nil
+	}
+
+	res := EvalDMARC("example.com", SPFResult{Result: "pass", Domain: "example.com"}, DKIMResult{})
+	if res.Result != "pass" {
+		t.Fatalf("result=%q", res.Result)
+	}
+	if res.Policy != "reject" || res.SubdomainPolicy != "quarantine" {
+		t.Fatalf("policy=%q sp=%q", res.Policy, res.SubdomainPolicy)
+	}
+	if res.Percent != 25 || res.ReportInterval != 3600 {
+		t.Fatalf("pct=%d ri=%d", res.Percent, res.ReportInterval)
+	}
+	if !reflect.DeepEqual(res.FailureOptions, []string{"1:d:s"}) {
+		t.Fatalf("fo=%v", res.FailureOptions)
+	}
+	if !reflect.DeepEqual(res.ReportFormat, []string{"afrf:iodef"}) {
+		t.Fatalf("rf=%v", res.ReportFormat)
+	}
+	if !reflect.DeepEqual(res.AggregateReport, []string{"mailto:agg@example.com", "mailto:agg2@example.com"}) {
+		t.Fatalf("rua=%v", res.AggregateReport)
+	}
+	if !reflect.DeepEqual(res.FailureReport, []string{"mailto:fail@example.com"}) {
+		t.Fatalf("ruf=%v", res.FailureReport)
 	}
 }
 
-func TestAligned(t *testing.T) {
-	tests := []struct {
-		name       string
-		fromDomain string
-		authDomain string
-		mode       string
-		want       bool
-	}{
-		{name: "strict exact", fromDomain: "example.com", authDomain: "example.com", mode: "s", want: true},
-		{name: "strict subdomain no", fromDomain: "a.example.com", authDomain: "example.com", mode: "s", want: false},
-		{name: "relaxed subdomain yes", fromDomain: "a.example.com", authDomain: "example.com", mode: "r", want: true},
-		{name: "relaxed org domain co uk", fromDomain: "a.example.co.uk", authDomain: "b.example.co.uk", mode: "r", want: true},
-		{name: "relaxed unrelated", fromDomain: "example.com", authDomain: "example.net", mode: "r", want: false},
+func TestEvalDMARCDefaultsMajorTags(t *testing.T) {
+	origLookup := dmarcLookupTXT
+	t.Cleanup(func() {
+		dmarcLookupTXT = origLookup
+	})
+
+	dmarcLookupTXT = func(_ context.Context, name string) ([]string, error) {
+		return []string{"v=DMARC1; p=none"}, nil
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := aligned(tt.fromDomain, tt.authDomain, tt.mode); got != tt.want {
-				t.Fatalf("got=%v want=%v", got, tt.want)
-			}
-		})
+
+	res := EvalDMARC("example.com", SPFResult{Result: "fail", Domain: "other.example"}, DKIMResult{})
+	if res.Policy != "none" || res.SubdomainPolicy != "none" {
+		t.Fatalf("policy=%q sp=%q", res.Policy, res.SubdomainPolicy)
+	}
+	if res.Percent != 100 || res.ReportInterval != 86400 {
+		t.Fatalf("pct=%d ri=%d", res.Percent, res.ReportInterval)
+	}
+	if !reflect.DeepEqual(res.FailureOptions, []string{"0"}) {
+		t.Fatalf("fo=%v", res.FailureOptions)
+	}
+	if !reflect.DeepEqual(res.ReportFormat, []string{"afrf"}) {
+		t.Fatalf("rf=%v", res.ReportFormat)
+	}
+	if len(res.AggregateReport) != 0 || len(res.FailureReport) != 0 {
+		t.Fatalf("rua=%v ruf=%v", res.AggregateReport, res.FailureReport)
 	}
 }
 
-func TestOrganizationalDomain(t *testing.T) {
-	tests := []struct {
-		in   string
-		want string
-	}{
-		{in: "a.example.com", want: "example.com"},
-		{in: "a.example.co.uk", want: "example.co.uk"},
-		{in: "example", want: "example"},
+func TestParseDMARCHelpers(t *testing.T) {
+	if got := parseDMARCInt("42", 1); got != 42 {
+		t.Fatalf("parseDMARCInt=%d", got)
 	}
-	for _, tt := range tests {
-		if got := organizationalDomain(tt.in); got != tt.want {
-			t.Fatalf("in=%q got=%q want=%q", tt.in, got, tt.want)
-		}
+	if got := parseDMARCInt("bad", 1); got != 1 {
+		t.Fatalf("parseDMARCInt fallback=%d", got)
+	}
+	if got := parseDMARCList(" a , b ", nil); !reflect.DeepEqual(got, []string{"a", "b"}) {
+		t.Fatalf("parseDMARCList=%v", got)
+	}
+	if got := parseDMARCList("", []string{"x"}); !reflect.DeepEqual(got, []string{"x"}) {
+		t.Fatalf("parseDMARCList fallback=%v", got)
 	}
 }

--- a/internal/mailauth/types.go
+++ b/internal/mailauth/types.go
@@ -38,10 +38,17 @@ type DKIMResult struct {
 }
 
 type DMARCResult struct {
-	Domain string
-	Result string
-	Policy string
-	Reason string
+	Domain           string
+	Result           string
+	Policy           string
+	SubdomainPolicy  string
+	Percent          int
+	FailureOptions   []string
+	ReportFormat     []string
+	ReportInterval   int
+	AggregateReport  []string
+	FailureReport    []string
+	Reason           string
 }
 
 type ARCResult struct {


### PR DESCRIPTION
## 概要
- DMARC の主要タグ `sp/pct/fo/rf/ri/rua/ruf` を解釈し、評価結果へ反映するようにしました。

## 変更内容
- `internal/mailauth/dmarc.go`
- `sp` を解釈し、未指定時は `p` を継承
- `pct` / `ri` を数値化
- `fo` / `rf` / `rua` / `ruf` を配列として保持
- DMARC TXT 取得を差し替え可能にしてテスト容易性を改善
- `internal/mailauth/types.go`
- `DMARCResult` に主要タグの保持先を追加
- `internal/mailauth/dmarc_test.go`
- 主要タグのパーステストを追加
- 既定値の確認テストを追加

## テスト
- `go test ./internal/mailauth -run DMARC -v`
- `go test ./...`

Closes #62
