### PR TITLE
feat: RFC7489 サブドメインDMARCポリシー適用を厳密化

### DIFF
--- a/internal/mailauth/dmarc.go
+++ b/internal/mailauth/dmarc.go
@@ -18,7 +18,7 @@ func EvalDMARC(fromDomain string, spf SPFResult, dkim DKIMResult) DMARCResult {
 	if fromDomain == "" {
 		return DMARCResult{Result: "permerror", Reason: "missing From domain"}
 	}
-	rec, ok, err := lookupDMARC(fromDomain)
+	rec, policyDomain, ok, err := lookupDMARC(fromDomain)
 	if err != nil {
 		return DMARCResult{Domain: fromDomain, Result: "temperror", Reason: err.Error()}
 	}
@@ -42,6 +42,10 @@ func EvalDMARC(fromDomain string, spf SPFResult, dkim DKIMResult) DMARCResult {
 	if subPolicy == "" {
 		subPolicy = policy
 	}
+	effectivePolicy := policy
+	if !strings.EqualFold(strings.TrimSpace(fromDomain), strings.TrimSpace(policyDomain)) {
+		effectivePolicy = subPolicy
+	}
 	percent := parseDMARCInt(pol["pct"], 100)
 	ri := parseDMARCInt(pol["ri"], 86400)
 	fo := parseDMARCList(pol["fo"], []string{"0"})
@@ -61,7 +65,7 @@ func EvalDMARC(fromDomain string, spf SPFResult, dkim DKIMResult) DMARCResult {
 		return DMARCResult{
 			Domain:          fromDomain,
 			Result:          "pass",
-			Policy:          policy,
+			Policy:          effectivePolicy,
 			SubdomainPolicy: subPolicy,
 			Percent:         percent,
 			FailureOptions:  fo,
@@ -74,7 +78,7 @@ func EvalDMARC(fromDomain string, spf SPFResult, dkim DKIMResult) DMARCResult {
 	return DMARCResult{
 		Domain:          fromDomain,
 		Result:          "fail",
-		Policy:          policy,
+		Policy:          effectivePolicy,
 		SubdomainPolicy: subPolicy,
 		Percent:         percent,
 		FailureOptions:  fo,
@@ -115,7 +119,23 @@ func aligned(fromDomain, authDomain, mode string) bool {
 	return organizationalDomain(fromDomain) == organizationalDomain(authDomain)
 }
 
-func lookupDMARC(domain string) (string, bool, error) {
+func lookupDMARC(domain string) (record string, policyDomain string, ok bool, err error) {
+	domain = strings.ToLower(strings.Trim(strings.TrimSpace(domain), "."))
+	if domain == "" {
+		return "", "", false, nil
+	}
+	if rec, ok, err := lookupDMARCAt(domain); err != nil || ok {
+		return rec, domain, ok, err
+	}
+	org := organizationalDomain(domain)
+	if org != "" && org != domain {
+		rec, ok, err := lookupDMARCAt(org)
+		return rec, org, ok, err
+	}
+	return "", "", false, nil
+}
+
+func lookupDMARCAt(domain string) (string, bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
 	defer cancel()
 	txt, err := dmarcLookupTXT(ctx, "_dmarc."+domain)

--- a/internal/mailauth/dmarc_test.go
+++ b/internal/mailauth/dmarc_test.go
@@ -82,3 +82,51 @@ func TestParseDMARCHelpers(t *testing.T) {
 		t.Fatalf("parseDMARCList fallback=%v", got)
 	}
 }
+
+func TestEvalDMARC_SubdomainUsesSPTag(t *testing.T) {
+	origLookup := dmarcLookupTXT
+	t.Cleanup(func() {
+		dmarcLookupTXT = origLookup
+	})
+
+	dmarcLookupTXT = func(_ context.Context, name string) ([]string, error) {
+		switch name {
+		case "_dmarc.mail.example.com":
+			return nil, nil
+		case "_dmarc.example.com":
+			return []string{"v=DMARC1; p=reject; sp=quarantine"}, nil
+		default:
+			return nil, nil
+		}
+	}
+
+	res := EvalDMARC("mail.example.com", SPFResult{Result: "fail", Domain: "other.example"}, DKIMResult{})
+	if res.Policy != "quarantine" {
+		t.Fatalf("policy=%q want=quarantine", res.Policy)
+	}
+	if res.SubdomainPolicy != "quarantine" {
+		t.Fatalf("sp=%q want=quarantine", res.SubdomainPolicy)
+	}
+}
+
+func TestEvalDMARC_ExactDomainUsesPTag(t *testing.T) {
+	origLookup := dmarcLookupTXT
+	t.Cleanup(func() {
+		dmarcLookupTXT = origLookup
+	})
+
+	dmarcLookupTXT = func(_ context.Context, name string) ([]string, error) {
+		if name == "_dmarc.example.com" {
+			return []string{"v=DMARC1; p=reject; sp=quarantine"}, nil
+		}
+		return nil, nil
+	}
+
+	res := EvalDMARC("example.com", SPFResult{Result: "fail", Domain: "other.example"}, DKIMResult{})
+	if res.Policy != "reject" {
+		t.Fatalf("policy=%q want=reject", res.Policy)
+	}
+	if res.SubdomainPolicy != "quarantine" {
+		t.Fatalf("sp=%q want=quarantine", res.SubdomainPolicy)
+	}
+}


### PR DESCRIPTION
## 概要
- DMARC のサブドメインポリシー適用を厳密化し、組織ドメインへのフォールバック時に `sp` を適用するようにしました。

## 変更内容
- `internal/mailauth/dmarc.go`
- `_dmarc.<fromDomain>` が無い場合に組織ドメインの DMARC レコードへフォールバック
- レコード取得ドメインと評価対象ドメインが異なる場合は `sp` を有効ポリシーとして適用
- 取得ドメインが同一の場合は `p` を適用
- `internal/mailauth/dmarc_test.go`
- サブドメイン時に `sp` が使われるテストを追加
- ルートドメイン時に `p` が使われるテストを追加

## テスト
- `go test ./internal/mailauth -run DMARC -v`
- `go test ./...`

Closes #63
