### PR TITLE
feat: DMARC rua/ruf レポート生成とSMTP連携

### DIFF
--- a/internal/mailauth/dmarc_report.go
+++ b/internal/mailauth/dmarc_report.go
@@ -1,0 +1,84 @@
+package mailauth
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/tamago0224/orinoco-mta/internal/util"
+)
+
+type DMARCOutboundReport struct {
+	To      string
+	Subject string
+	Body    []byte
+}
+
+func BuildDMARCOutboundReports(res DMARCResult, fromDomain, hostname, msgID string, now time.Time) []DMARCOutboundReport {
+	out := make([]DMARCOutboundReport, 0, len(res.AggregateReport)+len(res.FailureReport))
+	for _, rua := range res.AggregateReport {
+		to, ok := parseDMARCReportURI(rua)
+		if !ok {
+			continue
+		}
+		body := strings.Join([]string{
+			"DMARC Aggregate Report",
+			fmt.Sprintf("domain: %s", fromDomain),
+			fmt.Sprintf("result: %s", res.Result),
+			fmt.Sprintf("policy: %s", res.Policy),
+			fmt.Sprintf("message-id: %s", msgID),
+			fmt.Sprintf("time: %s", now.UTC().Format(time.RFC3339)),
+			"",
+		}, "\n")
+		out = append(out, DMARCOutboundReport{
+			To:      to,
+			Subject: fmt.Sprintf("DMARC aggregate report for %s", fromDomain),
+			Body:    []byte(body),
+		})
+	}
+	if !strings.EqualFold(res.Result, "fail") {
+		return out
+	}
+	for _, ruf := range res.FailureReport {
+		to, ok := parseDMARCReportURI(ruf)
+		if !ok {
+			continue
+		}
+		body := strings.Join([]string{
+			"DMARC Failure Report",
+			fmt.Sprintf("domain: %s", fromDomain),
+			fmt.Sprintf("result: %s", res.Result),
+			fmt.Sprintf("policy: %s", res.Policy),
+			fmt.Sprintf("reason: %s", res.Reason),
+			fmt.Sprintf("message-id: %s", msgID),
+			fmt.Sprintf("reporter: %s", hostname),
+			fmt.Sprintf("time: %s", now.UTC().Format(time.RFC3339)),
+			"",
+		}, "\n")
+		out = append(out, DMARCOutboundReport{
+			To:      to,
+			Subject: fmt.Sprintf("DMARC failure report for %s", fromDomain),
+			Body:    []byte(body),
+		})
+	}
+	return out
+}
+
+func parseDMARCReportURI(v string) (string, bool) {
+	s := strings.TrimSpace(v)
+	if s == "" {
+		return "", false
+	}
+	if strings.HasPrefix(strings.ToLower(s), "mailto:") {
+		addr := strings.TrimSpace(s[len("mailto:"):])
+		if i := strings.Index(addr, "!"); i >= 0 {
+			addr = strings.TrimSpace(addr[:i])
+		}
+		norm, err := util.NormalizePath(addr)
+		if err != nil || norm == "" {
+			return "", false
+		}
+		return norm, true
+	}
+	return "", false
+}

--- a/internal/mailauth/dmarc_report_test.go
+++ b/internal/mailauth/dmarc_report_test.go
@@ -1,0 +1,68 @@
+package mailauth
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBuildDMARCOutboundReportsFailIncludesAggregateAndFailure(t *testing.T) {
+	now := time.Date(2026, 3, 14, 12, 0, 0, 0, time.UTC)
+	res := DMARCResult{
+		Result:          "fail",
+		Policy:          "reject",
+		Reason:          "alignment failed",
+		AggregateReport: []string{"mailto:agg@example.net", "https://ignored.example.net"},
+		FailureReport:   []string{"mailto:forensic@example.net!10m"},
+	}
+
+	got := BuildDMARCOutboundReports(res, "example.com", "mx.example.test", "msg-1", now)
+	if len(got) != 2 {
+		t.Fatalf("len=%d want=2", len(got))
+	}
+	if got[0].To != "agg@example.net" {
+		t.Fatalf("aggregate to=%q", got[0].To)
+	}
+	if got[1].To != "forensic@example.net" {
+		t.Fatalf("failure to=%q", got[1].To)
+	}
+}
+
+func TestBuildDMARCOutboundReportsPassSkipsFailure(t *testing.T) {
+	now := time.Date(2026, 3, 14, 12, 0, 0, 0, time.UTC)
+	res := DMARCResult{
+		Result:          "pass",
+		Policy:          "none",
+		AggregateReport: []string{"mailto:agg@example.net"},
+		FailureReport:   []string{"mailto:forensic@example.net"},
+	}
+
+	got := BuildDMARCOutboundReports(res, "example.com", "mx.example.test", "msg-1", now)
+	if len(got) != 1 {
+		t.Fatalf("len=%d want=1", len(got))
+	}
+	if got[0].To != "agg@example.net" {
+		t.Fatalf("to=%q", got[0].To)
+	}
+}
+
+func TestParseDMARCReportURI(t *testing.T) {
+	tests := []struct {
+		in string
+		to string
+		ok bool
+	}{
+		{in: "mailto:agg@example.net", to: "agg@example.net", ok: true},
+		{in: "mailto:<Agg@Example.NET>", to: "agg@example.net", ok: true},
+		{in: "mailto:forensic@example.net!50k", to: "forensic@example.net", ok: true},
+		{in: "https://example.net", ok: false},
+		{in: "mailto:bad address@example.net", ok: false},
+		{in: "mailto:", ok: false},
+	}
+
+	for _, tt := range tests {
+		gotTo, gotOK := parseDMARCReportURI(tt.in)
+		if gotTo != tt.to || gotOK != tt.ok {
+			t.Fatalf("in=%q got=(%q,%v) want=(%q,%v)", tt.in, gotTo, gotOK, tt.to, tt.ok)
+		}
+	}
+}

--- a/internal/smtp/server.go
+++ b/internal/smtp/server.go
@@ -134,6 +134,8 @@ var (
 	errSMTPUTF8Address      = errors.New("smtputf8 address is not supported")
 	errDataLineTooLong      = errors.New("data line too long")
 	errMessageTooLarge      = errors.New("message too large")
+
+	evaluateAuthWithPolicy = mailauth.EvaluateWithPolicy
 )
 
 func (s *Server) handleConn(conn net.Conn) {
@@ -320,7 +322,7 @@ func (s *Server) handleConn(conn net.Conn) {
 			if msgRemoteIP == nil {
 				msgRemoteIP = parseRemoteIP(ss.remote)
 			}
-			authRes := mailauth.EvaluateWithPolicy(msgRemoteIP, ss.helo, ss.mailFrom, ss.data, mailauth.SPFPolicy{
+			authRes := evaluateAuthWithPolicy(msgRemoteIP, ss.helo, ss.mailFrom, ss.data, mailauth.SPFPolicy{
 				HeloMode:     s.cfg.SPFHeloPolicy,
 				MailFromMode: s.cfg.SPFMailFromPolicy,
 			})
@@ -352,6 +354,7 @@ func (s *Server) handleConn(conn net.Conn) {
 				writeResp(w, 451, "temporary local problem")
 				continue
 			}
+			s.enqueueDMARCReports(authRes, ss.mailFrom, id, time.Now().UTC())
 			s.metricInc("smtp_queued_messages")
 			writeResp(w, 250, "queued")
 			ss.mailFrom = ""
@@ -452,6 +455,72 @@ func (s *Server) enqueue(ss *session, id string) error {
 		Data:       append([]byte(nil), ss.data...),
 	}
 	return s.queue.Enqueue(msg)
+}
+
+func (s *Server) enqueueDMARCReports(authRes mailauth.Result, mailFrom, msgID string, now time.Time) {
+	if s.submission || s.queue == nil {
+		return
+	}
+	fromDomain, ok := util.DomainOf(mailFrom)
+	if !ok {
+		return
+	}
+	reports := mailauth.BuildDMARCOutboundReports(authRes.DMARC, fromDomain, s.cfg.Hostname, msgID, now)
+	if len(reports) == 0 {
+		return
+	}
+	for _, rep := range reports {
+		id, err := newID()
+		if err != nil {
+			slog.Warn("dmarc report id generation failed", "component", "smtp", "error", err, "parent_msg_id", msgID)
+			continue
+		}
+		reportFrom := fmt.Sprintf("postmaster@%s", s.cfg.Hostname)
+		msg := &model.Message{
+			ID:         id,
+			RemoteAddr: s.cfg.Hostname,
+			Helo:       s.cfg.Hostname,
+			MailFrom:   "",
+			RcptTo:     []string{rep.To},
+			Data:       buildReportMessage(reportFrom, rep.To, rep.Subject, rep.Body, id, now),
+		}
+		if err := s.queue.Enqueue(msg); err != nil {
+			slog.Warn("enqueue dmarc report failed", "component", "smtp", "error", err, "parent_msg_id", msgID, "rcpt", logging.MaskEmail(rep.To))
+			continue
+		}
+		s.metricInc("smtp_dmarc_report_queued")
+	}
+}
+
+func buildReportMessage(from, to, subject string, body []byte, msgID string, now time.Time) []byte {
+	normalizedBody := strings.ReplaceAll(string(body), "\r\n", "\n")
+	normalizedBody = strings.ReplaceAll(normalizedBody, "\r", "\n")
+	if !strings.HasSuffix(normalizedBody, "\n") {
+		normalizedBody += "\n"
+	}
+
+	var b bytes.Buffer
+	b.WriteString("From: ")
+	b.WriteString(sanitizeHeaderValue(from))
+	b.WriteString("\r\n")
+	b.WriteString("To: ")
+	b.WriteString(sanitizeHeaderValue(to))
+	b.WriteString("\r\n")
+	b.WriteString("Subject: ")
+	b.WriteString(sanitizeHeaderValue(subject))
+	b.WriteString("\r\n")
+	b.WriteString("Date: ")
+	b.WriteString(now.UTC().Format(time.RFC1123Z))
+	b.WriteString("\r\n")
+	b.WriteString("Message-ID: <")
+	b.WriteString(sanitizeHeaderValue(msgID))
+	b.WriteString(">\r\n")
+	b.WriteString("MIME-Version: 1.0\r\n")
+	b.WriteString("Content-Type: text/plain; charset=UTF-8\r\n")
+	b.WriteString("Content-Transfer-Encoding: 8bit\r\n")
+	b.WriteString("\r\n")
+	b.WriteString(strings.ReplaceAll(normalizedBody, "\n", "\r\n"))
+	return b.Bytes()
 }
 
 func splitVerb(line string) (string, string) {
@@ -836,4 +905,11 @@ func sanitizeReceivedToken(v string) string {
 		return out[:255]
 	}
 	return out
+}
+
+func sanitizeHeaderValue(v string) string {
+	s := strings.TrimSpace(v)
+	s = strings.ReplaceAll(s, "\r", "")
+	s = strings.ReplaceAll(s, "\n", "")
+	return s
 }

--- a/internal/smtp/server_test.go
+++ b/internal/smtp/server_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/tamago0224/orinoco-mta/internal/config"
+	"github.com/tamago0224/orinoco-mta/internal/mailauth"
 	"github.com/tamago0224/orinoco-mta/internal/model"
 	"github.com/tamago0224/orinoco-mta/internal/userauth"
 )
@@ -375,6 +376,76 @@ func TestQueueMessageInjectsReceivedHeader(t *testing.T) {
 	}
 	if !strings.Contains(msg, "by mx.example.test with ESMTP id ") {
 		t.Fatalf("missing expected trace fields: %q", msg)
+	}
+}
+
+func TestQueueMessageEnqueuesDMARCReports(t *testing.T) {
+	origEval := evaluateAuthWithPolicy
+	evaluateAuthWithPolicy = func(_ net.IP, _, _ string, _ []byte, _ mailauth.SPFPolicy) mailauth.Result {
+		return mailauth.Result{
+			Action: mailauth.ActionAccept,
+			DMARC: mailauth.DMARCResult{
+				Domain:          "example.com",
+				Result:          "fail",
+				Policy:          "reject",
+				Reason:          "alignment failed",
+				AggregateReport: []string{"mailto:agg@example.net"},
+				FailureReport:   []string{"mailto:forensic@example.net"},
+			},
+		}
+	}
+	defer func() {
+		evaluateAuthWithPolicy = origEval
+	}()
+
+	q := &recordingQueue{}
+	s := &Server{cfg: config.Config{Hostname: "mx.example.test", MaxMessageBytes: 1024 * 1024}, queue: q}
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	go s.handleConn(server)
+
+	r := bufio.NewReader(client)
+	w := bufio.NewWriter(client)
+	_, _ = readSMTPResponse(t, r) // banner
+
+	mustWriteSMTPLine(t, w, "EHLO client.example")
+	_, _ = readSMTPResponse(t, r)
+	mustWriteSMTPLine(t, w, "MAIL FROM:<alice@example.com>")
+	_, _ = readSMTPResponse(t, r)
+	mustWriteSMTPLine(t, w, "RCPT TO:<bob@example.com>")
+	_, _ = readSMTPResponse(t, r)
+	mustWriteSMTPLine(t, w, "DATA")
+	_, dataCode := readSMTPResponse(t, r)
+	if dataCode != 354 {
+		t.Fatalf("data code=%d want=354", dataCode)
+	}
+
+	data := "From: alice@example.com\r\nTo: bob@example.com\r\nSubject: test\r\n\r\nhello\r\n.\r\n"
+	if _, err := w.WriteString(data); err != nil {
+		t.Fatalf("write data: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("flush data: %v", err)
+	}
+	_, code := readSMTPResponse(t, r)
+	if code != 250 {
+		t.Fatalf("code=%d want=250", code)
+	}
+	if len(q.msgs) != 3 {
+		t.Fatalf("queued=%d want=3", len(q.msgs))
+	}
+	if q.msgs[1].MailFrom != "" || len(q.msgs[1].RcptTo) != 1 || q.msgs[1].RcptTo[0] != "agg@example.net" {
+		t.Fatalf("aggregate report envelope mismatch: %+v", q.msgs[1])
+	}
+	if q.msgs[2].MailFrom != "" || len(q.msgs[2].RcptTo) != 1 || q.msgs[2].RcptTo[0] != "forensic@example.net" {
+		t.Fatalf("failure report envelope mismatch: %+v", q.msgs[2])
+	}
+	if !strings.Contains(string(q.msgs[1].Data), "Subject: DMARC aggregate report for example.com") {
+		t.Fatalf("missing aggregate report subject: %q", string(q.msgs[1].Data))
+	}
+	if !strings.Contains(string(q.msgs[2].Data), "Subject: DMARC failure report for example.com") {
+		t.Fatalf("missing failure report subject: %q", string(q.msgs[2].Data))
 	}
 }
 


### PR DESCRIPTION
## 概要
- DMARC の rua / ruf URI から送信先を解釈し、アウトバウンドレポートを組み立てる処理を追加
- SMTP 受信時に DMARC 判定結果を見て、通常メールとは別に DMARC レポートメールをキュー投入する処理を追加
- レポート生成ロジックと SMTP 統合動作のテストを追加

## 変更点
- internal/mailauth/dmarc_report.go を追加
  - BuildDMARCOutboundReports を実装
  - mailto: URI（サイズ指定 ! 含む）の最小解釈を実装
- internal/smtp/server.go
  - 認証評価を差し替え可能な変数化（テスト容易性向上）
  - 本文受信成功後に DMARC レポートをキュー投入する enqueueDMARCReports を追加
  - レポート用 RFC5322 メッセージを生成するヘルパーを追加
- テスト追加
  - internal/mailauth/dmarc_report_test.go
  - internal/smtp/server_test.go（DMARC レポートが追加投入されることを検証）

## テスト
- go test ./internal/mailauth ./internal/smtp
- go test ./...

Closes #64