### PR TITLE
feat: DMARC pct による段階導入制御を実装

### DIFF
--- a/internal/mailauth/pipeline.go
+++ b/internal/mailauth/pipeline.go
@@ -2,6 +2,7 @@ package mailauth
 
 import (
 	"fmt"
+	"hash/fnv"
 	"net"
 	"strings"
 )
@@ -85,6 +86,11 @@ func EvaluateWithPolicy(remoteIP net.IP, helo, mailFrom string, raw []byte, poli
 	case "pass", "none":
 		result.Action = ActionAccept
 	case "fail":
+		if isEnforcingDMARCPolicy(dmarc.Policy) && !shouldApplyDMARCPolicy(dmarc, helo, mailFrom, raw) {
+			result.Action = ActionAccept
+			result.Reason = fmt.Sprintf("dmarc policy sampled out (pct=%d)", dmarc.Percent)
+			return result
+		}
 		switch strings.ToLower(dmarc.Policy) {
 		case "reject":
 			result.Action = ActionReject
@@ -99,6 +105,44 @@ func EvaluateWithPolicy(remoteIP net.IP, helo, mailFrom string, raw []byte, poli
 		result.Action = ActionAccept
 	}
 	return result
+}
+
+func isEnforcingDMARCPolicy(policy string) bool {
+	switch strings.ToLower(strings.TrimSpace(policy)) {
+	case "reject", "quarantine":
+		return true
+	default:
+		return false
+	}
+}
+
+func shouldApplyDMARCPolicy(dmarc DMARCResult, helo, mailFrom string, raw []byte) bool {
+	if !isEnforcingDMARCPolicy(dmarc.Policy) {
+		return false
+	}
+	if dmarc.Percent >= 100 {
+		return true
+	}
+	if dmarc.Percent <= 0 {
+		return false
+	}
+	return dmarcSamplingBucket(helo, mailFrom, raw) < dmarc.Percent
+}
+
+func dmarcSamplingBucket(helo, mailFrom string, raw []byte) int {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(strings.ToLower(strings.TrimSpace(helo))))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(strings.ToLower(strings.TrimSpace(mailFrom))))
+	_, _ = h.Write([]byte{0})
+	limit := len(raw)
+	if limit > 4096 {
+		limit = 4096
+	}
+	if limit > 0 {
+		_, _ = h.Write(raw[:limit])
+	}
+	return int(h.Sum32() % 100)
 }
 
 func spfRejected(v string) bool {

--- a/internal/mailauth/pipeline_test.go
+++ b/internal/mailauth/pipeline_test.go
@@ -130,3 +130,65 @@ func TestEvaluateWithPolicy_MailFromEnforce(t *testing.T) {
 		t.Fatalf("mailfrom enforce should reject, action=%s reason=%q", res.Action, res.Reason)
 	}
 }
+
+func TestEvaluateWithPolicy_DMARCRejectPctZeroSampledOut(t *testing.T) {
+	origLookup := dmarcLookupTXT
+	t.Cleanup(func() {
+		dmarcLookupTXT = origLookup
+	})
+	dmarcLookupTXT = func(_ context.Context, name string) ([]string, error) {
+		if strings.EqualFold(name, "_dmarc.example.com") {
+			return []string{"v=DMARC1; p=reject; pct=0"}, nil
+		}
+		return nil, nil
+	}
+
+	raw := []byte("From: sender@example.com\r\nTo: rcpt@example.net\r\nSubject: x\r\n\r\nbody")
+	res := EvaluateWithPolicy(nil, "mx.sender.test", "sender@example.com", raw, DefaultSPFPolicy())
+	if res.DMARC.Result != "fail" {
+		t.Fatalf("dmarc result=%s want=fail", res.DMARC.Result)
+	}
+	if res.Action != ActionAccept {
+		t.Fatalf("action=%s want=%s", res.Action, ActionAccept)
+	}
+	if !strings.Contains(res.Reason, "sampled out") {
+		t.Fatalf("reason=%q want contains sampled out", res.Reason)
+	}
+}
+
+func TestEvaluateWithPolicy_DMARCRejectPctHundredEnforced(t *testing.T) {
+	origLookup := dmarcLookupTXT
+	t.Cleanup(func() {
+		dmarcLookupTXT = origLookup
+	})
+	dmarcLookupTXT = func(_ context.Context, name string) ([]string, error) {
+		if strings.EqualFold(name, "_dmarc.example.com") {
+			return []string{"v=DMARC1; p=reject; pct=100"}, nil
+		}
+		return nil, nil
+	}
+
+	raw := []byte("From: sender@example.com\r\nTo: rcpt@example.net\r\nSubject: x\r\n\r\nbody")
+	res := EvaluateWithPolicy(nil, "mx.sender.test", "sender@example.com", raw, DefaultSPFPolicy())
+	if res.DMARC.Result != "fail" {
+		t.Fatalf("dmarc result=%s want=fail", res.DMARC.Result)
+	}
+	if res.Action != ActionReject {
+		t.Fatalf("action=%s want=%s", res.Action, ActionReject)
+	}
+	if res.Reason != "dmarc reject policy" {
+		t.Fatalf("reason=%q want=%q", res.Reason, "dmarc reject policy")
+	}
+}
+
+func TestDMARCSamplingBucketDeterministic(t *testing.T) {
+	raw := []byte("From: sender@example.com\r\nTo: rcpt@example.net\r\n\r\nbody")
+	a := dmarcSamplingBucket("mx.example.net", "sender@example.com", raw)
+	b := dmarcSamplingBucket("mx.example.net", "sender@example.com", raw)
+	if a != b {
+		t.Fatalf("bucket must be deterministic: %d != %d", a, b)
+	}
+	if a < 0 || a > 99 {
+		t.Fatalf("bucket out of range: %d", a)
+	}
+}


### PR DESCRIPTION
## 概要
- DMARC の pct タグを評価パイプラインで適用し、reject/quarantine ポリシーを段階導入できるようにしました。
- pct が 100 未満のときは、決定論的サンプリングでポリシー適用有無を判定します。

## 変更点
- internal/mailauth/pipeline.go
  - isEnforcingDMARCPolicy を追加
  - shouldApplyDMARCPolicy / dmarcSamplingBucket を追加
  - DMARC fail 時に p=reject|quarantine かつ pct によりサンプリング除外された場合は accept を返す分岐を追加
- internal/mailauth/pipeline_test.go
  - pct=0 でサンプリング除外されるテストを追加
  - pct=100 で従来通り reject されるテストを追加
  - サンプリングバケットが決定論的かつ 0..99 の範囲に収まるテストを追加

## テスト
- go test ./internal/mailauth ./internal/smtp
- go test ./...

Closes #65
