### PR TITLE
feat: DMARC評価結果の集計メトリクスを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ DNS を含む `docker compose` 環境を用意しています。
 
 - `/metrics`: Prometheus metrics
 - `/slo`: 現在の SLI/SLO 判定結果（JSON, breach時は HTTP 503）
+- DMARC集計メトリクス（受信時）:
+  - `smtp_auth_dmarc_result_<result>_total`（例: `fail`, `pass`, `none`）
+  - `smtp_auth_dmarc_policy_<policy>_total`（例: `reject`, `quarantine`, `none`）
+  - `smtp_auth_action_<action>_total`（例: `accept`, `quarantine`, `reject`）
 
 Prometheus alert rule の雛形は [orinoco_slo_rules.yml](/home/tamago/ghq/github.com/tamago/orinoco-mta/deploy/monitoring/prometheus/orinoco_slo_rules.yml) に配置しています。
 

--- a/internal/smtp/server.go
+++ b/internal/smtp/server.go
@@ -326,6 +326,7 @@ func (s *Server) handleConn(conn net.Conn) {
 				HeloMode:     s.cfg.SPFHeloPolicy,
 				MailFromMode: s.cfg.SPFMailFromPolicy,
 			})
+			s.metricAuthResult(authRes)
 			switch authRes.Action {
 			case mailauth.ActionReject:
 				writeResp(w, 550, "message rejected by auth policy")
@@ -443,6 +444,12 @@ func (s *Server) metricInc(name string) {
 	if s.metrics != nil {
 		s.metrics.Counter(name).Inc()
 	}
+}
+
+func (s *Server) metricAuthResult(res mailauth.Result) {
+	s.metricInc("smtp_auth_action_" + sanitizeMetricToken(string(res.Action)))
+	s.metricInc("smtp_auth_dmarc_result_" + sanitizeMetricToken(res.DMARC.Result))
+	s.metricInc("smtp_auth_dmarc_policy_" + sanitizeMetricToken(res.DMARC.Policy))
 }
 
 func (s *Server) enqueue(ss *session, id string) error {
@@ -912,4 +919,25 @@ func sanitizeHeaderValue(v string) string {
 	s = strings.ReplaceAll(s, "\r", "")
 	s = strings.ReplaceAll(s, "\n", "")
 	return s
+}
+
+func sanitizeMetricToken(v string) string {
+	s := strings.ToLower(strings.TrimSpace(v))
+	if s == "" {
+		return "unknown"
+	}
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		if (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '_' {
+			b.WriteByte(ch)
+		} else {
+			b.WriteByte('_')
+		}
+	}
+	out := strings.Trim(b.String(), "_")
+	if out == "" {
+		return "unknown"
+	}
+	return out
 }

--- a/internal/smtp/server_test.go
+++ b/internal/smtp/server_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tamago0224/orinoco-mta/internal/config"
 	"github.com/tamago0224/orinoco-mta/internal/mailauth"
 	"github.com/tamago0224/orinoco-mta/internal/model"
+	"github.com/tamago0224/orinoco-mta/internal/observability"
 	"github.com/tamago0224/orinoco-mta/internal/userauth"
 )
 
@@ -446,6 +447,73 @@ func TestQueueMessageEnqueuesDMARCReports(t *testing.T) {
 	}
 	if !strings.Contains(string(q.msgs[2].Data), "Subject: DMARC failure report for example.com") {
 		t.Fatalf("missing failure report subject: %q", string(q.msgs[2].Data))
+	}
+}
+
+func TestAuthMetricsByDMARCResultAndPolicy(t *testing.T) {
+	origEval := evaluateAuthWithPolicy
+	evaluateAuthWithPolicy = func(_ net.IP, _, _ string, _ []byte, _ mailauth.SPFPolicy) mailauth.Result {
+		return mailauth.Result{
+			Action: mailauth.ActionReject,
+			DMARC: mailauth.DMARCResult{
+				Domain: "example.com",
+				Result: "fail",
+				Policy: "reject",
+			},
+		}
+	}
+	defer func() {
+		evaluateAuthWithPolicy = origEval
+	}()
+
+	m := observability.NewMetrics()
+	q := &recordingQueue{}
+	s := &Server{
+		cfg:     config.Config{Hostname: "mx.example.test", MaxMessageBytes: 1024 * 1024},
+		queue:   q,
+		metrics: m,
+	}
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	go s.handleConn(server)
+
+	r := bufio.NewReader(client)
+	w := bufio.NewWriter(client)
+	_, _ = readSMTPResponse(t, r) // banner
+
+	mustWriteSMTPLine(t, w, "EHLO client.example")
+	_, _ = readSMTPResponse(t, r)
+	mustWriteSMTPLine(t, w, "MAIL FROM:<alice@example.com>")
+	_, _ = readSMTPResponse(t, r)
+	mustWriteSMTPLine(t, w, "RCPT TO:<bob@example.com>")
+	_, _ = readSMTPResponse(t, r)
+	mustWriteSMTPLine(t, w, "DATA")
+	_, dataCode := readSMTPResponse(t, r)
+	if dataCode != 354 {
+		t.Fatalf("data code=%d want=354", dataCode)
+	}
+
+	data := "From: alice@example.com\r\nTo: bob@example.com\r\nSubject: test\r\n\r\nhello\r\n.\r\n"
+	if _, err := w.WriteString(data); err != nil {
+		t.Fatalf("write data: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("flush data: %v", err)
+	}
+	_, code := readSMTPResponse(t, r)
+	if code != 550 {
+		t.Fatalf("code=%d want=550", code)
+	}
+	snap := m.Snapshot()
+	if snap["smtp_auth_action_reject_total"] != 1 {
+		t.Fatalf("smtp_auth_action_reject_total=%d want=1", snap["smtp_auth_action_reject_total"])
+	}
+	if snap["smtp_auth_dmarc_result_fail_total"] != 1 {
+		t.Fatalf("smtp_auth_dmarc_result_fail_total=%d want=1", snap["smtp_auth_dmarc_result_fail_total"])
+	}
+	if snap["smtp_auth_dmarc_policy_reject_total"] != 1 {
+		t.Fatalf("smtp_auth_dmarc_policy_reject_total=%d want=1", snap["smtp_auth_dmarc_policy_reject_total"])
 	}
 }
 


### PR DESCRIPTION
## 概要
- DMARC評価結果の集計・可視化向けに、受信時メトリクスを追加しました。
- SMTP受信時に action / DMARC result / DMARC policy をカウンタ集計します。

## 変更点
- internal/smtp/server.go
  - auth判定直後にメトリクス集計処理を追加
  - 追加メトリクス
    - smtp_auth_action_<action>_total
    - smtp_auth_dmarc_result_<result>_total
    - smtp_auth_dmarc_policy_<policy>_total
- internal/smtp/server_test.go
  - DMARC fail + reject時に上記メトリクスが加算されるテストを追加
- README.md
  - /metrics におけるDMARC集計メトリクス例を追記

## テスト
- go test ./internal/smtp ./internal/mailauth ./internal/observability
- go test ./...

Closes #66
