### PR TITLE
feat: ARC-Message-Signature/ARC-Seal の暗号検証を実装

### DIFF
--- a/internal/mailauth/arc.go
+++ b/internal/mailauth/arc.go
@@ -1,12 +1,16 @@
 package mailauth
 
 import (
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
 	"fmt"
 	"strconv"
 	"strings"
 )
 
-func EvalARC(headers []Header) ARCResult {
+func EvalARC(headers []Header, body string) ARCResult {
 	seals := HeaderValues(headers, "ARC-Seal")
 	msgs := HeaderValues(headers, "ARC-Message-Signature")
 	aars := HeaderValues(headers, "ARC-Authentication-Results")
@@ -21,11 +25,25 @@ func EvalARC(headers []Header) ARCResult {
 		if !hasInstance(seals, i) || !hasInstance(msgs, i) || !hasInstance(aars, i) {
 			return ARCResult{Result: "fail", Reason: fmt.Sprintf("missing instance i=%d", i)}
 		}
+		ams, ok := valueByInstance(msgs, i)
+		if !ok {
+			return ARCResult{Result: "fail", Reason: fmt.Sprintf("missing arc message signature i=%d", i)}
+		}
+		if err := verifyARCMessageSignature(headers, body, ams); err != nil {
+			return ARCResult{Result: "fail", Reason: fmt.Sprintf("arc message signature verify failed i=%d: %v", i, err)}
+		}
+		seal, ok := valueByInstance(seals, i)
+		if !ok {
+			return ARCResult{Result: "fail", Reason: fmt.Sprintf("missing arc seal i=%d", i)}
+		}
+		if err := verifyARCSeal(headers, seal, i); err != nil {
+			return ARCResult{Result: "fail", Reason: fmt.Sprintf("arc seal verify failed i=%d: %v", i, err)}
+		}
 	}
 	if !strings.Contains(strings.ToLower(seals[n-1]), "cv=") {
 		return ARCResult{Result: "fail", Reason: "missing cv in latest seal"}
 	}
-	return ARCResult{Result: "pass", Reason: "arc chain structure valid"}
+	return ARCResult{Result: "pass", Reason: "arc chain cryptographically valid"}
 }
 
 func hasInstance(values []string, want int) bool {
@@ -37,4 +55,129 @@ func hasInstance(values []string, want int) bool {
 		}
 	}
 	return false
+}
+
+func valueByInstance(values []string, want int) (string, bool) {
+	for _, v := range values {
+		tags := parseTagList(v)
+		i, _ := strconv.Atoi(tags["i"])
+		if i == want {
+			return v, true
+		}
+	}
+	return "", false
+}
+
+func verifyARCMessageSignature(headers []Header, body, sig string) error {
+	tags := parseTagList(sig)
+	domain := strings.ToLower(tags["d"])
+	selector := tags["s"]
+	algo := strings.ToLower(tags["a"])
+	if tags["i"] == "" || domain == "" || selector == "" || algo != "rsa-sha256" {
+		return fmt.Errorf("unsupported signature parameters")
+	}
+	if strings.TrimSpace(tags["h"]) == "" || strings.TrimSpace(tags["bh"]) == "" {
+		return fmt.Errorf("missing h/bh tag")
+	}
+	canonH, canonB := parseCanon(tags["c"])
+
+	canonBody, err := canonicalizeBodyWithLength(body, canonB, tags["l"])
+	if err != nil {
+		return err
+	}
+	bodyHash := sha256.Sum256(canonBody)
+	expectedBH, err := base64.StdEncoding.DecodeString(strings.TrimSpace(tags["bh"]))
+	if err != nil || !equalBytes(bodyHash[:], expectedBH) {
+		return fmt.Errorf("body hash mismatch")
+	}
+
+	signedData, err := buildSignedData(headers, tags["h"], sig, canonH, "ARC-Message-Signature")
+	if err != nil {
+		return err
+	}
+	pub, err := lookupDKIMKey(domain, selector)
+	if err != nil {
+		return err
+	}
+	sigBytes, err := base64.StdEncoding.DecodeString(compactBTag(tags["b"]))
+	if err != nil {
+		return fmt.Errorf("invalid b tag")
+	}
+	hash := sha256.Sum256([]byte(signedData))
+	if err := rsa.VerifyPKCS1v15(pub, crypto.SHA256, hash[:], sigBytes); err != nil {
+		return fmt.Errorf("signature verify failed")
+	}
+	return nil
+}
+
+func verifyARCSeal(headers []Header, seal string, instance int) error {
+	tags := parseTagList(seal)
+	domain := strings.ToLower(tags["d"])
+	selector := tags["s"]
+	algo := strings.ToLower(tags["a"])
+	if tags["i"] == "" || domain == "" || selector == "" || algo != "rsa-sha256" {
+		return fmt.Errorf("unsupported seal parameters")
+	}
+	if strings.TrimSpace(tags["cv"]) == "" {
+		return fmt.Errorf("missing cv tag")
+	}
+	chainData, err := buildARCSealSignedData(headers, instance)
+	if err != nil {
+		return err
+	}
+	pub, err := lookupDKIMKey(domain, selector)
+	if err != nil {
+		return err
+	}
+	sigBytes, err := base64.StdEncoding.DecodeString(compactBTag(tags["b"]))
+	if err != nil {
+		return fmt.Errorf("invalid b tag")
+	}
+	hash := sha256.Sum256([]byte(chainData))
+	if err := rsa.VerifyPKCS1v15(pub, crypto.SHA256, hash[:], sigBytes); err != nil {
+		return fmt.Errorf("seal verify failed")
+	}
+	return nil
+}
+
+func buildARCSealSignedData(headers []Header, maxInstance int) (string, error) {
+	if maxInstance <= 0 {
+		return "", fmt.Errorf("invalid instance")
+	}
+	var out strings.Builder
+	for i := 1; i <= maxInstance; i++ {
+		aar, ok := headerByInstance(headers, "ARC-Authentication-Results", i)
+		if !ok {
+			return "", fmt.Errorf("missing arc-authentication-results i=%d", i)
+		}
+		ams, ok := headerByInstance(headers, "ARC-Message-Signature", i)
+		if !ok {
+			return "", fmt.Errorf("missing arc-message-signature i=%d", i)
+		}
+		as, ok := headerByInstance(headers, "ARC-Seal", i)
+		if !ok {
+			return "", fmt.Errorf("missing arc-seal i=%d", i)
+		}
+		if i == maxInstance {
+			as = stripBTag(as)
+		}
+		out.WriteString(canonHeader("ARC-Authentication-Results", aar, "relaxed"))
+		out.WriteString(canonHeader("ARC-Message-Signature", ams, "relaxed"))
+		out.WriteString(canonHeader("ARC-Seal", as, "relaxed"))
+	}
+	return out.String(), nil
+}
+
+func headerByInstance(headers []Header, name string, want int) (string, bool) {
+	for _, h := range headers {
+		if !strings.EqualFold(h.Name, name) {
+			continue
+		}
+		tags := parseTagList(h.Value)
+		i, _ := strconv.Atoi(tags["i"])
+		if i == want {
+			return h.Value, true
+		}
+	}
+	return "", false
 }

--- a/internal/mailauth/arc_test.go
+++ b/internal/mailauth/arc_test.go
@@ -1,10 +1,19 @@
 package mailauth
 
-import "testing"
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"testing"
+)
 
 func TestEvalARC(t *testing.T) {
 	t.Run("none", func(t *testing.T) {
-		res := EvalARC([]Header{{Name: "From", Value: "a@example.com"}})
+		res := EvalARC([]Header{{Name: "From", Value: "a@example.com"}}, "")
 		if res.Result != "none" {
 			t.Fatalf("result=%s", res.Result)
 		}
@@ -14,20 +23,81 @@ func TestEvalARC(t *testing.T) {
 			{Name: "ARC-Seal", Value: "i=1; cv=none"},
 			{Name: "ARC-Message-Signature", Value: "i=1; d=example.com"},
 		}
-		res := EvalARC(h)
+		res := EvalARC(h, "")
 		if res.Result != "fail" {
 			t.Fatalf("result=%s", res.Result)
 		}
 	})
-	t.Run("pass_structure", func(t *testing.T) {
+	t.Run("fail_without_crypto", func(t *testing.T) {
 		h := []Header{
 			{Name: "ARC-Authentication-Results", Value: "i=1; mx=example"},
-			{Name: "ARC-Message-Signature", Value: "i=1; d=example.com"},
-			{Name: "ARC-Seal", Value: "i=1; cv=none; d=example.com"},
+			{Name: "ARC-Message-Signature", Value: "i=1; d=example.com; a=rsa-sha256; s=s1; h=from; bh=x; b=y"},
+			{Name: "ARC-Seal", Value: "i=1; cv=none; d=example.com; a=rsa-sha256; s=s1; b=z"},
 		}
-		res := EvalARC(h)
-		if res.Result != "pass" {
+		res := EvalARC(h, "")
+		if res.Result != "fail" {
 			t.Fatalf("result=%s reason=%s", res.Result, res.Reason)
 		}
 	})
+}
+
+func TestEvalARCCryptoPass(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	pubDER, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		t.Fatalf("marshal pubkey: %v", err)
+	}
+	origLookup := dkimLookupTXT
+	t.Cleanup(func() {
+		dkimLookupTXT = origLookup
+	})
+	dkimLookupTXT = func(_ context.Context, name string) ([]string, error) {
+		if name == "s1._domainkey.example.com" {
+			return []string{"v=DKIM1; k=rsa; p=" + base64.StdEncoding.EncodeToString(pubDER)}, nil
+		}
+		return nil, nil
+	}
+
+	body := "hello\r\n"
+	bodyHash := sha256.Sum256(canonicalizeBody(body, "simple"))
+	bh := base64.StdEncoding.EncodeToString(bodyHash[:])
+	amsBase := "i=1; a=rsa-sha256; d=example.com; s=s1; c=simple/simple; h=from:to:subject; bh=" + bh + "; b="
+	headers := []Header{
+		{Name: "From", Value: "a@example.com"},
+		{Name: "To", Value: "b@example.net"},
+		{Name: "Subject", Value: "arc test"},
+		{Name: "ARC-Authentication-Results", Value: "i=1; mx=example.net; dmarc=pass"},
+		{Name: "ARC-Message-Signature", Value: amsBase},
+		{Name: "ARC-Seal", Value: "i=1; cv=none; a=rsa-sha256; d=example.com; s=s1; b="},
+	}
+
+	amsData, err := buildSignedData(headers, "from:to:subject", amsBase, "simple", "ARC-Message-Signature")
+	if err != nil {
+		t.Fatalf("build ams data: %v", err)
+	}
+	amsHash := sha256.Sum256([]byte(amsData))
+	amsSig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, amsHash[:])
+	if err != nil {
+		t.Fatalf("sign ams: %v", err)
+	}
+	headers[4].Value = amsBase + base64.StdEncoding.EncodeToString(amsSig)
+
+	sealData, err := buildARCSealSignedData(headers, 1)
+	if err != nil {
+		t.Fatalf("build seal data: %v", err)
+	}
+	sealHash := sha256.Sum256([]byte(sealData))
+	sealSig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, sealHash[:])
+	if err != nil {
+		t.Fatalf("sign seal: %v", err)
+	}
+	headers[5].Value = headers[5].Value + base64.StdEncoding.EncodeToString(sealSig)
+
+	res := EvalARC(headers, body)
+	if res.Result != "pass" {
+		t.Fatalf("result=%s reason=%s", res.Result, res.Reason)
+	}
 }

--- a/internal/mailauth/dkim.go
+++ b/internal/mailauth/dkim.go
@@ -89,7 +89,7 @@ func verifyDKIMSig(headers []Header, body, sig string) DKIMSigResult {
 		return DKIMSigResult{Domain: domain, Selector: selector, Result: "fail", Reason: "body hash mismatch"}
 	}
 
-	signedData, err := buildSignedData(headers, tags["h"], sig, canonH)
+	signedData, err := buildSignedData(headers, tags["h"], sig, canonH, "DKIM-Signature")
 	if err != nil {
 		return DKIMSigResult{Domain: domain, Selector: selector, Result: "permerror", Reason: err.Error()}
 	}
@@ -174,7 +174,7 @@ func canonicalizeBodyWithLength(body, mode, bodyLength string) ([]byte, error) {
 	return out[:n], nil
 }
 
-func buildSignedData(headers []Header, hTag, dkimSigValue, canon string) (string, error) {
+func buildSignedData(headers []Header, hTag, sigValue, canon, sigHeaderName string) (string, error) {
 	headerNames := strings.Split(strings.ToLower(hTag), ":")
 	if len(headerNames) == 0 {
 		return "", fmt.Errorf("h tag missing")
@@ -193,8 +193,8 @@ func buildSignedData(headers []Header, hTag, dkimSigValue, canon string) (string
 		used[idx] = true
 		out.WriteString(canonHeader(headers[idx].Name, headers[idx].Value, canon))
 	}
-	stripped := stripBTag(dkimSigValue)
-	out.WriteString(canonHeader("DKIM-Signature", stripped, canon))
+	stripped := stripBTag(sigValue)
+	out.WriteString(canonHeader(sigHeaderName, stripped, canon))
 	return out.String(), nil
 }
 

--- a/internal/mailauth/dkim_test.go
+++ b/internal/mailauth/dkim_test.go
@@ -175,7 +175,7 @@ func TestBuildSignedDataUsesHeadersFromBottom(t *testing.T) {
 		{Name: "From", Value: "sender@example.com"},
 	}
 
-	got, err := buildSignedData(headers, "subject:from", "v=1; a=rsa-sha256; b=abc123; h=subject:from", "simple")
+	got, err := buildSignedData(headers, "subject:from", "v=1; a=rsa-sha256; b=abc123; h=subject:from", "simple", "DKIM-Signature")
 	if err != nil {
 		t.Fatalf("buildSignedData: %v", err)
 	}

--- a/internal/mailauth/pipeline.go
+++ b/internal/mailauth/pipeline.go
@@ -59,7 +59,7 @@ func EvaluateWithPolicy(remoteIP net.IP, helo, mailFrom string, raw []byte, poli
 	}
 
 	dkim := EvalDKIM(headers, bodyPart)
-	arc := EvalARC(headers)
+	arc := EvalARC(headers, bodyPart)
 	fromDomain := ExtractFromDomain(headers)
 	dmarc := EvalDMARC(fromDomain, effectiveSPF, dkim)
 


### PR DESCRIPTION
## 概要
- ARC の構造検証のみだった実装に、ARC-Message-Signature (AMS) / ARC-Seal (AS) の暗号学的検証を追加しました。
- 既存 DKIM 検証ロジックを再利用しつつ、ARC 用の署名データ組み立てを実装しています。

## 変更点
- internal/mailauth/arc.go
  - EvalARC のシグネチャを `EvalARC(headers, body)` に変更
  - AMS 検証（bh 検証 + RSA 署名検証）を追加
  - AS 検証（ARC set チェーンデータの RSA 署名検証）を追加
  - instance ごとのヘッダ解決/chain data 構築ヘルパーを追加
- internal/mailauth/pipeline.go
  - ARC 評価呼び出しを本文付きに更新
- internal/mailauth/dkim.go
  - 署名データ組み立て関数を汎用化（DKIM/ARC で再利用）
- テスト
  - internal/mailauth/arc_test.go に暗号検証成功ケースを追加
  - internal/mailauth/dkim_test.go の関数シグネチャ変更追従

## テスト
- go test ./internal/mailauth
- go test ./...

Closes #67
