### PR TITLE
feat: 中継送信時のARC署名付与（i=1）を実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Orinoco は南米を流れる川の名前で、
 | RFC 7208 | SPF | 一部対応 | `ip4`, `ip6`, `a`, `mx`, `include`, `all` を評価 |
 | RFC 6376 | DKIM | 一部対応 | DKIM署名検証（`rsa-sha256`）を実装 |
 | RFC 7489 | DMARC | 一部対応 | SPF/DKIM alignment と `p` ポリシー評価を実装 |
-| RFC 8617 | ARC | 一部対応 | ARCセットの構造検証（チェーン整合）を実装 |
+| RFC 8617 | ARC | 一部対応 | ARCセットの構造検証、AMS/AS検証、送信時の i=1 ARC付与を実装 |
 | RFC 8461 | MTA-STS | 一部対応 | policy取得・キャッシュ・enforce適用を実装 |
 | RFC 7672 | DANE for SMTP | 一部対応 | TLSA取得と優先適用（DANE > MTA-STS）を実装 |
 | RFC 3464 | DSN | 一部対応 | DSNパースと suppression 連携を実装 |

--- a/internal/delivery/modes_test.go
+++ b/internal/delivery/modes_test.go
@@ -98,6 +98,30 @@ func TestDeliverLocalSpoolReturnsSignerError(t *testing.T) {
 	}
 }
 
+func TestDeliverLocalSpoolAppliesARCSignerWhenConfigured(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Config{DeliveryMode: "local_spool", LocalSpoolDir: dir}
+	cl := NewClient(cfg)
+	cl.arcSigner = testSigner(func(raw []byte) ([]byte, error) {
+		return append([]byte("ARC-Seal: test\r\n"), raw...), nil
+	})
+	msg := &model.Message{ID: "m5", MailFrom: "sender@example.com", Data: []byte("From: sender@example.com\r\n\r\nhello")}
+	if err := cl.Deliver(context.Background(), msg, "user@example.net"); err != nil {
+		t.Fatalf("deliver local spool with arc signer: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read spool dir: %v", err)
+	}
+	b, err := os.ReadFile(filepath.Join(dir, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("read spool file: %v", err)
+	}
+	if !strings.HasPrefix(string(b), "ARC-Seal: test\r\n") {
+		t.Fatalf("missing arc seal prefix: %q", string(b))
+	}
+}
+
 type testSigner func([]byte) ([]byte, error)
 
 func (s testSigner) Sign(raw []byte) ([]byte, error) {

--- a/internal/delivery/smtp_client.go
+++ b/internal/delivery/smtp_client.go
@@ -29,6 +29,7 @@ type Client struct {
 	dane                           *DANEResolver
 	mtaSTS                         *MTASTSResolver
 	signer                         messageSigner
+	arcSigner                      messageSigner
 	resolveMXFn                    func(string, time.Duration) ([]router.MXHost, error)
 	deliverHostFn                  func(context.Context, string, int, *model.Message, string, bool, *DANEResult) error
 	spoolWriteFn                   func(*model.Message, string) error
@@ -45,6 +46,9 @@ func NewClient(cfg config.Config) *Client {
 	if cfg.DKIMSignDomain != "" || cfg.DKIMSignSelector != "" || cfg.DKIMPrivateKeyFile != "" {
 		if signer, err := dkim.NewFileSigner(cfg.DKIMSignDomain, cfg.DKIMSignSelector, cfg.DKIMPrivateKeyFile, cfg.DKIMSignHeaders); err == nil {
 			c.signer = signer
+		}
+		if arcSigner, err := dkim.NewARCFileSigner(cfg.DKIMSignDomain, cfg.DKIMSignSelector, cfg.DKIMPrivateKeyFile, cfg.Hostname, cfg.DKIMSignHeaders); err == nil {
+			c.arcSigner = arcSigner
 		}
 	}
 	c.deliverHostFn = c.deliverHost
@@ -413,8 +417,20 @@ func dotStuff(data []byte) []byte {
 }
 
 func (c *Client) prepareOutboundData(raw []byte) ([]byte, error) {
-	if c.signer == nil {
-		return raw, nil
+	signed := raw
+	if c.signer != nil {
+		var err error
+		signed, err = c.signer.Sign(signed)
+		if err != nil {
+			return nil, err
+		}
 	}
-	return c.signer.Sign(raw)
+	if c.arcSigner != nil {
+		var err error
+		signed, err = c.arcSigner.Sign(signed)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return signed, nil
 }

--- a/internal/dkim/arc_signer.go
+++ b/internal/dkim/arc_signer.go
@@ -1,0 +1,147 @@
+package dkim
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type ARCFileSigner struct {
+	domain     string
+	selector   string
+	authserv   string
+	headers    []string
+	privateKey *rsa.PrivateKey
+}
+
+func NewARCFileSigner(domain, selector, keyFile, authservID, headers string) (*ARCFileSigner, error) {
+	d := strings.ToLower(strings.TrimSpace(domain))
+	s := strings.TrimSpace(selector)
+	k := strings.TrimSpace(keyFile)
+	a := strings.TrimSpace(authservID)
+	if d == "" || s == "" || k == "" {
+		return nil, errors.New("arc signer requires domain, selector, and private key file")
+	}
+	if a == "" {
+		a = "orinoco.local"
+	}
+	key, err := loadPrivateKey(k)
+	if err != nil {
+		return nil, err
+	}
+	h := parseHeaderList(headers)
+	if len(h) == 0 {
+		h = []string{"from", "to", "subject", "date", "message-id"}
+	}
+	return &ARCFileSigner{
+		domain:     d,
+		selector:   s,
+		authserv:   a,
+		headers:    h,
+		privateKey: key,
+	}, nil
+}
+
+func (s *ARCFileSigner) Sign(raw []byte) ([]byte, error) {
+	headerPart, bodyPart, ok := splitMessage(raw)
+	if !ok {
+		return nil, errors.New("invalid message format")
+	}
+	headers := parseRawHeaders(headerPart)
+	if len(headers) == 0 {
+		return nil, errors.New("missing headers")
+	}
+	if hasARCSet(headers) {
+		// Existing chain update is handled by the next issue; keep current message as-is.
+		return raw, nil
+	}
+
+	aarValue := s.buildAARValue(headers)
+
+	msgWithAAR := "ARC-Authentication-Results: " + aarValue + "\r\n" + headerPart + "\r\n\r\n" + bodyPart
+	aarHeaderPart, _, _ := splitMessage([]byte(msgWithAAR))
+	headersWithAAR := parseRawHeaders(aarHeaderPart)
+
+	hdrNames, signedHeaderPart := buildSignedHeaders(headersWithAAR, append(append([]string{}, s.headers...), "arc-authentication-results"))
+	if len(hdrNames) == 0 {
+		return nil, errors.New("no headers available for arc message signature")
+	}
+
+	bh := bodyHash(bodyPart)
+	ts := time.Now().UTC().Unix()
+	amsBase := fmt.Sprintf(
+		"i=1; a=rsa-sha256; c=relaxed/relaxed; d=%s; s=%s; t=%d; h=%s; bh=%s; b=",
+		s.domain,
+		s.selector,
+		ts,
+		strings.Join(hdrNames, ":"),
+		bh,
+	)
+	amsSigningData := signedHeaderPart + canonHeaderRelaxed("ARC-Message-Signature", amsBase)
+	amsSig, err := signPKCS1v15SHA256(s.privateKey, []byte(amsSigningData))
+	if err != nil {
+		return nil, err
+	}
+	amsValue := amsBase + amsSig
+
+	sealBase := fmt.Sprintf("i=1; cv=none; a=rsa-sha256; d=%s; s=%s; t=%d; b=", s.domain, s.selector, ts)
+	sealSigningData := canonHeaderRelaxed("ARC-Authentication-Results", aarValue) +
+		canonHeaderRelaxed("ARC-Message-Signature", amsValue) +
+		canonHeaderRelaxed("ARC-Seal", sealBase)
+	sealSig, err := signPKCS1v15SHA256(s.privateKey, []byte(sealSigningData))
+	if err != nil {
+		return nil, err
+	}
+	sealValue := sealBase + sealSig
+
+	var out strings.Builder
+	out.WriteString("ARC-Seal: ")
+	out.WriteString(sealValue)
+	out.WriteString("\r\n")
+	out.WriteString("ARC-Message-Signature: ")
+	out.WriteString(amsValue)
+	out.WriteString("\r\n")
+	out.WriteString("ARC-Authentication-Results: ")
+	out.WriteString(aarValue)
+	out.WriteString("\r\n")
+	out.WriteString(headerPart)
+	out.WriteString("\r\n\r\n")
+	out.WriteString(bodyPart)
+	return []byte(out.String()), nil
+}
+
+func (s *ARCFileSigner) buildAARValue(headers []rawHeader) string {
+	for _, h := range headers {
+		if strings.EqualFold(h.name, "Authentication-Results") {
+			v := collapseWSP(strings.TrimSpace(h.value))
+			if v != "" {
+				return "i=1; " + v
+			}
+		}
+	}
+	return fmt.Sprintf("i=1; %s; arc=none", s.authserv)
+}
+
+func hasARCSet(headers []rawHeader) bool {
+	for _, h := range headers {
+		if strings.EqualFold(h.name, "ARC-Seal") || strings.EqualFold(h.name, "ARC-Message-Signature") || strings.EqualFold(h.name, "ARC-Authentication-Results") {
+			return true
+		}
+	}
+	return false
+}
+
+func signPKCS1v15SHA256(key *rsa.PrivateKey, payload []byte) (string, error) {
+	sum := sha256.Sum256(payload)
+	sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, sum[:])
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(sig), nil
+}

--- a/internal/dkim/arc_signer_test.go
+++ b/internal/dkim/arc_signer_test.go
@@ -1,0 +1,52 @@
+package dkim
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestARCFileSignerSignInjectsARCSet(t *testing.T) {
+	keyPath := filepath.Join(t.TempDir(), "arc.pem")
+	if err := writeTestKey(keyPath); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	s, err := NewARCFileSigner("example.com", "s1", keyPath, "mx.example.com", "from:to:subject")
+	if err != nil {
+		t.Fatalf("new signer: %v", err)
+	}
+	raw := []byte("From: a@example.com\r\nTo: b@example.net\r\nSubject: hi\r\nAuthentication-Results: mx.example.com; dmarc=pass\r\n\r\nhello")
+	got, err := s.Sign(raw)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	out := string(got)
+	if !strings.HasPrefix(out, "ARC-Seal: ") {
+		t.Fatalf("missing arc-seal: %q", out)
+	}
+	if !strings.Contains(out, "\r\nARC-Message-Signature: i=1;") {
+		t.Fatalf("missing arc message signature: %q", out)
+	}
+	if !strings.Contains(out, "\r\nARC-Authentication-Results: i=1;") {
+		t.Fatalf("missing arc authentication results: %q", out)
+	}
+}
+
+func TestARCFileSignerSignSkipsExistingARCSet(t *testing.T) {
+	keyPath := filepath.Join(t.TempDir(), "arc.pem")
+	if err := writeTestKey(keyPath); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	s, err := NewARCFileSigner("example.com", "s1", keyPath, "mx.example.com", "from")
+	if err != nil {
+		t.Fatalf("new signer: %v", err)
+	}
+	raw := []byte("ARC-Seal: i=1; cv=none; a=rsa-sha256; d=example.com; s=s1; b=abc\r\nFrom: a@example.com\r\n\r\nhello")
+	got, err := s.Sign(raw)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	if string(got) != string(raw) {
+		t.Fatalf("existing arc set must be untouched")
+	}
+}


### PR DESCRIPTION
## Summary
- 中継MTAとして送信時に ARC セット（i=1）を付与する処理を追加しました。
- 既存 ARC チェーンがあるメッセージは現段階では上書きせず、そのまま通す実装です（多段チェーン更新は次タスクで対応）。

## Changes
- internal/dkim/arc_signer.go を追加
  - ARC-Authentication-Results / ARC-Message-Signature / ARC-Seal を生成
  - RSA-SHA256 で AMS/AS を署名
  - 既存 ARC ヘッダがある場合はスキップ
- internal/dkim/arc_signer_test.go を追加
  - ARC セット付与と既存ARCスキップをテスト
- internal/delivery/smtp_client.go
  - 送信前処理を DKIM -> ARC の順で実行
  - ARC signer の初期化を追加
- internal/delivery/modes_test.go
  - ARC signer 適用テストを追加
- README.md
  - RFC 8617 補足を更新

## Validation
- bash ./.agents/skills/github-flow/scripts/run-checks.sh
  - No supported project check script detected.
- go test ./internal/dkim ./internal/delivery
- go test ./...

## Risks / Follow-ups
- 現在は i=1 の新規付与のみ対応（既存ARCチェーン更新は未対応）
- ARC instance 連番や cv 伝播の厳密化は #69 で対応

Closes #68
