### PR TITLE
feat: ARC instance連番とチェーン整合性判定を厳密化

### DIFF
--- a/internal/mailauth/arc.go
+++ b/internal/mailauth/arc.go
@@ -20,52 +20,55 @@ func EvalARC(headers []Header, body string) ARCResult {
 	if len(seals) != len(msgs) || len(seals) != len(aars) {
 		return ARCResult{Result: "fail", Reason: "arc set counts mismatch"}
 	}
+	sealMap, err := buildARCInstanceMap(seals)
+	if err != nil {
+		return ARCResult{Result: "fail", Reason: "invalid arc-seal instances: " + err.Error()}
+	}
+	msgMap, err := buildARCInstanceMap(msgs)
+	if err != nil {
+		return ARCResult{Result: "fail", Reason: "invalid arc-message-signature instances: " + err.Error()}
+	}
+	aarMap, err := buildARCInstanceMap(aars)
+	if err != nil {
+		return ARCResult{Result: "fail", Reason: "invalid arc-authentication-results instances: " + err.Error()}
+	}
 	n := len(seals)
 	for i := 1; i <= n; i++ {
-		if !hasInstance(seals, i) || !hasInstance(msgs, i) || !hasInstance(aars, i) {
+		ams, okMsg := msgMap[i]
+		seal, okSeal := sealMap[i]
+		_, okAAR := aarMap[i]
+		if !okSeal || !okMsg || !okAAR {
 			return ARCResult{Result: "fail", Reason: fmt.Sprintf("missing instance i=%d", i)}
-		}
-		ams, ok := valueByInstance(msgs, i)
-		if !ok {
-			return ARCResult{Result: "fail", Reason: fmt.Sprintf("missing arc message signature i=%d", i)}
 		}
 		if err := verifyARCMessageSignature(headers, body, ams); err != nil {
 			return ARCResult{Result: "fail", Reason: fmt.Sprintf("arc message signature verify failed i=%d: %v", i, err)}
-		}
-		seal, ok := valueByInstance(seals, i)
-		if !ok {
-			return ARCResult{Result: "fail", Reason: fmt.Sprintf("missing arc seal i=%d", i)}
 		}
 		if err := verifyARCSeal(headers, seal, i); err != nil {
 			return ARCResult{Result: "fail", Reason: fmt.Sprintf("arc seal verify failed i=%d: %v", i, err)}
 		}
 	}
-	if !strings.Contains(strings.ToLower(seals[n-1]), "cv=") {
-		return ARCResult{Result: "fail", Reason: "missing cv in latest seal"}
-	}
 	return ARCResult{Result: "pass", Reason: "arc chain cryptographically valid"}
 }
 
-func hasInstance(values []string, want int) bool {
+func buildARCInstanceMap(values []string) (map[int]string, error) {
+	out := make(map[int]string, len(values))
 	for _, v := range values {
 		tags := parseTagList(v)
-		i, _ := strconv.Atoi(tags["i"])
-		if i == want {
-			return true
+		i, err := strconv.Atoi(strings.TrimSpace(tags["i"]))
+		if err != nil || i <= 0 {
+			return nil, fmt.Errorf("invalid i tag")
+		}
+		if _, exists := out[i]; exists {
+			return nil, fmt.Errorf("duplicate i=%d", i)
+		}
+		out[i] = v
+	}
+	for i := 1; i <= len(values); i++ {
+		if _, ok := out[i]; !ok {
+			return nil, fmt.Errorf("missing i=%d", i)
 		}
 	}
-	return false
-}
-
-func valueByInstance(values []string, want int) (string, bool) {
-	for _, v := range values {
-		tags := parseTagList(v)
-		i, _ := strconv.Atoi(tags["i"])
-		if i == want {
-			return v, true
-		}
-	}
-	return "", false
+	return out, nil
 }
 
 func verifyARCMessageSignature(headers []Header, body, sig string) error {
@@ -112,14 +115,19 @@ func verifyARCMessageSignature(headers []Header, body, sig string) error {
 
 func verifyARCSeal(headers []Header, seal string, instance int) error {
 	tags := parseTagList(seal)
+	iVal, err := strconv.Atoi(strings.TrimSpace(tags["i"]))
+	if err != nil || iVal != instance {
+		return fmt.Errorf("invalid i tag")
+	}
 	domain := strings.ToLower(tags["d"])
 	selector := tags["s"]
 	algo := strings.ToLower(tags["a"])
 	if tags["i"] == "" || domain == "" || selector == "" || algo != "rsa-sha256" {
 		return fmt.Errorf("unsupported seal parameters")
 	}
-	if strings.TrimSpace(tags["cv"]) == "" {
-		return fmt.Errorf("missing cv tag")
+	cv := strings.ToLower(strings.TrimSpace(tags["cv"]))
+	if !validSealCV(cv, instance) {
+		return fmt.Errorf("invalid cv tag")
 	}
 	chainData, err := buildARCSealSignedData(headers, instance)
 	if err != nil {
@@ -138,6 +146,13 @@ func verifyARCSeal(headers []Header, seal string, instance int) error {
 		return fmt.Errorf("seal verify failed")
 	}
 	return nil
+}
+
+func validSealCV(cv string, instance int) bool {
+	if instance <= 1 {
+		return cv == "none"
+	}
+	return cv == "pass" || cv == "fail"
 }
 
 func buildARCSealSignedData(headers []Header, maxInstance int) (string, error) {

--- a/internal/mailauth/arc_test.go
+++ b/internal/mailauth/arc_test.go
@@ -28,6 +28,32 @@ func TestEvalARC(t *testing.T) {
 			t.Fatalf("result=%s", res.Result)
 		}
 	})
+	t.Run("duplicate_instance_fails", func(t *testing.T) {
+		h := []Header{
+			{Name: "ARC-Authentication-Results", Value: "i=1; mx=example"},
+			{Name: "ARC-Authentication-Results", Value: "i=1; mx=example-dup"},
+			{Name: "ARC-Message-Signature", Value: "i=1; d=example.com; a=rsa-sha256; s=s1; h=from; bh=x; b=y"},
+			{Name: "ARC-Seal", Value: "i=1; cv=none; d=example.com; a=rsa-sha256; s=s1; b=z"},
+		}
+		res := EvalARC(h, "")
+		if res.Result != "fail" {
+			t.Fatalf("result=%s reason=%s", res.Result, res.Reason)
+		}
+	})
+	t.Run("missing_sequence_fails", func(t *testing.T) {
+		h := []Header{
+			{Name: "ARC-Authentication-Results", Value: "i=1; mx=example"},
+			{Name: "ARC-Authentication-Results", Value: "i=3; mx=example"},
+			{Name: "ARC-Message-Signature", Value: "i=1; d=example.com; a=rsa-sha256; s=s1; h=from; bh=x; b=y"},
+			{Name: "ARC-Message-Signature", Value: "i=3; d=example.com; a=rsa-sha256; s=s1; h=from; bh=x; b=y"},
+			{Name: "ARC-Seal", Value: "i=1; cv=none; d=example.com; a=rsa-sha256; s=s1; b=z"},
+			{Name: "ARC-Seal", Value: "i=3; cv=pass; d=example.com; a=rsa-sha256; s=s1; b=z"},
+		}
+		res := EvalARC(h, "")
+		if res.Result != "fail" {
+			t.Fatalf("result=%s reason=%s", res.Result, res.Reason)
+		}
+	})
 	t.Run("fail_without_crypto", func(t *testing.T) {
 		h := []Header{
 			{Name: "ARC-Authentication-Results", Value: "i=1; mx=example"},
@@ -39,6 +65,21 @@ func TestEvalARC(t *testing.T) {
 			t.Fatalf("result=%s reason=%s", res.Result, res.Reason)
 		}
 	})
+}
+
+func TestVerifyARCSealCVRules(t *testing.T) {
+	if !validSealCV("none", 1) {
+		t.Fatal("i=1 must allow cv=none")
+	}
+	if validSealCV("pass", 1) {
+		t.Fatal("i=1 must not allow cv=pass")
+	}
+	if !validSealCV("pass", 2) || !validSealCV("fail", 2) {
+		t.Fatal("i>1 must allow cv=pass/fail")
+	}
+	if validSealCV("none", 2) {
+		t.Fatal("i>1 must not allow cv=none")
+	}
 }
 
 func TestEvalARCCryptoPass(t *testing.T) {


### PR DESCRIPTION
## Summary
- ARC の instance(i=) 連番・欠落・重複判定を厳密化しました。
- ARC-Seal の cv 値ルールを instance に応じて検証するようにしました。

## Changes
- internal/mailauth/arc.go
  - `i` タグを instance map 化して厳密チェック
    - 不正 `i`（非数値/0以下）
    - 重複 `i`
    - 連番欠落（1..N の欠落）
  - ARC set の照合を map ベースへ変更
  - ARC-Seal 検証で `i` 一致を必須化
  - `cv` ルールを追加
    - `i=1` は `cv=none` のみ許可
    - `i>1` は `cv=pass|fail` のみ許可
- internal/mailauth/arc_test.go
  - duplicate instance fail
  - missing sequence fail
  - cv ルール単体テスト

## Validation
- go test ./internal/mailauth
- go test ./...

## Risks / Follow-ups
- 中継時の既存ARCチェーン更新（`i=n+1` 付与と `cv` 伝播）は次タスクで対応

Closes #69
