### PR TITLE
feat: ARC署名鍵のローテーション自動リロードを実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ go run ./cmd/mta
 - `MTA_DKIM_SIGN_SELECTOR` (default: unset)
 - `MTA_DKIM_PRIVATE_KEY_FILE` (default: unset, PEM RSA private key)
 - `MTA_DKIM_SIGN_HEADERS` (default: `from:to:subject:date:message-id`)
+  - ARC署名も同じ鍵設定を利用し、鍵ファイル更新時は送信時に自動リロード
 
 ## 補足
 

--- a/internal/dkim/arc_signer.go
+++ b/internal/dkim/arc_signer.go
@@ -8,15 +8,21 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
+	"sync"
 	"time"
 )
 
 type ARCFileSigner struct {
-	domain     string
-	selector   string
-	authserv   string
-	headers    []string
+	domain   string
+	selector string
+	authserv string
+	headers  []string
+	keyFile  string
+
+	mu         sync.RWMutex
+	mtime      time.Time
 	privateKey *rsa.PrivateKey
 }
 
@@ -31,24 +37,27 @@ func NewARCFileSigner(domain, selector, keyFile, authservID, headers string) (*A
 	if a == "" {
 		a = "orinoco.local"
 	}
-	key, err := loadPrivateKey(k)
-	if err != nil {
-		return nil, err
-	}
 	h := parseHeaderList(headers)
 	if len(h) == 0 {
 		h = []string{"from", "to", "subject", "date", "message-id"}
 	}
-	return &ARCFileSigner{
-		domain:     d,
-		selector:   s,
-		authserv:   a,
-		headers:    h,
-		privateKey: key,
-	}, nil
+	signer := &ARCFileSigner{
+		domain:   d,
+		selector: s,
+		authserv: a,
+		headers:  h,
+		keyFile:  k,
+	}
+	if err := signer.reloadIfNeeded(); err != nil {
+		return nil, err
+	}
+	return signer, nil
 }
 
 func (s *ARCFileSigner) Sign(raw []byte) ([]byte, error) {
+	if err := s.reloadIfNeeded(); err != nil {
+		return nil, err
+	}
 	headerPart, bodyPart, ok := splitMessage(raw)
 	if !ok {
 		return nil, errors.New("invalid message format")
@@ -84,7 +93,10 @@ func (s *ARCFileSigner) Sign(raw []byte) ([]byte, error) {
 		bh,
 	)
 	amsSigningData := signedHeaderPart + canonHeaderRelaxed("ARC-Message-Signature", amsBase)
-	amsSig, err := signPKCS1v15SHA256(s.privateKey, []byte(amsSigningData))
+	s.mu.RLock()
+	key := s.privateKey
+	s.mu.RUnlock()
+	amsSig, err := signPKCS1v15SHA256(key, []byte(amsSigningData))
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +106,7 @@ func (s *ARCFileSigner) Sign(raw []byte) ([]byte, error) {
 	sealSigningData := canonHeaderRelaxed("ARC-Authentication-Results", aarValue) +
 		canonHeaderRelaxed("ARC-Message-Signature", amsValue) +
 		canonHeaderRelaxed("ARC-Seal", sealBase)
-	sealSig, err := signPKCS1v15SHA256(s.privateKey, []byte(sealSigningData))
+	sealSig, err := signPKCS1v15SHA256(key, []byte(sealSigningData))
 	if err != nil {
 		return nil, err
 	}
@@ -114,6 +126,28 @@ func (s *ARCFileSigner) Sign(raw []byte) ([]byte, error) {
 	out.WriteString("\r\n\r\n")
 	out.WriteString(bodyPart)
 	return []byte(out.String()), nil
+}
+
+func (s *ARCFileSigner) reloadIfNeeded() error {
+	st, err := os.Stat(s.keyFile)
+	if err != nil {
+		return err
+	}
+	s.mu.RLock()
+	needs := s.privateKey == nil || st.ModTime().After(s.mtime)
+	s.mu.RUnlock()
+	if !needs {
+		return nil
+	}
+	key, err := loadPrivateKey(s.keyFile)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.privateKey = key
+	s.mtime = st.ModTime()
+	s.mu.Unlock()
+	return nil
 }
 
 func (s *ARCFileSigner) buildAARValue(headers []rawHeader) string {

--- a/internal/dkim/arc_signer_test.go
+++ b/internal/dkim/arc_signer_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestARCFileSignerSignInjectsARCSet(t *testing.T) {
@@ -48,5 +49,32 @@ func TestARCFileSignerSignSkipsExistingARCSet(t *testing.T) {
 	}
 	if string(got) != string(raw) {
 		t.Fatalf("existing arc set must be untouched")
+	}
+}
+
+func TestARCFileSignerReloadsRotatedKey(t *testing.T) {
+	keyPath := filepath.Join(t.TempDir(), "arc.pem")
+	if err := writeTestKey(keyPath); err != nil {
+		t.Fatalf("write key1: %v", err)
+	}
+	s, err := NewARCFileSigner("example.com", "s1", keyPath, "mx.example.com", "from:to:subject")
+	if err != nil {
+		t.Fatalf("new signer: %v", err)
+	}
+	msg := []byte("From: a@example.com\r\nTo: b@example.net\r\nSubject: hi\r\n\r\nhello")
+	first, err := s.Sign(msg)
+	if err != nil {
+		t.Fatalf("sign first: %v", err)
+	}
+	time.Sleep(1100 * time.Millisecond)
+	if err := writeTestKey(keyPath); err != nil {
+		t.Fatalf("write key2: %v", err)
+	}
+	second, err := s.Sign(msg)
+	if err != nil {
+		t.Fatalf("sign second: %v", err)
+	}
+	if string(first) == string(second) {
+		t.Fatal("arc signature should change after key rotation")
 	}
 }


### PR DESCRIPTION
## Summary
- ARC signer の鍵管理を強化し、鍵ファイル更新時に自動リロードできるようにしました。
- 鍵ローテーション後に新鍵で署名されることをテストで担保しました。

## Changes
- internal/dkim/arc_signer.go
  - `keyFile` / `mtime` / `sync.RWMutex` を追加
  - `reloadIfNeeded()` を追加し、`Sign()` 前に鍵更新を検知して再読込
  - 署名時の鍵参照をロック付きに変更
- internal/dkim/arc_signer_test.go
  - `TestARCFileSignerReloadsRotatedKey` を追加
- README.md
  - ARC署名はDKIM鍵設定を共有し、鍵更新時に自動リロードする旨を追記

## Validation
- go test ./internal/dkim ./internal/delivery
- go test ./...

Closes #70
