### PR TITLE
feat: ARC失敗時ポリシー（accept/quarantine/reject）を実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ go run ./cmd/mta
 - `MTA_DKIM_PRIVATE_KEY_FILE` (default: unset, PEM RSA private key)
 - `MTA_DKIM_SIGN_HEADERS` (default: `from:to:subject:date:message-id`)
   - ARC署名も同じ鍵設定を利用し、鍵ファイル更新時は送信時に自動リロード
+- `MTA_ARC_FAILURE_POLICY` (default: `accept`, values: `accept` / `quarantine` / `reject`)
+- `MTA_ARC_FAILURE_POLICY` (default: `accept`, values: `accept` / `quarantine` / `reject`)
 
 ## 補足
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,7 @@ type Config struct {
 	DKIMSignSelector           string
 	DKIMPrivateKeyFile         string
 	DKIMSignHeaders            string
+	ARCFailurePolicy           string
 	SPFHeloPolicy              string
 	SPFMailFromPolicy          string
 	DomainMaxConcurrentDefault int
@@ -114,6 +115,7 @@ func Load() Config {
 		DKIMSignSelector:           env("MTA_DKIM_SIGN_SELECTOR", ""),
 		DKIMPrivateKeyFile:         env("MTA_DKIM_PRIVATE_KEY_FILE", ""),
 		DKIMSignHeaders:            env("MTA_DKIM_SIGN_HEADERS", "from:to:subject:date:message-id"),
+		ARCFailurePolicy:           envEnum("MTA_ARC_FAILURE_POLICY", "accept", []string{"accept", "quarantine", "reject"}),
 		SPFHeloPolicy:              envEnum("MTA_SPF_HELO_POLICY", "advisory", []string{"off", "advisory", "enforce"}),
 		SPFMailFromPolicy:          envEnum("MTA_SPF_MAILFROM_POLICY", "advisory", []string{"off", "advisory", "enforce"}),
 		DomainMaxConcurrentDefault: envInt("MTA_DOMAIN_MAX_CONCURRENT_DEFAULT", 8),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -150,6 +150,20 @@ func TestLoadSPFPolicyConfig(t *testing.T) {
 	}
 }
 
+func TestLoadARCFailurePolicyConfig(t *testing.T) {
+	t.Setenv("MTA_ARC_FAILURE_POLICY", "reject")
+	cfg := Load()
+	if cfg.ARCFailurePolicy != "reject" {
+		t.Fatalf("arc policy=%q", cfg.ARCFailurePolicy)
+	}
+
+	t.Setenv("MTA_ARC_FAILURE_POLICY", "invalid")
+	cfg = Load()
+	if cfg.ARCFailurePolicy != "accept" {
+		t.Fatalf("arc invalid should fallback, got=%q", cfg.ARCFailurePolicy)
+	}
+}
+
 func TestLoadDomainThrottleConfig(t *testing.T) {
 	t.Setenv("MTA_DOMAIN_MAX_CONCURRENT_DEFAULT", "4")
 	t.Setenv("MTA_DOMAIN_MAX_CONCURRENT_RULES", "gmail.com:2,yahoo.com:1")

--- a/internal/mailauth/pipeline.go
+++ b/internal/mailauth/pipeline.go
@@ -8,20 +8,31 @@ import (
 )
 
 type SPFPolicy struct {
-	HeloMode     string
-	MailFromMode string
+	HeloMode       string
+	MailFromMode   string
+	ARCFailureMode string
 }
 
 func DefaultSPFPolicy() SPFPolicy {
 	return SPFPolicy{
-		HeloMode:     "advisory",
-		MailFromMode: "advisory",
+		HeloMode:       "advisory",
+		MailFromMode:   "advisory",
+		ARCFailureMode: "accept",
 	}
 }
 
 func normalizeSPFMode(v, def string) string {
 	switch strings.ToLower(strings.TrimSpace(v)) {
 	case "off", "advisory", "enforce":
+		return strings.ToLower(strings.TrimSpace(v))
+	default:
+		return def
+	}
+}
+
+func normalizeARCFailureMode(v, def string) string {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "accept", "quarantine", "reject":
 		return strings.ToLower(strings.TrimSpace(v))
 	default:
 		return def
@@ -44,6 +55,7 @@ func EvaluateWithPolicy(remoteIP net.IP, helo, mailFrom string, raw []byte, poli
 
 	heloMode := normalizeSPFMode(policy.HeloMode, "advisory")
 	mailFromMode := normalizeSPFMode(policy.MailFromMode, "advisory")
+	arcFailureMode := normalizeARCFailureMode(policy.ARCFailureMode, "accept")
 
 	spfHelo := SPFResult{Result: "none", Reason: "helo spf disabled"}
 	if heloMode != "off" {
@@ -103,6 +115,16 @@ func EvaluateWithPolicy(remoteIP net.IP, helo, mailFrom string, raw []byte, poli
 		}
 	default:
 		result.Action = ActionAccept
+	}
+	if result.Action == ActionAccept && strings.EqualFold(strings.TrimSpace(arc.Result), "fail") {
+		switch arcFailureMode {
+		case "reject":
+			result.Action = ActionReject
+			result.Reason = "arc failure policy"
+		case "quarantine":
+			result.Action = ActionQuarantine
+			result.Reason = "arc failure policy"
+		}
 	}
 	return result
 }

--- a/internal/mailauth/pipeline_test.go
+++ b/internal/mailauth/pipeline_test.go
@@ -192,3 +192,101 @@ func TestDMARCSamplingBucketDeterministic(t *testing.T) {
 		t.Fatalf("bucket out of range: %d", a)
 	}
 }
+
+func TestEvaluateWithPolicy_ARCFailurePolicyReject(t *testing.T) {
+	origLookup := dmarcLookupTXT
+	t.Cleanup(func() {
+		dmarcLookupTXT = origLookup
+	})
+	dmarcLookupTXT = func(_ context.Context, _ string) ([]string, error) {
+		return nil, nil
+	}
+
+	raw := []byte("From: sender@example.com\r\nARC-Seal: i=1; cv=none\r\n\r\nbody")
+	res := EvaluateWithPolicy(nil, "mx.example.net", "sender@example.com", raw, SPFPolicy{
+		HeloMode:       "off",
+		MailFromMode:   "off",
+		ARCFailureMode: "reject",
+	})
+	if res.ARC.Result != "fail" {
+		t.Fatalf("arc result=%s want=fail", res.ARC.Result)
+	}
+	if res.Action != ActionReject {
+		t.Fatalf("action=%s want=%s", res.Action, ActionReject)
+	}
+	if res.Reason != "arc failure policy" {
+		t.Fatalf("reason=%q", res.Reason)
+	}
+}
+
+func TestEvaluateWithPolicy_ARCFailurePolicyQuarantine(t *testing.T) {
+	origLookup := dmarcLookupTXT
+	t.Cleanup(func() {
+		dmarcLookupTXT = origLookup
+	})
+	dmarcLookupTXT = func(_ context.Context, _ string) ([]string, error) {
+		return nil, nil
+	}
+
+	raw := []byte("From: sender@example.com\r\nARC-Seal: i=1; cv=none\r\n\r\nbody")
+	res := EvaluateWithPolicy(nil, "mx.example.net", "sender@example.com", raw, SPFPolicy{
+		HeloMode:       "off",
+		MailFromMode:   "off",
+		ARCFailureMode: "quarantine",
+	})
+	if res.ARC.Result != "fail" {
+		t.Fatalf("arc result=%s want=fail", res.ARC.Result)
+	}
+	if res.Action != ActionQuarantine {
+		t.Fatalf("action=%s want=%s", res.Action, ActionQuarantine)
+	}
+	if res.Reason != "arc failure policy" {
+		t.Fatalf("reason=%q", res.Reason)
+	}
+}
+
+func TestEvaluateWithPolicy_ARCFailurePolicy(t *testing.T) {
+	origDMARC := dmarcLookupTXT
+	t.Cleanup(func() {
+		dmarcLookupTXT = origDMARC
+	})
+	dmarcLookupTXT = func(_ context.Context, _ string) ([]string, error) {
+		return nil, nil
+	}
+
+	raw := []byte(strings.Join([]string{
+		"From: sender@example.com",
+		"To: rcpt@example.net",
+		"Subject: x",
+		"ARC-Authentication-Results: i=1; mx=example.net; dmarc=pass",
+		"ARC-Message-Signature: i=1; a=rsa-sha256; d=example.com; s=s1; h=from; bh=abc; b=abc",
+		"ARC-Seal: i=1; cv=none; a=rsa-sha256; d=example.com; s=s1; b=abc",
+		"",
+		"body",
+	}, "\r\n"))
+
+	tests := []struct {
+		mode       string
+		wantAction Action
+	}{
+		{mode: "accept", wantAction: ActionAccept},
+		{mode: "quarantine", wantAction: ActionQuarantine},
+		{mode: "reject", wantAction: ActionReject},
+	}
+	for _, tt := range tests {
+		res := EvaluateWithPolicy(nil, "mx.sender.test", "sender@example.com", raw, SPFPolicy{
+			HeloMode:       "advisory",
+			MailFromMode:   "advisory",
+			ARCFailureMode: tt.mode,
+		})
+		if res.ARC.Result != "fail" {
+			t.Fatalf("mode=%s arc result=%s want=fail", tt.mode, res.ARC.Result)
+		}
+		if res.Action != tt.wantAction {
+			t.Fatalf("mode=%s action=%s want=%s", tt.mode, res.Action, tt.wantAction)
+		}
+		if tt.wantAction != ActionAccept && res.Reason != "arc failure policy" {
+			t.Fatalf("mode=%s reason=%q", tt.mode, res.Reason)
+		}
+	}
+}

--- a/internal/smtp/server.go
+++ b/internal/smtp/server.go
@@ -323,8 +323,9 @@ func (s *Server) handleConn(conn net.Conn) {
 				msgRemoteIP = parseRemoteIP(ss.remote)
 			}
 			authRes := evaluateAuthWithPolicy(msgRemoteIP, ss.helo, ss.mailFrom, ss.data, mailauth.SPFPolicy{
-				HeloMode:     s.cfg.SPFHeloPolicy,
-				MailFromMode: s.cfg.SPFMailFromPolicy,
+				HeloMode:       s.cfg.SPFHeloPolicy,
+				MailFromMode:   s.cfg.SPFMailFromPolicy,
+				ARCFailureMode: s.cfg.ARCFailurePolicy,
 			})
 			s.metricAuthResult(authRes)
 			switch authRes.Action {


### PR DESCRIPTION
## Summary
- ARC 失敗時の扱いを設定可能にし、運用ポリシー（accept/quarantine/reject）を統一しました。

## Changes
- internal/config/config.go
  - `ARCFailurePolicy` を追加
  - `MTA_ARC_FAILURE_POLICY`（accept/quarantine/reject）を読み込み
- internal/config/config_test.go
  - ARC failure policy の読込テスト追加
- internal/mailauth/pipeline.go
  - `SPFPolicy` に `ARCFailureMode` を追加
  - ARC失敗時に `accept/quarantine/reject` を適用する分岐を追加
  - DMARC/SPFで既に reject/quarantine の場合は上書きしない
- internal/mailauth/pipeline_test.go
  - ARC failure policy のテーブルテストを追加
- internal/smtp/server.go
  - `EvaluateWithPolicy` 呼び出しに `ARCFailureMode` を連携
- README.md
  - `MTA_ARC_FAILURE_POLICY` 環境変数を追記

## Validation
- go test ./internal/config ./internal/mailauth ./internal/smtp
- go test ./...

Closes #71
