### PR TITLE
feat: DR向けバックアップ/リストア手順とドリルスクリプトを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,17 @@ Prometheus alert rule の雛形は [orinoco_slo_rules.yml](/home/tamago/ghq/gith
 - 障害注入ドリル補助スクリプト:
   `scripts/chaos/run_ha_drill.sh`
 
+## DR Backup / Restore
+
+- DR（Disaster Recovery, 災害対策）向け runbook:
+  [dr_backup_restore.md](/home/tamago/ghq/github.com/tamago/orinoco-mta/docs/runbooks/dr_backup_restore.md)
+- バックアップ:
+  `scripts/dr/backup_queue.sh ./var/queue ./var/backups`
+- リストア:
+  `scripts/dr/restore_queue.sh ./var/backups/orinoco-queue-<timestamp>.tar.gz ./var/queue --force`
+- DRドリル:
+  `scripts/chaos/run_dr_drill.sh ./var/queue ./var/backups --apply`
+
 ## Compliance Basics
 
 - ログは `slog(JSON)` で出力

--- a/docs/runbooks/dr_backup_restore.md
+++ b/docs/runbooks/dr_backup_restore.md
@@ -1,0 +1,73 @@
+# DR Backup / Restore Runbook
+
+Issue: #34
+
+## 目的
+
+- 災害対策（Disaster Recovery, DR）時に、Orinoco MTA のキュー状態を短時間で復旧する
+- 目標値を明示して定期的に検証する
+  - RTO (Recovery Time Objective): 5分以内
+  - RPO (Recovery Point Objective): 1分以内
+
+## 対象データ
+
+- `MTA_QUEUE_DIR` 配下（既定: `./var/queue`）
+  - `mail.inbound`
+  - `mail.retry`
+  - `mail.dlq`
+  - `sent`
+  - `suppression.json`
+
+## 事前準備
+
+- バックアップ保存先を用意（例: `./var/backups`）
+- バックアップ周期を RPO 目標以下に設定（例: 1分ごと）
+- 復旧手順を本番相当環境で定期演習
+
+## バックアップ手順
+
+```bash
+scripts/dr/backup_queue.sh ./var/queue ./var/backups
+```
+
+出力例:
+
+```text
+backup_created=./var/backups/orinoco-queue-20260316T010101Z.tar.gz host=mta-a queue_dir=./var/queue
+```
+
+## リストア手順
+
+```bash
+scripts/dr/restore_queue.sh ./var/backups/orinoco-queue-20260316T010101Z.tar.gz ./var/queue --force
+```
+
+- `--force` なしの場合、復旧先が空でないと失敗する
+- `--force` ありの場合、復旧先の既存データを削除して展開する
+
+## DRドリル手順
+
+```bash
+scripts/chaos/run_dr_drill.sh ./var/queue ./var/backups --apply
+```
+
+このスクリプトは以下を実行する:
+
+1. バックアップ作成
+2. 障害注入を想定した停止フェーズ（オペレーター作業）
+3. 最新アーカイブからの復旧
+4. 経過秒数の出力（`drill_elapsed_seconds`）
+
+## 検証項目
+
+- RPO: 最新バックアップの時刻が目標以内か
+- RTO: 障害検知から復旧完了までが 5 分以内か
+- 復旧後の整合性:
+  - キュー件数が想定範囲内
+  - SMTP受信/配送ワーカーが再開し配送が進む
+  - `/healthz` と `/slo` が正常
+
+## ロールバック
+
+- 復旧データに異常がある場合は直前の正常バックアップに再リストア
+- 影響範囲が広い場合はメール受信を一時停止し、キュー整合性を優先確認する

--- a/scripts/chaos/run_dr_drill.sh
+++ b/scripts/chaos/run_dr_drill.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# DR drill helper: backup -> simulated outage -> restore -> validation.
+
+QUEUE_DIR="${1:-./var/queue}"
+BACKUP_DIR="${2:-./var/backups}"
+APPLY="${3:-}"
+
+if [[ "${APPLY}" != "--apply" ]]; then
+  cat <<USAGE
+Usage:
+  scripts/chaos/run_dr_drill.sh [queue-dir] [backup-dir] --apply
+
+Without --apply this script only prints what would run.
+USAGE
+fi
+
+run() {
+  local cmd="$1"
+  if [[ "${APPLY}" == "--apply" ]]; then
+    echo "+ ${cmd}"
+    eval "${cmd}"
+  else
+    echo "[dry-run] ${cmd}"
+  fi
+}
+
+START_TS="$(date +%s)"
+
+run "scripts/dr/backup_queue.sh '${QUEUE_DIR}' '${BACKUP_DIR}'"
+run "echo 'simulate outage: stop MTA / queue backend here'"
+run "LATEST=\$(ls -1t '${BACKUP_DIR}'/orinoco-queue-*.tar.gz | head -n1) && scripts/dr/restore_queue.sh \"\${LATEST}\" '${QUEUE_DIR}' --force"
+run "echo 'post-check: go run ./cmd/mta and validate /healthz + queue processing'"
+
+END_TS="$(date +%s)"
+DURATION="$((END_TS - START_TS))"
+echo "drill_elapsed_seconds=${DURATION}"
+
+cat <<CHECKS
+Checks:
+  - RPO: latest backup timestamp <= target window
+  - RTO: restore+service recovery duration <= target window
+  - queue consistency: pending/retry/dlq counts are sensible after restore
+CHECKS

--- a/scripts/dr/backup_queue.sh
+++ b/scripts/dr/backup_queue.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create a compressed backup of queue state for DR operation.
+
+QUEUE_DIR="${1:-./var/queue}"
+BACKUP_DIR="${2:-./var/backups}"
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+HOST="$(hostname 2>/dev/null || echo unknown)"
+ARCHIVE="${BACKUP_DIR}/orinoco-queue-${TS}.tar.gz"
+
+if [[ ! -d "${QUEUE_DIR}" ]]; then
+  echo "queue dir not found: ${QUEUE_DIR}" >&2
+  exit 1
+fi
+
+mkdir -p "${BACKUP_DIR}"
+
+# Pack queue content as-is so runtime layout is preserved on restore.
+tar -czf "${ARCHIVE}" \
+  -C "${QUEUE_DIR}" .
+
+echo "backup_created=${ARCHIVE} host=${HOST} queue_dir=${QUEUE_DIR}"

--- a/scripts/dr/restore_queue.sh
+++ b/scripts/dr/restore_queue.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Restore queue state from backup archive.
+# Example:
+#   scripts/dr/restore_queue.sh ./var/backups/orinoco-queue-20260316T000000Z.tar.gz ./var/queue --force
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <backup-archive> [target-queue-dir] [--force]" >&2
+  exit 1
+fi
+
+ARCHIVE="$1"
+TARGET_DIR="${2:-./var/queue}"
+FORCE="${3:-}"
+
+if [[ ! -f "${ARCHIVE}" ]]; then
+  echo "archive not found: ${ARCHIVE}" >&2
+  exit 1
+fi
+
+if [[ -d "${TARGET_DIR}" ]] && [[ "$(find "${TARGET_DIR}" -mindepth 1 -print -quit 2>/dev/null || true)" != "" ]] && [[ "${FORCE}" != "--force" ]]; then
+  echo "target dir is not empty: ${TARGET_DIR}" >&2
+  echo "pass --force to overwrite" >&2
+  exit 1
+fi
+
+mkdir -p "${TARGET_DIR}"
+
+if [[ "${FORCE}" == "--force" ]]; then
+  # Clear only children under the target directory.
+  find "${TARGET_DIR}" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
+fi
+
+tar -xzf "${ARCHIVE}" -C "${TARGET_DIR}"
+
+echo "restore_completed target=${TARGET_DIR} archive=${ARCHIVE}"


### PR DESCRIPTION
## 概要
- DR（Disaster Recovery, 災害対策）向けに、キューデータのバックアップ/リストア手順を追加
- DRドリル実行用スクリプトを追加
- READMEに運用導線を追記

## 変更内容
- `scripts/dr/backup_queue.sh` を追加（`MTA_QUEUE_DIR` 相当のキュー内容をtar.gz化）
- `scripts/dr/restore_queue.sh` を追加（アーカイブからキューを復旧、`--force`対応）
- `scripts/chaos/run_dr_drill.sh` を追加（バックアップ→障害想定→復旧のドリル補助）
- `docs/runbooks/dr_backup_restore.md` を追加（RTO/RPO目標、運用手順、検証観点）
- READMEにDR手順セクションを追加

## 検証
- `bash -n scripts/dr/backup_queue.sh scripts/dr/restore_queue.sh scripts/chaos/run_dr_drill.sh`
- `scripts/chaos/run_dr_drill.sh ./var/queue ./var/backups`（dry-run）
- 一時ディレクトリで backup/restore のスモーク確認（復旧後に `mail.inbound` と `suppression.json` が存在）

## リスク / フォローアップ
- 現在はローカルファイルキュー前提。Kafkaバックエンド時のDR手順は別Issueで拡張が必要

Close #34
