### PR TITLE
feat: 負荷試験/カオス試験の基盤（loadgen + runbook）を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,15 @@ Prometheus alert rule の雛形は [orinoco_slo_rules.yml](/home/tamago/ghq/gith
 - 障害注入ドリル補助スクリプト:
   `scripts/chaos/run_ha_drill.sh`
 
+## Load / Chaos Testing
+
+- 負荷試験 runbook:
+  [load_chaos.md](/home/tamago/ghq/github.com/tamago/orinoco-mta/docs/runbooks/load_chaos.md)
+- 単体シナリオ実行:
+  `scripts/load/run_smtp_load.sh normal 127.0.0.1:2525`
+- カオス併用スイート:
+  `scripts/chaos/run_load_chaos_suite.sh 127.0.0.1:2525 --apply`
+
 ## DR Backup / Restore
 
 - DR（Disaster Recovery, 災害対策）向け runbook:

--- a/cmd/smtpload/main.go
+++ b/cmd/smtpload/main.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"flag"
+	"fmt"
+	"math"
+	"net"
+	"net/textproto"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type summary struct {
+	Address      string  `json:"address"`
+	Concurrency  int     `json:"concurrency"`
+	Requested    int     `json:"requested"`
+	Succeeded    int64   `json:"succeeded"`
+	Failed       int64   `json:"failed"`
+	DurationSec  float64 `json:"duration_sec"`
+	TPS          float64 `json:"tps"`
+	AvgMs        float64 `json:"avg_ms"`
+	P95Ms        float64 `json:"p95_ms"`
+	MaxMs        float64 `json:"max_ms"`
+	StartedAtUTC string  `json:"started_at_utc"`
+}
+
+func main() {
+	var (
+		addr        = flag.String("addr", "127.0.0.1:2525", "SMTP server address")
+		concurrency = flag.Int("concurrency", 10, "number of workers")
+		messages    = flag.Int("messages", 100, "number of messages to send")
+		from        = flag.String("from", "loadtest@example.net", "envelope from")
+		to          = flag.String("to", "receiver@example.net", "envelope to")
+		timeout     = flag.Duration("timeout", 8*time.Second, "dial/read/write timeout")
+	)
+	flag.Parse()
+
+	if *concurrency <= 0 || *messages <= 0 {
+		fmt.Fprintln(os.Stderr, "concurrency and messages must be > 0")
+		os.Exit(2)
+	}
+
+	started := time.Now().UTC()
+	jobs := make(chan int)
+	latCh := make(chan time.Duration, *messages)
+
+	var succeeded int64
+	var failed int64
+	var wg sync.WaitGroup
+
+	for i := 0; i < *concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for n := range jobs {
+				_ = n
+				t0 := time.Now()
+				err := sendOne(*addr, *from, *to, *timeout)
+				if err != nil {
+					atomic.AddInt64(&failed, 1)
+					continue
+				}
+				latCh <- time.Since(t0)
+				atomic.AddInt64(&succeeded, 1)
+			}
+		}()
+	}
+
+	begin := time.Now()
+	for i := 0; i < *messages; i++ {
+		jobs <- i
+	}
+	close(jobs)
+	wg.Wait()
+	close(latCh)
+	elapsed := time.Since(begin)
+
+	latencies := make([]float64, 0, len(latCh))
+	for d := range latCh {
+		latencies = append(latencies, float64(d.Microseconds())/1000.0)
+	}
+	sort.Float64s(latencies)
+
+	s := summary{
+		Address:      *addr,
+		Concurrency:  *concurrency,
+		Requested:    *messages,
+		Succeeded:    succeeded,
+		Failed:       failed,
+		DurationSec:  elapsed.Seconds(),
+		StartedAtUTC: started.Format(time.RFC3339),
+	}
+
+	if elapsed > 0 {
+		s.TPS = float64(succeeded) / elapsed.Seconds()
+	}
+	if len(latencies) > 0 {
+		var sum float64
+		for _, v := range latencies {
+			sum += v
+		}
+		s.AvgMs = sum / float64(len(latencies))
+		s.P95Ms = percentile(latencies, 95)
+		s.MaxMs = latencies[len(latencies)-1]
+	}
+
+	fmt.Printf("{\"address\":%q,\"concurrency\":%d,\"requested\":%d,\"succeeded\":%d,\"failed\":%d,\"duration_sec\":%.3f,\"tps\":%.3f,\"avg_ms\":%.3f,\"p95_ms\":%.3f,\"max_ms\":%.3f,\"started_at_utc\":%q}\n",
+		s.Address, s.Concurrency, s.Requested, s.Succeeded, s.Failed, s.DurationSec, s.TPS, s.AvgMs, s.P95Ms, s.MaxMs, s.StartedAtUTC)
+
+	if failed > 0 {
+		os.Exit(1)
+	}
+}
+
+func percentile(sorted []float64, p float64) float64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	if p <= 0 {
+		return sorted[0]
+	}
+	if p >= 100 {
+		return sorted[len(sorted)-1]
+	}
+	rank := (p / 100.0) * float64(len(sorted)-1)
+	lo := int(math.Floor(rank))
+	hi := int(math.Ceil(rank))
+	if lo == hi {
+		return sorted[lo]
+	}
+	frac := rank - float64(lo)
+	return sorted[lo] + (sorted[hi]-sorted[lo])*frac
+}
+
+func sendOne(addr, from, to string, timeout time.Duration) error {
+	conn, err := net.DialTimeout("tcp", addr, timeout)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(timeout))
+
+	tp := textproto.NewConn(conn)
+	defer tp.Close()
+
+	if _, _, err := tp.ReadResponse(220); err != nil {
+		return err
+	}
+	if err := sendCmd(tp, 250, "EHLO loadgen"); err != nil {
+		return err
+	}
+	if err := sendCmd(tp, 250, fmt.Sprintf("MAIL FROM:<%s>", from)); err != nil {
+		return err
+	}
+	if err := sendCmd(tp, 250, fmt.Sprintf("RCPT TO:<%s>", to)); err != nil {
+		return err
+	}
+	if err := sendCmd(tp, 354, "DATA"); err != nil {
+		return err
+	}
+
+	writer := bufio.NewWriter(conn)
+	msg := strings.Join([]string{
+		"From: <" + from + ">",
+		"To: <" + to + ">",
+		"Subject: Orinoco Load Test",
+		"Date: " + time.Now().UTC().Format(time.RFC1123Z),
+		"",
+		"load test message",
+		".",
+		"",
+	}, "\r\n")
+	if _, err := writer.WriteString(msg); err != nil {
+		return err
+	}
+	if err := writer.Flush(); err != nil {
+		return err
+	}
+
+	if _, _, err := tp.ReadResponse(250); err != nil {
+		return err
+	}
+	if err := sendCmd(tp, 221, "QUIT"); err != nil && !errors.Is(err, net.ErrClosed) {
+		return err
+	}
+	return nil
+}
+
+func sendCmd(tp *textproto.Conn, expect int, cmd string) error {
+	if err := tp.PrintfLine("%s", cmd); err != nil {
+		return err
+	}
+	_, _, err := tp.ReadResponse(expect)
+	return err
+}

--- a/cmd/smtpload/main_test.go
+++ b/cmd/smtpload/main_test.go
@@ -1,0 +1,16 @@
+package main
+
+import "testing"
+
+func TestPercentile(t *testing.T) {
+	xs := []float64{10, 20, 30, 40, 50}
+	if got := percentile(xs, 0); got != 10 {
+		t.Fatalf("p0=%v want=10", got)
+	}
+	if got := percentile(xs, 95); got < 45 || got > 50 {
+		t.Fatalf("p95=%v out of expected range", got)
+	}
+	if got := percentile(xs, 100); got != 50 {
+		t.Fatalf("p100=%v want=50", got)
+	}
+}

--- a/docs/runbooks/load_chaos.md
+++ b/docs/runbooks/load_chaos.md
@@ -1,0 +1,57 @@
+# Load / Chaos Test Runbook
+
+Issue: #35
+
+## 目的
+
+- SMTP受信のスループットと遅延を定量化する
+- 障害注入時の劣化挙動を再現し、運用上のボトルネックを特定する
+
+## シナリオ
+
+- normal: 日常想定
+- peak: ピーク想定
+- degraded: 障害時想定（HAドリル併用）
+
+## 実行手順
+
+1. MTAを起動
+
+```bash
+go run ./cmd/mta
+```
+
+2. 単体シナリオ実行
+
+```bash
+scripts/load/run_smtp_load.sh normal 127.0.0.1:2525
+scripts/load/run_smtp_load.sh peak 127.0.0.1:2525
+scripts/load/run_smtp_load.sh degraded 127.0.0.1:2525
+```
+
+3. カオス併用スイート実行
+
+```bash
+scripts/chaos/run_load_chaos_suite.sh 127.0.0.1:2525 --apply
+```
+
+## 出力
+
+`cmd/smtpload` は JSON を出力する。
+
+```json
+{"address":"127.0.0.1:2525","concurrency":10,"requested":200,"succeeded":200,"failed":0,"duration_sec":4.2,"tps":47.6,"avg_ms":20.1,"p95_ms":35.0,"max_ms":58.3,"started_at_utc":"2026-03-16T00:00:00Z"}
+```
+
+## 判定観点
+
+- TPS: 目標TPSを満たすか
+- p95遅延: 受け入れ閾値以内か
+- 失敗率: `failed / requested` が許容範囲か
+- カオス時の復帰: ドリル後に再び normal 相当の指標へ戻るか
+
+## 次の拡張候補
+
+- Queue backend（Kafka）別のシナリオ追加
+- SMTP Submission(587) 経路の負荷シナリオ追加
+- 指標収集を Prometheus pushgateway 連携で自動化

--- a/scripts/chaos/run_load_chaos_suite.sh
+++ b/scripts/chaos/run_load_chaos_suite.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Load + chaos baseline suite for Issue #35.
+# Runs normal load, optionally chaos drill, then degraded load.
+
+ADDR="${1:-127.0.0.1:2525}"
+APPLY="${2:-}"
+
+echo "+ scripts/load/run_smtp_load.sh normal ${ADDR}"
+scripts/load/run_smtp_load.sh normal "${ADDR}"
+
+if [[ "${APPLY}" == "--apply" ]]; then
+  echo "+ scripts/chaos/run_ha_drill.sh broker-a-down --apply"
+  scripts/chaos/run_ha_drill.sh broker-a-down --apply
+else
+  echo "[info] chaos drill skipped (pass --apply to execute)"
+fi
+
+echo "+ scripts/load/run_smtp_load.sh degraded ${ADDR}"
+scripts/load/run_smtp_load.sh degraded "${ADDR}"
+
+echo "suite_completed"

--- a/scripts/load/run_smtp_load.sh
+++ b/scripts/load/run_smtp_load.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# SMTP load scenario runner for Issue #35.
+
+SCENARIO="${1:-normal}"
+ADDR="${2:-127.0.0.1:2525}"
+
+case "${SCENARIO}" in
+  normal)
+    CONCURRENCY=10
+    MESSAGES=200
+    ;;
+  peak)
+    CONCURRENCY=50
+    MESSAGES=2000
+    ;;
+  degraded)
+    CONCURRENCY=20
+    MESSAGES=500
+    ;;
+  *)
+    echo "unknown scenario: ${SCENARIO}" >&2
+    echo "usage: $0 <normal|peak|degraded> [addr]" >&2
+    exit 2
+    ;;
+esac
+
+echo "scenario=${SCENARIO} addr=${ADDR} concurrency=${CONCURRENCY} messages=${MESSAGES}"
+
+go run ./cmd/smtpload \
+  -addr "${ADDR}" \
+  -concurrency "${CONCURRENCY}" \
+  -messages "${MESSAGES}" \
+  -from "loadtest@orinoco.local" \
+  -to "receiver@orinoco.local"


### PR DESCRIPTION
## 概要
- Issue #35 の第一段として、負荷試験/カオス試験の実行基盤を追加
- SMTP負荷生成ツール（Go実装）を追加
- シナリオ実行スクリプトとrunbookを追加

## 変更内容
- `cmd/smtpload` を追加
  - SMTPセッション（EHLO/MAIL/RCPT/DATA/QUIT）を自前で実行
  - 並列送信、成功/失敗件数、TPS、平均遅延、p95、最大遅延をJSON出力
- `scripts/load/run_smtp_load.sh` を追加
  - `normal` / `peak` / `degraded` シナリオを実行
- `scripts/chaos/run_load_chaos_suite.sh` を追加
  - normal実行 → （任意）HAドリル → degraded実行
- `docs/runbooks/load_chaos.md` を追加
- README に負荷/カオス試験の導線を追加

## 検証
- `go test ./cmd/smtpload`
- `bash -n scripts/load/run_smtp_load.sh scripts/chaos/run_load_chaos_suite.sh`

## 補足
- 本PRは基盤整備（第一段）で、容量計画の具体値策定は次PRで対応予定

Refs #35
