### PR TITLE
docs: 負荷試験結果の容量計画フローを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,9 @@ Prometheus alert rule の雛形は [orinoco_slo_rules.yml](/home/tamago/ghq/gith
 - 単体シナリオ実行:
   `scripts/load/run_smtp_load.sh normal 127.0.0.1:2525`
 - カオス併用スイート:
-  `scripts/chaos/run_load_chaos_suite.sh 127.0.0.1:2525 --apply`
+  `scripts/chaos/run_load_chaos_suite.sh 127.0.0.1:2525 --apply ./var/load-chaos/results.ndjson`
+- 容量計画表への整形:
+  `scripts/load/plan_capacity.sh ./var/load-chaos/results.ndjson`
 
 ## DR Backup / Restore
 

--- a/docs/runbooks/load_chaos.md
+++ b/docs/runbooks/load_chaos.md
@@ -13,6 +13,12 @@ Issue: #35
 - peak: ピーク想定
 - degraded: 障害時想定（HAドリル併用）
 
+## 目標値
+
+- normal: `tps >= 40`, `p95_ms <= 100`, `failed == 0`
+- peak: `tps >= 80`, `p95_ms <= 250`, `failed / requested <= 0.01`
+- degraded: `tps >= 20`, `p95_ms <= 300`, `failed / requested <= 0.05`
+
 ## 実行手順
 
 1. MTAを起動
@@ -32,7 +38,7 @@ scripts/load/run_smtp_load.sh degraded 127.0.0.1:2525
 3. カオス併用スイート実行
 
 ```bash
-scripts/chaos/run_load_chaos_suite.sh 127.0.0.1:2525 --apply
+scripts/chaos/run_load_chaos_suite.sh 127.0.0.1:2525 --apply ./var/load-chaos/results.ndjson
 ```
 
 ## 出力
@@ -49,6 +55,21 @@ scripts/chaos/run_load_chaos_suite.sh 127.0.0.1:2525 --apply
 - p95遅延: 受け入れ閾値以内か
 - 失敗率: `failed / requested` が許容範囲か
 - カオス時の復帰: ドリル後に再び normal 相当の指標へ戻るか
+
+## 容量計画の記録
+
+- `scripts/load/run_smtp_load.sh` の第3引数に `results.ndjson` を渡すと、シナリオ付きで結果を追記できる
+- `scripts/load/plan_capacity.sh ./var/load-chaos/results.ndjson` で Markdown 表に整形できる
+- 週次で同一条件の結果を記録し、CPU/メモリ/ディスク使用率と併せて容量計画表へ転記する
+
+出力例:
+
+```text
+| scenario | concurrency | requested | succeeded | failed | tps | avg_ms | p95_ms | max_ms |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| normal | 10 | 200 | 200 | 0 | 47.6 | 20.1 | 35.0 | 58.3 |
+| degraded | 20 | 500 | 497 | 3 | 22.4 | 84.3 | 140.2 | 220.7 |
+```
 
 ## 次の拡張候補
 

--- a/scripts/chaos/run_load_chaos_suite.sh
+++ b/scripts/chaos/run_load_chaos_suite.sh
@@ -6,9 +6,12 @@ set -euo pipefail
 
 ADDR="${1:-127.0.0.1:2525}"
 APPLY="${2:-}"
+RESULTS_FILE="${3:-./var/load-chaos/results.ndjson}"
 
-echo "+ scripts/load/run_smtp_load.sh normal ${ADDR}"
-scripts/load/run_smtp_load.sh normal "${ADDR}"
+mkdir -p "$(dirname "${RESULTS_FILE}")"
+
+echo "+ scripts/load/run_smtp_load.sh normal ${ADDR} ${RESULTS_FILE}"
+scripts/load/run_smtp_load.sh normal "${ADDR}" "${RESULTS_FILE}"
 
 if [[ "${APPLY}" == "--apply" ]]; then
   echo "+ scripts/chaos/run_ha_drill.sh broker-a-down --apply"
@@ -17,7 +20,9 @@ else
   echo "[info] chaos drill skipped (pass --apply to execute)"
 fi
 
-echo "+ scripts/load/run_smtp_load.sh degraded ${ADDR}"
-scripts/load/run_smtp_load.sh degraded "${ADDR}"
+echo "+ scripts/load/run_smtp_load.sh degraded ${ADDR} ${RESULTS_FILE}"
+scripts/load/run_smtp_load.sh degraded "${ADDR}" "${RESULTS_FILE}"
 
+echo "+ scripts/load/plan_capacity.sh ${RESULTS_FILE}"
+scripts/load/plan_capacity.sh "${RESULTS_FILE}"
 echo "suite_completed"

--- a/scripts/load/plan_capacity.sh
+++ b/scripts/load/plan_capacity.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Convert newline-delimited JSON summaries from cmd/smtpload into a markdown table.
+
+INPUT="${1:-}"
+
+if [[ -z "${INPUT}" ]]; then
+  echo "usage: $0 <results.ndjson>" >&2
+  exit 2
+fi
+
+if [[ ! -f "${INPUT}" ]]; then
+  echo "results file not found: ${INPUT}" >&2
+  exit 1
+fi
+
+jq -sr '
+  (
+    [
+    "| scenario | concurrency | requested | succeeded | failed | tps | avg_ms | p95_ms | max_ms |",
+    "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
+    ][]
+  ),
+  (
+    .[] as $row |
+    "| \($row.scenario // "unknown") | \($row.concurrency) | \($row.requested) | \($row.succeeded) | \($row.failed) | \($row.tps) | \($row.avg_ms) | \($row.p95_ms) | \($row.max_ms) |"
+  )
+' "${INPUT}"

--- a/scripts/load/run_smtp_load.sh
+++ b/scripts/load/run_smtp_load.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 SCENARIO="${1:-normal}"
 ADDR="${2:-127.0.0.1:2525}"
+OUT_FILE="${3:-}"
 
 case "${SCENARIO}" in
   normal)
@@ -28,9 +29,15 @@ esac
 
 echo "scenario=${SCENARIO} addr=${ADDR} concurrency=${CONCURRENCY} messages=${MESSAGES}"
 
-go run ./cmd/smtpload \
+RESULT="$(go run ./cmd/smtpload \
   -addr "${ADDR}" \
   -concurrency "${CONCURRENCY}" \
   -messages "${MESSAGES}" \
   -from "loadtest@orinoco.local" \
-  -to "receiver@orinoco.local"
+  -to "receiver@orinoco.local")"
+
+echo "${RESULT}"
+
+if [[ -n "${OUT_FILE}" ]]; then
+  echo "${RESULT}" | jq --arg scenario "${SCENARIO}" '. + {scenario: $scenario}' >> "${OUT_FILE}"
+fi


### PR DESCRIPTION
## 概要
- Issue #35 の残タスクとして、容量計画に使う結果整理フローを追加
- 負荷試験結果を NDJSON で蓄積し、Markdown 表へ整形できるようにした
- runbook に目標値と運用手順を追記した

## 変更内容
- `scripts/load/run_smtp_load.sh`
  - 第3引数に結果ファイルを受け取り、シナリオ名付きで NDJSON に追記
- `scripts/load/plan_capacity.sh`
  - `cmd/smtpload` の結果を Markdown 表へ整形
- `scripts/chaos/run_load_chaos_suite.sh`
  - 結果ファイル出力と表整形を組み込み
- `docs/runbooks/load_chaos.md`
  - normal / peak / degraded の目標値を追加
  - 容量計画の記録方法を追加
- `README.md`
  - 結果整形コマンドの導線を追加

## 検証
- `bash -n scripts/load/plan_capacity.sh scripts/load/run_smtp_load.sh scripts/chaos/run_load_chaos_suite.sh`
- サンプルNDJSONを使った `scripts/load/plan_capacity.sh` のスモーク確認

## 完了条件との対応
- 負荷試験シナリオ整備: 実施済み
- カオス試験自動化: 実施済み
- 容量計画の策定基盤: 今回追加

Close #35
