### PR TITLE
feat: 運用管理APIと最小CLIを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ go run ./cmd/mta
 - `MTA_SUBMISSION_ENFORCE_SENDER_IDENTITY` (default: `true`, requires `MAIL FROM` domain to match authenticated user domain)
 - `MTA_LOG_LEVEL` (default: `info`, values: `debug` / `info` / `warn` / `error`, logs are JSON via `slog`)
 - `MTA_OBSERVABILITY_ADDR` (default: `:9090`)
+- `MTA_ADMIN_ADDR` (default: unset)
+- `MTA_ADMIN_TOKENS` (default: unset, format: `viewer-token:viewer,operator-token:operator`)
 - `MTA_SLO_MIN_DELIVERY_SUCCESS_RATE` (default: `0.99`)
 - `MTA_SLO_MAX_RETRY_RATE` (default: `0.20`)
 - `MTA_SLO_MAX_QUEUE_BACKLOG` (default: `50000`)
@@ -199,6 +201,17 @@ Prometheus alert rule の雛形は [orinoco_slo_rules.yml](/home/tamago/ghq/gith
   `scripts/chaos/run_load_chaos_suite.sh 127.0.0.1:2525 --apply ./var/load-chaos/results.ndjson`
 - 容量計画表への整形:
   `scripts/load/plan_capacity.sh ./var/load-chaos/results.ndjson`
+
+## Admin API
+
+- runbook:
+  [admin_api.md](/home/tamago/ghq/github.com/tamago/orinoco-mta/docs/runbooks/admin_api.md)
+- 最小CLI:
+  `scripts/admin/orinoco_admin.sh`
+- 対応操作:
+  `suppression` 一覧/追加/削除、`retry` / `dlq` 一覧、再投入
+- 認可:
+  Bearer token + role（`viewer` / `operator` / `admin`）
 
 ## DR Backup / Restore
 

--- a/cmd/mta/main.go
+++ b/cmd/mta/main.go
@@ -9,11 +9,14 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 
+	"github.com/tamago0224/orinoco-mta/internal/admin"
 	"github.com/tamago0224/orinoco-mta/internal/bounce"
 	"github.com/tamago0224/orinoco-mta/internal/config"
 	"github.com/tamago0224/orinoco-mta/internal/delivery"
 	"github.com/tamago0224/orinoco-mta/internal/logging"
+	"github.com/tamago0224/orinoco-mta/internal/model"
 	"github.com/tamago0224/orinoco-mta/internal/observability"
 	"github.com/tamago0224/orinoco-mta/internal/queue"
 	"github.com/tamago0224/orinoco-mta/internal/retention"
@@ -63,6 +66,9 @@ func main() {
 	if submissionServer != nil {
 		workers++
 	}
+	if cfg.AdminAddr != "" {
+		workers++
+	}
 	workers++
 	errCh := make(chan error, workers)
 	go func() { errCh <- s.Run(ctx) }()
@@ -71,6 +77,16 @@ func main() {
 	}
 	go func() { errCh <- d.Run(ctx) }()
 	go func() { errCh <- observability.RunServer(ctx, cfg.ObservabilityAddr, metrics) }()
+	if cfg.AdminAddr != "" {
+		var queueAdmin interface {
+			ListState(state string, limit int) ([]*model.Message, error)
+			RequeueFromState(state, id string, now time.Time) (*model.Message, error)
+		}
+		if localQueue, ok := q.(*queue.Store); ok {
+			queueAdmin = localQueue
+		}
+		go func() { errCh <- admin.RunServer(ctx, cfg.AdminAddr, cfg.AdminTokens, sup, queueAdmin) }()
+	}
 	go func() {
 		errCh <- retention.Run(ctx, cfg.QueueDir, retention.Policy{
 			SentTTL:   cfg.DataRetentionSent,

--- a/docs/runbooks/admin_api.md
+++ b/docs/runbooks/admin_api.md
@@ -1,0 +1,62 @@
+# Admin API Runbook
+
+Issue: #36
+
+## 目的
+
+- 再送キューや `mail.dlq` の再投入を手作業ファイル操作なしで実施する
+- suppression list を API 経由で安全に操作する
+- 操作を監査ログへ残す
+
+## 有効化
+
+- `MTA_ADMIN_ADDR=:9091`
+- `MTA_ADMIN_TOKENS=viewer-token:viewer,operator-token:operator,admin-token:admin`
+
+`MTA_ADMIN_TOKENS` は `token:role` のカンマ区切りで指定する。
+
+## 権限
+
+- `viewer`: 一覧参照
+- `operator`: 一覧参照、requeue、suppression 追加/削除
+- `admin`: 現時点では `operator` と同等。将来の危険操作用に予約
+
+## API
+
+- `GET /api/v1/suppressions`
+- `POST /api/v1/suppressions`
+- `DELETE /api/v1/suppressions/{address}`
+- `GET /api/v1/queue/{state}?limit=50`
+- `POST /api/v1/queue/{state}/{message_id}/requeue`
+
+`state` は `retry` または `dlq` を想定する。
+
+## dry-run
+
+- suppression 削除:
+  `DELETE /api/v1/suppressions/user@example.com?dry_run=1`
+- 再投入:
+  `POST /api/v1/queue/dlq/msg-1/requeue?dry_run=1`
+
+## CLI
+
+```bash
+export ORINOCO_ADMIN_URL=http://127.0.0.1:9091
+export ORINOCO_ADMIN_TOKEN=operator-token
+export ORINOCO_ADMIN_ACTOR=oncall@example.com
+
+scripts/admin/orinoco_admin.sh list-suppressions
+scripts/admin/orinoco_admin.sh add-suppression user@example.com manual
+scripts/admin/orinoco_admin.sh list-queue dlq 20
+scripts/admin/orinoco_admin.sh requeue dlq msg-1 --dry-run
+```
+
+## 監査ログ
+
+- すべての運用操作は `component=audit` で JSON ログ出力
+- `event`, `actor`, `path`, `message_id`, `dry_run` を含む
+
+## 制約
+
+- 現時点の queue 操作はローカルファイルバックエンド専用
+- Kafka バックエンドの運用APIは別対応

--- a/internal/admin/api.go
+++ b/internal/admin/api.go
@@ -1,0 +1,249 @@
+package admin
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/tamago0224/orinoco-mta/internal/bounce"
+	"github.com/tamago0224/orinoco-mta/internal/model"
+	"github.com/tamago0224/orinoco-mta/internal/queue"
+)
+
+type queueManager interface {
+	ListState(state string, limit int) ([]*model.Message, error)
+	RequeueFromState(state, id string, now time.Time) (*model.Message, error)
+}
+
+type role string
+
+const (
+	roleViewer   role = "viewer"
+	roleOperator role = "operator"
+	roleAdmin    role = "admin"
+)
+
+type API struct {
+	suppressions *bounce.SuppressionStore
+	queue        queueManager
+	tokens       map[string]role
+	now          func() time.Time
+}
+
+func NewAPI(s *bounce.SuppressionStore, q queueManager, tokenConfig string) *API {
+	return &API{
+		suppressions: s,
+		queue:        q,
+		tokens:       parseTokens(tokenConfig),
+		now:          time.Now,
+	}
+}
+
+func (a *API) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/suppressions", a.handleSuppressions)
+	mux.HandleFunc("/api/v1/suppressions/", a.handleSuppressionByAddress)
+	mux.HandleFunc("/api/v1/queue/", a.handleQueue)
+	return mux
+}
+
+func parseTokens(v string) map[string]role {
+	out := map[string]role{}
+	for _, part := range strings.Split(v, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		fields := strings.SplitN(part, ":", 2)
+		if len(fields) != 2 {
+			continue
+		}
+		token := strings.TrimSpace(fields[0])
+		r := role(strings.ToLower(strings.TrimSpace(fields[1])))
+		if token == "" {
+			continue
+		}
+		switch r {
+		case roleViewer, roleOperator, roleAdmin:
+			out[token] = r
+		}
+	}
+	return out
+}
+
+func (a *API) authorize(w http.ResponseWriter, r *http.Request, min role) (role, bool) {
+	header := strings.TrimSpace(r.Header.Get("Authorization"))
+	if !strings.HasPrefix(header, "Bearer ") {
+		http.Error(w, "missing bearer token", http.StatusUnauthorized)
+		return "", false
+	}
+	token := strings.TrimSpace(strings.TrimPrefix(header, "Bearer "))
+	got, ok := a.tokens[token]
+	if !ok || !roleAllowed(got, min) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return "", false
+	}
+	return got, true
+}
+
+func roleAllowed(got, min role) bool {
+	order := map[role]int{roleViewer: 1, roleOperator: 2, roleAdmin: 3}
+	return order[got] >= order[min]
+}
+
+func (a *API) handleSuppressions(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		if _, ok := a.authorize(w, r, roleViewer); !ok {
+			return
+		}
+		if a.suppressions == nil {
+			http.Error(w, "suppression admin is unavailable", http.StatusNotImplemented)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"items": a.suppressions.List()})
+	case http.MethodPost:
+		if _, ok := a.authorize(w, r, roleOperator); !ok {
+			return
+		}
+		if a.suppressions == nil {
+			http.Error(w, "suppression admin is unavailable", http.StatusNotImplemented)
+			return
+		}
+		var req struct {
+			Address string `json:"address"`
+			Reason  string `json:"reason"`
+			DryRun  bool   `json:"dry_run"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
+		if strings.TrimSpace(req.Address) == "" {
+			http.Error(w, "address is required", http.StatusBadRequest)
+			return
+		}
+		if !req.DryRun {
+			if err := a.suppressions.Add(req.Address, req.Reason); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+		a.audit(r, "suppression_add", map[string]any{"address": req.Address, "dry_run": req.DryRun})
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true, "dry_run": req.DryRun})
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (a *API) handleSuppressionByAddress(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if _, ok := a.authorize(w, r, roleOperator); !ok {
+		return
+	}
+	if a.suppressions == nil {
+		http.Error(w, "suppression admin is unavailable", http.StatusNotImplemented)
+		return
+	}
+	address := strings.TrimPrefix(r.URL.Path, "/api/v1/suppressions/")
+	if address == "" {
+		http.Error(w, "address is required", http.StatusBadRequest)
+		return
+	}
+	dryRun := r.URL.Query().Get("dry_run") == "1"
+	removed := false
+	var err error
+	if !dryRun {
+		removed, err = a.suppressions.Remove(address)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+	a.audit(r, "suppression_remove", map[string]any{"address": address, "dry_run": dryRun})
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "removed": removed, "dry_run": dryRun})
+}
+
+func (a *API) handleQueue(w http.ResponseWriter, r *http.Request) {
+	if a.queue == nil {
+		http.Error(w, "queue admin is unavailable", http.StatusNotImplemented)
+		return
+	}
+	path := strings.TrimPrefix(r.URL.Path, "/api/v1/queue/")
+	parts := strings.Split(path, "/")
+	if len(parts) == 1 && r.Method == http.MethodGet {
+		if _, ok := a.authorize(w, r, roleViewer); !ok {
+			return
+		}
+		state := strings.TrimSpace(parts[0])
+		limit := 50
+		if v := r.URL.Query().Get("limit"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				limit = n
+			}
+		}
+		items, err := a.queue.ListState(state, limit)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"items": items})
+		return
+	}
+	if len(parts) == 3 && r.Method == http.MethodPost && parts[2] == "requeue" {
+		if _, ok := a.authorize(w, r, roleOperator); !ok {
+			return
+		}
+		state := strings.TrimSpace(parts[0])
+		id := strings.TrimSpace(parts[1])
+		dryRun := r.URL.Query().Get("dry_run") == "1"
+		if dryRun {
+			a.audit(r, "queue_requeue", map[string]any{"state": state, "message_id": id, "dry_run": true})
+			writeJSON(w, http.StatusOK, map[string]any{"ok": true, "dry_run": true})
+			return
+		}
+		msg, err := a.queue.RequeueFromState(state, id, a.now().UTC())
+		if err != nil {
+			code := http.StatusInternalServerError
+			if errors.Is(err, queue.ErrMessageNotFound) {
+				code = http.StatusNotFound
+			} else if strings.Contains(err.Error(), "unknown queue state") {
+				code = http.StatusBadRequest
+			}
+			http.Error(w, err.Error(), code)
+			return
+		}
+		a.audit(r, "queue_requeue", map[string]any{"state": state, "message_id": id, "dry_run": false})
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true, "message": msg})
+		return
+	}
+	http.NotFound(w, r)
+}
+
+func (a *API) audit(r *http.Request, event string, attrs map[string]any) {
+	fields := []any{"component", "audit", "event", event, "actor", actorFromRequest(r), "method", r.Method, "path", r.URL.Path}
+	for k, v := range attrs {
+		fields = append(fields, k, v)
+	}
+	slog.Info("admin operation", fields...)
+}
+
+func actorFromRequest(r *http.Request) string {
+	if v := strings.TrimSpace(r.Header.Get("X-Admin-Actor")); v != "" {
+		return v
+	}
+	return "unknown"
+}
+
+func writeJSON(w http.ResponseWriter, code int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/internal/admin/api_test.go
+++ b/internal/admin/api_test.go
@@ -1,0 +1,110 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tamago0224/orinoco-mta/internal/bounce"
+	"github.com/tamago0224/orinoco-mta/internal/model"
+	"github.com/tamago0224/orinoco-mta/internal/queue"
+)
+
+func TestSuppressionsAPIRequiresBearerToken(t *testing.T) {
+	s, err := bounce.NewSuppressionStore(filepath.Join(t.TempDir(), "suppression.json"))
+	if err != nil {
+		t.Fatalf("new suppression store: %v", err)
+	}
+	api := NewAPI(s, nil, "viewer-token:viewer")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/suppressions", nil)
+	rec := httptest.NewRecorder()
+	api.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status=%d want=%d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestSuppressionsAPIAddAndDelete(t *testing.T) {
+	s, err := bounce.NewSuppressionStore(filepath.Join(t.TempDir(), "suppression.json"))
+	if err != nil {
+		t.Fatalf("new suppression store: %v", err)
+	}
+	api := NewAPI(s, nil, "operator-token:operator")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/suppressions", strings.NewReader(`{"address":"user@example.com","reason":"manual"}`))
+	req.Header.Set("Authorization", "Bearer operator-token")
+	rec := httptest.NewRecorder()
+	api.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("add status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if !s.IsSuppressed("user@example.com") {
+		t.Fatal("suppression was not added")
+	}
+
+	req = httptest.NewRequest(http.MethodDelete, "/api/v1/suppressions/user@example.com", nil)
+	req.Header.Set("Authorization", "Bearer operator-token")
+	rec = httptest.NewRecorder()
+	api.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("delete status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if s.IsSuppressed("user@example.com") {
+		t.Fatal("suppression was not removed")
+	}
+}
+
+func TestQueueAPIListAndRequeue(t *testing.T) {
+	store, err := queue.New(filepath.Join(t.TempDir(), "queue"))
+	if err != nil {
+		t.Fatalf("new queue: %v", err)
+	}
+	msg := &model.Message{ID: "m1", MailFrom: "sender@example.com", RcptTo: []string{"rcpt@example.net"}, Data: []byte("x")}
+	if err := store.Enqueue(msg); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	if err := store.Fail(msg, "perm"); err != nil {
+		t.Fatalf("fail: %v", err)
+	}
+
+	api := NewAPI(nil, store, "viewer-token:viewer,operator-token:operator")
+	api.now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/queue/dlq?limit=10", nil)
+	req.Header.Set("Authorization", "Bearer viewer-token")
+	rec := httptest.NewRecorder()
+	api.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var listed struct {
+		Items []model.Message `json:"items"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("unmarshal list: %v", err)
+	}
+	if len(listed.Items) != 1 || listed.Items[0].ID != "m1" {
+		t.Fatalf("listed items=%+v", listed.Items)
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/queue/dlq/m1/requeue", nil)
+	req.Header.Set("Authorization", "Bearer operator-token")
+	rec = httptest.NewRecorder()
+	api.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("requeue status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	inbound, err := store.ListState("inbound", 10)
+	if err != nil {
+		t.Fatalf("list inbound: %v", err)
+	}
+	if len(inbound) != 1 || inbound[0].ID != "m1" {
+		t.Fatalf("inbound items=%+v", inbound)
+	}
+}

--- a/internal/admin/server.go
+++ b/internal/admin/server.go
@@ -1,0 +1,27 @@
+package admin
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+
+	"github.com/tamago0224/orinoco-mta/internal/bounce"
+)
+
+func RunServer(ctx context.Context, addr, tokenConfig string, suppressions *bounce.SuppressionStore, queue queueManager) error {
+	if addr == "" {
+		return nil
+	}
+	api := NewAPI(suppressions, queue, tokenConfig)
+	srv := &http.Server{Addr: addr, Handler: api.Handler()}
+	go func() {
+		<-ctx.Done()
+		_ = srv.Shutdown(context.Background())
+	}()
+	slog.Info("admin api listening", "component", "admin", "listen_addr", addr)
+	err := srv.ListenAndServe()
+	if err == http.ErrServerClosed {
+		return nil
+	}
+	return err
+}

--- a/internal/bounce/suppression.go
+++ b/internal/bounce/suppression.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -58,6 +59,40 @@ func (s *SuppressionStore) Add(addr, reason string) error {
 	}
 	s.entries[n] = SuppressionEntry{Address: n, Reason: reason, CreatedAt: time.Now().UTC()}
 	return s.saveLocked()
+}
+
+func (s *SuppressionStore) Remove(addr string) (bool, error) {
+	n := normalizeAddress(addr)
+	if n == "" {
+		return false, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.entries[n]; !ok {
+		return false, nil
+	}
+	delete(s.entries, n)
+	return true, s.saveLocked()
+}
+
+func (s *SuppressionStore) List() []SuppressionEntry {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]SuppressionEntry, 0, len(s.entries))
+	for _, e := range s.entries {
+		out = append(out, e)
+	}
+	slices.SortFunc(out, func(a, b SuppressionEntry) int {
+		switch {
+		case a.Address < b.Address:
+			return -1
+		case a.Address > b.Address:
+			return 1
+		default:
+			return 0
+		}
+	})
+	return out
 }
 
 func (s *SuppressionStore) load() error {

--- a/internal/bounce/suppression_test.go
+++ b/internal/bounce/suppression_test.go
@@ -26,3 +26,36 @@ func TestSuppressionStoreAddAndPersist(t *testing.T) {
 		t.Fatal("suppression should persist")
 	}
 }
+
+func TestSuppressionStoreListAndRemove(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "suppression.json")
+	s, err := NewSuppressionStore(p)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	if err := s.Add("b@example.com", "bounce"); err != nil {
+		t.Fatalf("add b: %v", err)
+	}
+	if err := s.Add("a@example.com", "policy"); err != nil {
+		t.Fatalf("add a: %v", err)
+	}
+
+	list := s.List()
+	if len(list) != 2 {
+		t.Fatalf("list len=%d want=2", len(list))
+	}
+	if list[0].Address != "a@example.com" || list[1].Address != "b@example.com" {
+		t.Fatalf("sorted list unexpected: %+v", list)
+	}
+
+	removed, err := s.Remove("A@example.com")
+	if err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if !removed {
+		t.Fatal("expected remove=true")
+	}
+	if s.IsSuppressed("a@example.com") {
+		t.Fatal("address should have been removed")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,8 @@ type Config struct {
 	SubmissionSenderID         bool
 	LogLevel                   string
 	ObservabilityAddr          string
+	AdminAddr                  string
+	AdminTokens                string
 	Hostname                   string
 	QueueDir                   string
 	QueueBackend               string
@@ -73,6 +75,8 @@ func Load() Config {
 		SubmissionSenderID: envBool("MTA_SUBMISSION_ENFORCE_SENDER_IDENTITY", true),
 		LogLevel:           env("MTA_LOG_LEVEL", "info"),
 		ObservabilityAddr:  env("MTA_OBSERVABILITY_ADDR", ":9090"),
+		AdminAddr:          env("MTA_ADMIN_ADDR", ""),
+		AdminTokens:        envOrFile("MTA_ADMIN_TOKENS", "MTA_ADMIN_TOKENS_FILE", ""),
 		Hostname:           env("MTA_HOSTNAME", "orinoco.local"),
 		QueueDir:           env("MTA_QUEUE_DIR", "./var/queue"),
 		QueueBackend:       env("MTA_QUEUE_BACKEND", "local"),

--- a/internal/queue/store.go
+++ b/internal/queue/store.go
@@ -83,6 +83,62 @@ func (s *Store) Due(limit int) ([]*model.Message, error) {
 	return out, nil
 }
 
+func (s *Store) ListState(state string, limit int) ([]*model.Message, error) {
+	dir, err := s.dirForState(state)
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	out := make([]*model.Message, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		msg, err := s.read(filepath.Join(dir, e.Name()))
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, msg)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].UpdatedAt.After(out[j].UpdatedAt)
+	})
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+func (s *Store) RequeueFromState(state, id string, now time.Time) (*model.Message, error) {
+	dir, err := s.dirForState(state)
+	if err != nil {
+		return nil, err
+	}
+	path := filepath.Join(dir, id+".json")
+	msg, err := s.read(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, ErrMessageNotFound
+		}
+		return nil, err
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+	msg.UpdatedAt = now.UTC()
+	msg.NextAttempt = now.UTC()
+	if err := s.write(filepath.Join(s.inbound, id+".json"), msg); err != nil {
+		return nil, err
+	}
+	return msg, nil
+}
+
 func (s *Store) AckSent(id string, msg *model.Message) error {
 	st, err := s.messageState(id)
 	if err != nil {
@@ -254,4 +310,19 @@ func (s *Store) messageState(id string) (string, error) {
 		}
 	}
 	return "none", nil
+}
+
+func (s *Store) dirForState(state string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "inbound":
+		return s.inbound, nil
+	case "retry":
+		return s.retry, nil
+	case "dlq":
+		return s.dlq, nil
+	case "sent":
+		return s.sent, nil
+	default:
+		return "", errors.New("unknown queue state: " + state)
+	}
 }

--- a/internal/queue/store_test.go
+++ b/internal/queue/store_test.go
@@ -195,3 +195,61 @@ func TestStoreDueReadsLegacyPending(t *testing.T) {
 		t.Fatalf("expected legacy message due, got=%v", due)
 	}
 }
+
+func TestStoreRequeueFromRetryAndDLQ(t *testing.T) {
+	d := t.TempDir()
+	s, err := New(filepath.Join(d, "queue"))
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	retryMsg := &model.Message{ID: "m-retry", MailFrom: "sender@example.com", RcptTo: []string{"r@example.net"}, Data: []byte("x")}
+	if err := s.Enqueue(retryMsg); err != nil {
+		t.Fatalf("enqueue retry: %v", err)
+	}
+	if err := s.Retry(retryMsg, time.Hour, "temp"); err != nil {
+		t.Fatalf("retry: %v", err)
+	}
+	if _, err := s.RequeueFromState("retry", "m-retry", time.Now()); err != nil {
+		t.Fatalf("requeue retry: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(d, "queue", "mail.inbound", "m-retry.json")); err != nil {
+		t.Fatalf("requeued inbound not found: %v", err)
+	}
+
+	dlqMsg := &model.Message{ID: "m-dlq", MailFrom: "sender@example.com", RcptTo: []string{"r@example.net"}, Data: []byte("x")}
+	if err := s.Enqueue(dlqMsg); err != nil {
+		t.Fatalf("enqueue dlq: %v", err)
+	}
+	if err := s.Fail(dlqMsg, "perm"); err != nil {
+		t.Fatalf("fail: %v", err)
+	}
+	if _, err := s.RequeueFromState("dlq", "m-dlq", time.Now()); err != nil {
+		t.Fatalf("requeue dlq: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(d, "queue", "mail.inbound", "m-dlq.json")); err != nil {
+		t.Fatalf("requeued inbound from dlq not found: %v", err)
+	}
+}
+
+func TestStoreListState(t *testing.T) {
+	d := t.TempDir()
+	s, err := New(filepath.Join(d, "queue"))
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	msg := &model.Message{ID: "m-list", MailFrom: "sender@example.com", RcptTo: []string{"r@example.net"}, Data: []byte("x")}
+	if err := s.Enqueue(msg); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	if err := s.Retry(msg, time.Hour, "temp"); err != nil {
+		t.Fatalf("retry: %v", err)
+	}
+	list, err := s.ListState("retry", 10)
+	if err != nil {
+		t.Fatalf("list retry: %v", err)
+	}
+	if len(list) != 1 || list[0].ID != "m-list" {
+		t.Fatalf("list=%v", list)
+	}
+}

--- a/scripts/admin/orinoco_admin.sh
+++ b/scripts/admin/orinoco_admin.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${ORINOCO_ADMIN_URL:-http://127.0.0.1:9091}"
+TOKEN="${ORINOCO_ADMIN_TOKEN:-}"
+ACTOR="${ORINOCO_ADMIN_ACTOR:-cli}"
+
+if [[ -z "${TOKEN}" ]]; then
+  echo "ORINOCO_ADMIN_TOKEN is required" >&2
+  exit 1
+fi
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <command> [args...]" >&2
+  exit 2
+fi
+
+auth_args=(
+  -H "Authorization: Bearer ${TOKEN}"
+  -H "X-Admin-Actor: ${ACTOR}"
+  -H "Content-Type: application/json"
+)
+
+cmd="$1"
+shift
+
+case "${cmd}" in
+  list-suppressions)
+    curl -fsS "${auth_args[@]}" "${BASE_URL}/api/v1/suppressions"
+    ;;
+  add-suppression)
+    addr="${1:-}"
+    reason="${2:-manual}"
+    curl -fsS "${auth_args[@]}" -X POST \
+      -d "{\"address\":\"${addr}\",\"reason\":\"${reason}\"}" \
+      "${BASE_URL}/api/v1/suppressions"
+    ;;
+  remove-suppression)
+    addr="${1:-}"
+    curl -fsS "${auth_args[@]}" -X DELETE \
+      "${BASE_URL}/api/v1/suppressions/${addr}"
+    ;;
+  list-queue)
+    state="${1:-retry}"
+    limit="${2:-50}"
+    curl -fsS "${auth_args[@]}" \
+      "${BASE_URL}/api/v1/queue/${state}?limit=${limit}"
+    ;;
+  requeue)
+    state="${1:-}"
+    id="${2:-}"
+    dry="${3:-}"
+    url="${BASE_URL}/api/v1/queue/${state}/${id}/requeue"
+    if [[ "${dry}" == "--dry-run" ]]; then
+      url="${url}?dry_run=1"
+    fi
+    curl -fsS "${auth_args[@]}" -X POST "${url}"
+    ;;
+  *)
+    echo "unknown command: ${cmd}" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## 概要
- Issue #36 として、運用管理APIの最小実装を追加
- suppression 操作と retry / dlq の再投入をHTTP API経由で実行可能にした
- Bearer token + role による認可、監査ログ、最小CLIを追加した

## 変更内容
- `internal/admin`
  - `/api/v1/suppressions` 一覧/追加/削除
  - `/api/v1/queue/{state}` 一覧
  - `/api/v1/queue/{state}/{message_id}/requeue` 再投入
  - Bearer token + role (`viewer` / `operator` / `admin`) 認可
  - `component=audit` の監査ログ出力
- `internal/bounce.SuppressionStore`
  - `List` / `Remove` を追加
- `internal/queue.Store`
  - `ListState` / `RequeueFromState` を追加
- `cmd/mta`
  - `MTA_ADMIN_ADDR` / `MTA_ADMIN_TOKENS` による管理API起動を追加
- `scripts/admin/orinoco_admin.sh`
  - 最小CLIを追加
- `docs/runbooks/admin_api.md`
  - 運用手順とAPI例を追加

## 検証
- `go test ./internal/admin ./internal/bounce ./internal/queue ./internal/observability`
- `go build ./cmd/mta`
- `bash -n scripts/admin/orinoco_admin.sh`

## 制約
- queue の運用APIは現時点でローカルファイルバックエンド向け
- Kafka バックエンドの再投入APIは別対応
- バルク操作はまだ未対応で、現状は単体操作 + dry-run のみ

Close #36
