### PR TITLE
feat: reputation制御と可視化を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ go run ./cmd/mta
 - `MTA_OBSERVABILITY_ADDR` (default: `:9090`)
 - `MTA_ADMIN_ADDR` (default: unset)
 - `MTA_ADMIN_TOKENS` (default: unset, format: `viewer-token:viewer,operator-token:operator`)
+- `MTA_REPUTATION_START_DATE` (default: unset, format: `YYYY-MM-DD`)
+- `MTA_REPUTATION_WARMUP_RULES` (default: `0:100,7:1000,14:5000`)
+- `MTA_REPUTATION_BOUNCE_THRESHOLD` (default: `0.05`)
+- `MTA_REPUTATION_COMPLAINT_THRESHOLD` (default: `0.001`)
+- `MTA_REPUTATION_MIN_SAMPLES` (default: `100`)
 - `MTA_SLO_MIN_DELIVERY_SUCCESS_RATE` (default: `0.99`)
 - `MTA_SLO_MAX_RETRY_RATE` (default: `0.20`)
 - `MTA_SLO_MAX_QUEUE_BACKLOG` (default: `50000`)
@@ -212,6 +217,16 @@ Prometheus alert rule の雛形は [orinoco_slo_rules.yml](/home/tamago/ghq/gith
   `suppression` 一覧/追加/削除、`retry` / `dlq` 一覧、再投入
 - 認可:
   Bearer token + role（`viewer` / `operator` / `admin`）
+
+## Reputation Controls
+
+- runbook:
+  [reputation_ops.md](/home/tamago/ghq/github.com/tamago/orinoco-mta/docs/runbooks/reputation_ops.md)
+- 可視化:
+  `GET /reputation`
+- 記録:
+  `scripts/admin/orinoco_admin.sh record-complaint gmail.com`
+  `scripts/admin/orinoco_admin.sh record-tlsrpt gmail.com false`
 
 ## DR Backup / Restore
 

--- a/cmd/mta/main.go
+++ b/cmd/mta/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/tamago0224/orinoco-mta/internal/model"
 	"github.com/tamago0224/orinoco-mta/internal/observability"
 	"github.com/tamago0224/orinoco-mta/internal/queue"
+	"github.com/tamago0224/orinoco-mta/internal/reputation"
 	"github.com/tamago0224/orinoco-mta/internal/retention"
 	"github.com/tamago0224/orinoco-mta/internal/smtp"
 	"github.com/tamago0224/orinoco-mta/internal/userauth"
@@ -47,8 +48,15 @@ func main() {
 		fatal("suppression init failed", "error", err)
 	}
 	metrics := observability.NewMetrics()
+	rep := reputation.New(reputation.Config{
+		StartDate:          reputation.ParseStartDate(cfg.ReputationStartDate),
+		WarmupRules:        reputation.ParseWarmupRules(cfg.ReputationWarmupRules),
+		BounceThreshold:    cfg.ReputationBounceThreshold,
+		ComplaintThreshold: cfg.ReputationComplaintThresh,
+		MinSamples:         cfg.ReputationMinSamples,
+	})
 
-	d := worker.New(cfg, q, delivery.NewClient(cfg), sup, metrics)
+	d := worker.New(cfg, q, delivery.NewClient(cfg), sup, metrics, rep)
 	s := smtp.NewServer(cfg, q, metrics)
 	var submissionServer *smtp.Server
 	if cfg.SubmissionAddr != "" {
@@ -76,7 +84,7 @@ func main() {
 		go func() { errCh <- submissionServer.Run(ctx) }()
 	}
 	go func() { errCh <- d.Run(ctx) }()
-	go func() { errCh <- observability.RunServer(ctx, cfg.ObservabilityAddr, metrics) }()
+	go func() { errCh <- observability.RunServerWithReputation(ctx, cfg.ObservabilityAddr, metrics, rep) }()
 	if cfg.AdminAddr != "" {
 		var queueAdmin interface {
 			ListState(state string, limit int) ([]*model.Message, error)
@@ -85,7 +93,7 @@ func main() {
 		if localQueue, ok := q.(*queue.Store); ok {
 			queueAdmin = localQueue
 		}
-		go func() { errCh <- admin.RunServer(ctx, cfg.AdminAddr, cfg.AdminTokens, sup, queueAdmin) }()
+		go func() { errCh <- admin.RunServer(ctx, cfg.AdminAddr, cfg.AdminTokens, sup, queueAdmin, rep) }()
 	}
 	go func() {
 		errCh <- retention.Run(ctx, cfg.QueueDir, retention.Policy{

--- a/docs/runbooks/reputation_ops.md
+++ b/docs/runbooks/reputation_ops.md
@@ -1,0 +1,55 @@
+# Reputation Operations Runbook
+
+Issue: #37
+
+## 目的
+
+- IP / ドメインレピュテーション低下時に自動で送信制御する
+- warm-up、bounce rate、complaint rate、TLS-RPT を可視化する
+
+## 有効化
+
+- `MTA_REPUTATION_START_DATE=2026-03-17`
+- `MTA_REPUTATION_WARMUP_RULES=0:100,7:1000,14:5000`
+- `MTA_REPUTATION_BOUNCE_THRESHOLD=0.05`
+- `MTA_REPUTATION_COMPLAINT_THRESHOLD=0.001`
+- `MTA_REPUTATION_MIN_SAMPLES=100`
+
+## 動作
+
+- warm-up 制限を超えると、その日の追加送信は一時抑止される
+- permanent failure 比率が閾値以上になると送信を一時抑止する
+- complaint 比率が閾値以上になると送信を一時抑止する
+- TLS-RPT / complaint は管理API経由で記録できる
+
+## 可視化
+
+- `/reputation` でドメインごとの状態を JSON 取得できる
+- メトリクス:
+  - `worker_reputation_block_total`
+  - `reputation_warmup_limit_total`
+  - `reputation_bounce_rate_block_total`
+  - `reputation_complaint_rate_block_total`
+
+## 収集操作
+
+```bash
+scripts/admin/orinoco_admin.sh record-complaint gmail.com
+scripts/admin/orinoco_admin.sh record-tlsrpt gmail.com false
+```
+
+## 判定の見方
+
+- `blocked=true`:
+  そのドメイン向け配送は一時抑止中
+- `block_reason=warmup_limit`:
+  warm-up 日次上限に到達
+- `block_reason=bounce_rate`:
+  permanent failure 比率が閾値超過
+- `block_reason=complaint_rate`:
+  complaint 比率が閾値超過
+
+## 制約
+
+- complaint / TLS-RPT の自動受信パーサは未実装
+- 現時点では API からの記録と in-memory 集計が中心

--- a/internal/admin/api.go
+++ b/internal/admin/api.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tamago0224/orinoco-mta/internal/bounce"
 	"github.com/tamago0224/orinoco-mta/internal/model"
 	"github.com/tamago0224/orinoco-mta/internal/queue"
+	"github.com/tamago0224/orinoco-mta/internal/reputation"
 )
 
 type queueManager interface {
@@ -30,14 +31,16 @@ const (
 type API struct {
 	suppressions *bounce.SuppressionStore
 	queue        queueManager
+	reputation   *reputation.Tracker
 	tokens       map[string]role
 	now          func() time.Time
 }
 
-func NewAPI(s *bounce.SuppressionStore, q queueManager, tokenConfig string) *API {
+func NewAPI(s *bounce.SuppressionStore, q queueManager, rep *reputation.Tracker, tokenConfig string) *API {
 	return &API{
 		suppressions: s,
 		queue:        q,
+		reputation:   rep,
 		tokens:       parseTokens(tokenConfig),
 		now:          time.Now,
 	}
@@ -48,6 +51,8 @@ func (a *API) Handler() http.Handler {
 	mux.HandleFunc("/api/v1/suppressions", a.handleSuppressions)
 	mux.HandleFunc("/api/v1/suppressions/", a.handleSuppressionByAddress)
 	mux.HandleFunc("/api/v1/queue/", a.handleQueue)
+	mux.HandleFunc("/api/v1/reputation/complaints", a.handleComplaint)
+	mux.HandleFunc("/api/v1/reputation/tlsrpt", a.handleTLSReport)
 	return mux
 }
 
@@ -225,6 +230,69 @@ func (a *API) handleQueue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	http.NotFound(w, r)
+}
+
+func (a *API) handleComplaint(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if _, ok := a.authorize(w, r, roleOperator); !ok {
+		return
+	}
+	if a.reputation == nil {
+		http.Error(w, "reputation admin is unavailable", http.StatusNotImplemented)
+		return
+	}
+	var req struct {
+		Domain string `json:"domain"`
+		DryRun bool   `json:"dry_run"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	if strings.TrimSpace(req.Domain) == "" {
+		http.Error(w, "domain is required", http.StatusBadRequest)
+		return
+	}
+	if !req.DryRun {
+		a.reputation.RecordComplaint(req.Domain)
+	}
+	a.audit(r, "reputation_complaint_record", map[string]any{"domain": req.Domain, "dry_run": req.DryRun})
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "dry_run": req.DryRun})
+}
+
+func (a *API) handleTLSReport(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if _, ok := a.authorize(w, r, roleOperator); !ok {
+		return
+	}
+	if a.reputation == nil {
+		http.Error(w, "reputation admin is unavailable", http.StatusNotImplemented)
+		return
+	}
+	var req struct {
+		Domain  string `json:"domain"`
+		Success bool   `json:"success"`
+		DryRun  bool   `json:"dry_run"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	if strings.TrimSpace(req.Domain) == "" {
+		http.Error(w, "domain is required", http.StatusBadRequest)
+		return
+	}
+	if !req.DryRun {
+		a.reputation.RecordTLSReport(req.Domain, req.Success)
+	}
+	a.audit(r, "reputation_tlsrpt_record", map[string]any{"domain": req.Domain, "success": req.Success, "dry_run": req.DryRun})
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "dry_run": req.DryRun})
 }
 
 func (a *API) audit(r *http.Request, event string, attrs map[string]any) {

--- a/internal/admin/api_test.go
+++ b/internal/admin/api_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tamago0224/orinoco-mta/internal/bounce"
 	"github.com/tamago0224/orinoco-mta/internal/model"
 	"github.com/tamago0224/orinoco-mta/internal/queue"
+	"github.com/tamago0224/orinoco-mta/internal/reputation"
 )
 
 func TestSuppressionsAPIRequiresBearerToken(t *testing.T) {
@@ -19,7 +20,7 @@ func TestSuppressionsAPIRequiresBearerToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new suppression store: %v", err)
 	}
-	api := NewAPI(s, nil, "viewer-token:viewer")
+	api := NewAPI(s, nil, nil, "viewer-token:viewer")
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/suppressions", nil)
 	rec := httptest.NewRecorder()
@@ -35,7 +36,7 @@ func TestSuppressionsAPIAddAndDelete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new suppression store: %v", err)
 	}
-	api := NewAPI(s, nil, "operator-token:operator")
+	api := NewAPI(s, nil, nil, "operator-token:operator")
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/suppressions", strings.NewReader(`{"address":"user@example.com","reason":"manual"}`))
 	req.Header.Set("Authorization", "Bearer operator-token")
@@ -73,7 +74,7 @@ func TestQueueAPIListAndRequeue(t *testing.T) {
 		t.Fatalf("fail: %v", err)
 	}
 
-	api := NewAPI(nil, store, "viewer-token:viewer,operator-token:operator")
+	api := NewAPI(nil, store, nil, "viewer-token:viewer,operator-token:operator")
 	api.now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/queue/dlq?limit=10", nil)
@@ -106,5 +107,34 @@ func TestQueueAPIListAndRequeue(t *testing.T) {
 	}
 	if len(inbound) != 1 || inbound[0].ID != "m1" {
 		t.Fatalf("inbound items=%+v", inbound)
+	}
+}
+
+func TestReputationAPIRecordsComplaintAndTLSReport(t *testing.T) {
+	rep := reputation.New(reputation.Config{MinSamples: 1})
+	api := NewAPI(nil, nil, rep, "operator-token:operator")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/reputation/complaints", strings.NewReader(`{"domain":"gmail.com"}`))
+	req.Header.Set("Authorization", "Bearer operator-token")
+	rec := httptest.NewRecorder()
+	api.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("complaint status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/reputation/tlsrpt", strings.NewReader(`{"domain":"gmail.com","success":false}`))
+	req.Header.Set("Authorization", "Bearer operator-token")
+	rec = httptest.NewRecorder()
+	api.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("tlsrpt status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	snap := rep.Snapshot(time.Now().UTC())
+	if len(snap) != 1 {
+		t.Fatalf("snapshot len=%d", len(snap))
+	}
+	if snap[0].Complaints != 1 || snap[0].TLSRPTFailures != 1 {
+		t.Fatalf("snapshot=%+v", snap[0])
 	}
 }

--- a/internal/admin/server.go
+++ b/internal/admin/server.go
@@ -6,13 +6,14 @@ import (
 	"net/http"
 
 	"github.com/tamago0224/orinoco-mta/internal/bounce"
+	"github.com/tamago0224/orinoco-mta/internal/reputation"
 )
 
-func RunServer(ctx context.Context, addr, tokenConfig string, suppressions *bounce.SuppressionStore, queue queueManager) error {
+func RunServer(ctx context.Context, addr, tokenConfig string, suppressions *bounce.SuppressionStore, queue queueManager, rep *reputation.Tracker) error {
 	if addr == "" {
 		return nil
 	}
-	api := NewAPI(suppressions, queue, tokenConfig)
+	api := NewAPI(suppressions, queue, rep, tokenConfig)
 	srv := &http.Server{Addr: addr, Handler: api.Handler()}
 	go func() {
 		<-ctx.Done()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,6 +64,11 @@ type Config struct {
 	DataRetentionDLQ           time.Duration
 	DataRetentionPoison        time.Duration
 	RetentionSweepInterval     time.Duration
+	ReputationStartDate        string
+	ReputationWarmupRules      string
+	ReputationBounceThreshold  float64
+	ReputationComplaintThresh  float64
+	ReputationMinSamples       int
 }
 
 func Load() Config {
@@ -131,6 +136,11 @@ func Load() Config {
 		DataRetentionDLQ:           envDuration("MTA_DATA_RETENTION_DLQ", 90*24*time.Hour),
 		DataRetentionPoison:        envDuration("MTA_DATA_RETENTION_POISON", 180*24*time.Hour),
 		RetentionSweepInterval:     envDuration("MTA_RETENTION_SWEEP_INTERVAL", time.Hour),
+		ReputationStartDate:        env("MTA_REPUTATION_START_DATE", ""),
+		ReputationWarmupRules:      env("MTA_REPUTATION_WARMUP_RULES", ""),
+		ReputationBounceThreshold:  envFloat64("MTA_REPUTATION_BOUNCE_THRESHOLD", 0.05),
+		ReputationComplaintThresh:  envFloat64("MTA_REPUTATION_COMPLAINT_THRESHOLD", 0.001),
+		ReputationMinSamples:       envInt("MTA_REPUTATION_MIN_SAMPLES", 100),
 	}
 }
 
@@ -243,6 +253,18 @@ func envCSV(k string, def []string) []string {
 	return out
 }
 
+func envFloat64(k string, def float64) float64 {
+	v := strings.TrimSpace(os.Getenv(k))
+	if v == "" {
+		return def
+	}
+	n, err := strconv.ParseFloat(v, 64)
+	if err != nil {
+		return def
+	}
+	return n
+}
+
 func envBool(k string, def bool) bool {
 	v := strings.TrimSpace(strings.ToLower(os.Getenv(k)))
 	if v == "" {
@@ -256,16 +278,4 @@ func envBool(k string, def bool) bool {
 	default:
 		return def
 	}
-}
-
-func envFloat64(k string, def float64) float64 {
-	v := strings.TrimSpace(os.Getenv(k))
-	if v == "" {
-		return def
-	}
-	n, err := strconv.ParseFloat(v, 64)
-	if err != nil {
-		return def
-	}
-	return n
 }

--- a/internal/observability/server.go
+++ b/internal/observability/server.go
@@ -4,9 +4,16 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
+	"time"
+
+	"github.com/tamago0224/orinoco-mta/internal/reputation"
 )
 
 func RunServer(ctx context.Context, addr string, m *Metrics) error {
+	return RunServerWithReputation(ctx, addr, m, nil)
+}
+
+func RunServerWithReputation(ctx context.Context, addr string, m *Metrics, rep *reputation.Tracker) error {
 	if addr == "" {
 		return nil
 	}
@@ -37,6 +44,15 @@ func RunServer(ctx context.Context, addr string, m *Metrics) error {
 			w.WriteHeader(http.StatusOK)
 		}
 		_, _ = w.Write(report.JSON())
+	})
+	mux.HandleFunc("/reputation", func(w http.ResponseWriter, r *http.Request) {
+		if rep == nil {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(rep.JSON(time.Now().UTC()))
 	})
 
 	srv := &http.Server{Addr: addr, Handler: mux}

--- a/internal/observability/server_test.go
+++ b/internal/observability/server_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/tamago0224/orinoco-mta/internal/reputation"
 )
 
 func TestRunServerMetricsEndpoint(t *testing.T) {
@@ -54,5 +56,41 @@ func TestRunServerMetricsEndpoint(t *testing.T) {
 	b, _ := io.ReadAll(resp.Body)
 	if len(b) == 0 {
 		t.Fatal("empty slo body")
+	}
+}
+
+func TestRunServerReputationEndpoint(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	rep := reputation.New(reputation.Config{MinSamples: 1})
+	if ok, _ := rep.Admit("gmail.com", time.Now().UTC()); !ok {
+		t.Fatal("admit should pass")
+	}
+	rep.ObserveDelivery("gmail.com", false, false)
+
+	addr := "127.0.0.1:29091"
+	go func() {
+		_ = RunServerWithReputation(ctx, addr, NewMetrics(), rep)
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		resp, err := http.Get("http://" + addr + "/reputation")
+		if err == nil {
+			b, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status=%d", resp.StatusCode)
+			}
+			if len(b) == 0 {
+				t.Fatal("empty reputation body")
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("reputation endpoint not ready: %v", err)
+		}
+		time.Sleep(50 * time.Millisecond)
 	}
 }

--- a/internal/reputation/tracker.go
+++ b/internal/reputation/tracker.go
@@ -1,0 +1,278 @@
+package reputation
+
+import (
+	"encoding/json"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+type WarmupStep struct {
+	AfterDays int `json:"after_days"`
+	Limit     int `json:"limit"`
+}
+
+type Config struct {
+	StartDate          time.Time
+	WarmupRules        []WarmupStep
+	BounceThreshold    float64
+	ComplaintThreshold float64
+	MinSamples         int
+}
+
+type DomainSnapshot struct {
+	Domain          string  `json:"domain"`
+	TodayAttempts   int     `json:"today_attempts"`
+	WarmupLimit     int     `json:"warmup_limit"`
+	Successes       uint64  `json:"successes"`
+	TemporaryFails  uint64  `json:"temporary_fails"`
+	PermanentFails  uint64  `json:"permanent_fails"`
+	Complaints      uint64  `json:"complaints"`
+	TLSRPTSuccesses uint64  `json:"tlsrpt_successes"`
+	TLSRPTFailures  uint64  `json:"tlsrpt_failures"`
+	BounceRate      float64 `json:"bounce_rate"`
+	ComplaintRate   float64 `json:"complaint_rate"`
+	Blocked         bool    `json:"blocked"`
+	BlockReason     string  `json:"block_reason,omitempty"`
+}
+
+type domainStats struct {
+	day            string
+	todayAttempts  int
+	successes      uint64
+	temporaryFails uint64
+	permanentFails uint64
+	complaints     uint64
+	tlsrptSuccess  uint64
+	tlsrptFailure  uint64
+}
+
+type Tracker struct {
+	cfg     Config
+	mu      sync.Mutex
+	domains map[string]*domainStats
+}
+
+func New(cfg Config) *Tracker {
+	if cfg.BounceThreshold <= 0 || cfg.BounceThreshold >= 1 {
+		cfg.BounceThreshold = 0.05
+	}
+	if cfg.ComplaintThreshold <= 0 || cfg.ComplaintThreshold >= 1 {
+		cfg.ComplaintThreshold = 0.001
+	}
+	if cfg.MinSamples <= 0 {
+		cfg.MinSamples = 100
+	}
+	if len(cfg.WarmupRules) == 0 {
+		cfg.WarmupRules = []WarmupStep{
+			{AfterDays: 0, Limit: 100},
+			{AfterDays: 7, Limit: 1000},
+			{AfterDays: 14, Limit: 5000},
+		}
+	}
+	sort.Slice(cfg.WarmupRules, func(i, j int) bool {
+		return cfg.WarmupRules[i].AfterDays < cfg.WarmupRules[j].AfterDays
+	})
+	return &Tracker{cfg: cfg, domains: map[string]*domainStats{}}
+}
+
+func ParseWarmupRules(raw string) []WarmupStep {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]WarmupStep, 0, len(parts))
+	for _, part := range parts {
+		pair := strings.SplitN(strings.TrimSpace(part), ":", 2)
+		if len(pair) != 2 {
+			continue
+		}
+		afterDays, err1 := strconv.Atoi(strings.TrimSpace(pair[0]))
+		limit, err2 := strconv.Atoi(strings.TrimSpace(pair[1]))
+		if err1 != nil || err2 != nil || afterDays < 0 || limit <= 0 {
+			continue
+		}
+		out = append(out, WarmupStep{AfterDays: afterDays, Limit: limit})
+	}
+	return out
+}
+
+func ParseStartDate(raw string) time.Time {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}
+	}
+	t, err := time.Parse("2006-01-02", raw)
+	if err != nil {
+		return time.Time{}
+	}
+	return t.UTC()
+}
+
+func (t *Tracker) Admit(domain string, now time.Time) (bool, string) {
+	domain = normalizeDomain(domain)
+	if domain == "" {
+		return true, ""
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	st := t.getLocked(domain, now)
+	limit := t.warmupLimit(now)
+	if limit > 0 && st.todayAttempts >= limit {
+		return false, "warmup_limit"
+	}
+	attempts := st.successes + st.temporaryFails + st.permanentFails
+	if attempts >= uint64(t.cfg.MinSamples) {
+		if float64(st.permanentFails)/float64(attempts) >= t.cfg.BounceThreshold {
+			return false, "bounce_rate"
+		}
+		if float64(st.complaints)/float64(attempts) >= t.cfg.ComplaintThreshold {
+			return false, "complaint_rate"
+		}
+	}
+	st.todayAttempts++
+	return true, ""
+}
+
+func (t *Tracker) ObserveDelivery(domain string, temporary, permanent bool) {
+	domain = normalizeDomain(domain)
+	if domain == "" {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	st := t.getLocked(domain, time.Now().UTC())
+	switch {
+	case permanent:
+		st.permanentFails++
+	case temporary:
+		st.temporaryFails++
+	default:
+		st.successes++
+	}
+}
+
+func (t *Tracker) RecordComplaint(domain string) {
+	domain = normalizeDomain(domain)
+	if domain == "" {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	st := t.getLocked(domain, time.Now().UTC())
+	st.complaints++
+}
+
+func (t *Tracker) RecordTLSReport(domain string, success bool) {
+	domain = normalizeDomain(domain)
+	if domain == "" {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	st := t.getLocked(domain, time.Now().UTC())
+	if success {
+		st.tlsrptSuccess++
+	} else {
+		st.tlsrptFailure++
+	}
+}
+
+func (t *Tracker) Snapshot(now time.Time) []DomainSnapshot {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := make([]DomainSnapshot, 0, len(t.domains))
+	for domain := range t.domains {
+		out = append(out, t.snapshotLocked(domain, now))
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Domain < out[j].Domain
+	})
+	return out
+}
+
+func (t *Tracker) JSON(now time.Time) []byte {
+	b, _ := json.Marshal(t.Snapshot(now))
+	return b
+}
+
+func (t *Tracker) snapshotLocked(domain string, now time.Time) DomainSnapshot {
+	st := t.getLocked(domain, now)
+	attempts := st.successes + st.temporaryFails + st.permanentFails
+	s := DomainSnapshot{
+		Domain:          domain,
+		TodayAttempts:   st.todayAttempts,
+		WarmupLimit:     t.warmupLimit(now),
+		Successes:       st.successes,
+		TemporaryFails:  st.temporaryFails,
+		PermanentFails:  st.permanentFails,
+		Complaints:      st.complaints,
+		TLSRPTSuccesses: st.tlsrptSuccess,
+		TLSRPTFailures:  st.tlsrptFailure,
+	}
+	if attempts > 0 {
+		s.BounceRate = round4(float64(st.permanentFails) / float64(attempts))
+		s.ComplaintRate = round4(float64(st.complaints) / float64(attempts))
+	}
+	if blocked, reason := t.evaluateBlocked(st, now); blocked {
+		s.Blocked = true
+		s.BlockReason = reason
+	}
+	return s
+}
+
+func (t *Tracker) evaluateBlocked(st *domainStats, now time.Time) (bool, string) {
+	limit := t.warmupLimit(now)
+	if limit > 0 && st.todayAttempts >= limit {
+		return true, "warmup_limit"
+	}
+	attempts := st.successes + st.temporaryFails + st.permanentFails
+	if attempts >= uint64(t.cfg.MinSamples) {
+		if float64(st.permanentFails)/float64(attempts) >= t.cfg.BounceThreshold {
+			return true, "bounce_rate"
+		}
+		if float64(st.complaints)/float64(attempts) >= t.cfg.ComplaintThreshold {
+			return true, "complaint_rate"
+		}
+	}
+	return false, ""
+}
+
+func (t *Tracker) warmupLimit(now time.Time) int {
+	if t.cfg.StartDate.IsZero() {
+		return 0
+	}
+	days := int(now.UTC().Sub(t.cfg.StartDate.UTC()) / (24 * time.Hour))
+	limit := 0
+	for _, step := range t.cfg.WarmupRules {
+		if days >= step.AfterDays {
+			limit = step.Limit
+		}
+	}
+	return limit
+}
+
+func (t *Tracker) getLocked(domain string, now time.Time) *domainStats {
+	st, ok := t.domains[domain]
+	if !ok {
+		st = &domainStats{}
+		t.domains[domain] = st
+	}
+	day := now.UTC().Format("2006-01-02")
+	if st.day != day {
+		st.day = day
+		st.todayAttempts = 0
+	}
+	return st
+}
+
+func normalizeDomain(in string) string {
+	return strings.ToLower(strings.TrimSpace(in))
+}
+
+func round4(v float64) float64 {
+	return float64(int(v*10000+0.5)) / 10000
+}

--- a/internal/reputation/tracker_test.go
+++ b/internal/reputation/tracker_test.go
@@ -1,0 +1,66 @@
+package reputation
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTrackerBlocksByWarmupLimit(t *testing.T) {
+	tr := New(Config{
+		StartDate: time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+		WarmupRules: []WarmupStep{
+			{AfterDays: 0, Limit: 2},
+		},
+		MinSamples: 1,
+	})
+	now := time.Date(2026, 3, 1, 10, 0, 0, 0, time.UTC)
+	if ok, _ := tr.Admit("gmail.com", now); !ok {
+		t.Fatal("first admit should pass")
+	}
+	if ok, _ := tr.Admit("gmail.com", now); !ok {
+		t.Fatal("second admit should pass")
+	}
+	if ok, reason := tr.Admit("gmail.com", now); ok || reason != "warmup_limit" {
+		t.Fatalf("third admit ok=%v reason=%q", ok, reason)
+	}
+}
+
+func TestTrackerBlocksByBounceRate(t *testing.T) {
+	tr := New(Config{
+		BounceThreshold:    0.5,
+		ComplaintThreshold: 0.9,
+		MinSamples:         2,
+	})
+	now := time.Date(2026, 3, 17, 10, 0, 0, 0, time.UTC)
+	if ok, _ := tr.Admit("gmail.com", now); !ok {
+		t.Fatal("admit1 should pass")
+	}
+	tr.ObserveDelivery("gmail.com", false, true)
+	if ok, _ := tr.Admit("gmail.com", now); !ok {
+		t.Fatal("admit2 should pass before threshold check on next attempt")
+	}
+	tr.ObserveDelivery("gmail.com", false, true)
+	if ok, reason := tr.Admit("gmail.com", now); ok || reason != "bounce_rate" {
+		t.Fatalf("admit3 ok=%v reason=%q", ok, reason)
+	}
+}
+
+func TestTrackerRecordsComplaintAndTLSReport(t *testing.T) {
+	tr := New(Config{MinSamples: 1})
+	now := time.Date(2026, 3, 17, 10, 0, 0, 0, time.UTC)
+	if ok, _ := tr.Admit("example.net", now); !ok {
+		t.Fatal("admit should pass")
+	}
+	tr.ObserveDelivery("example.net", false, false)
+	tr.RecordComplaint("example.net")
+	tr.RecordTLSReport("example.net", true)
+	tr.RecordTLSReport("example.net", false)
+
+	snap := tr.Snapshot(now)
+	if len(snap) != 1 {
+		t.Fatalf("snapshot len=%d want=1", len(snap))
+	}
+	if snap[0].Complaints != 1 || snap[0].TLSRPTSuccesses != 1 || snap[0].TLSRPTFailures != 1 {
+		t.Fatalf("snapshot=%+v", snap[0])
+	}
+}

--- a/internal/worker/dispatcher.go
+++ b/internal/worker/dispatcher.go
@@ -15,6 +15,7 @@ import (
 	"github.com/tamago0224/orinoco-mta/internal/model"
 	"github.com/tamago0224/orinoco-mta/internal/observability"
 	"github.com/tamago0224/orinoco-mta/internal/queue"
+	"github.com/tamago0224/orinoco-mta/internal/reputation"
 	"github.com/tamago0224/orinoco-mta/internal/util"
 )
 
@@ -25,9 +26,10 @@ type Dispatcher struct {
 	sup      *bounce.SuppressionStore
 	m        *observability.Metrics
 	throttle *domainThrottle
+	rep      *reputation.Tracker
 }
 
-func New(cfg config.Config, q queue.Backend, cl *delivery.Client, sup *bounce.SuppressionStore, metrics *observability.Metrics) *Dispatcher {
+func New(cfg config.Config, q queue.Backend, cl *delivery.Client, sup *bounce.SuppressionStore, metrics *observability.Metrics, rep *reputation.Tracker) *Dispatcher {
 	return &Dispatcher{
 		cfg:      cfg,
 		queue:    q,
@@ -35,6 +37,7 @@ func New(cfg config.Config, q queue.Backend, cl *delivery.Client, sup *bounce.Su
 		sup:      sup,
 		m:        metrics,
 		throttle: newDomainThrottle(cfg.DomainMaxConcurrentDefault, parseDomainRules(cfg.DomainMaxConcurrentRules), cfg.DomainAdaptiveThrottle, cfg.DomainTempFailThreshold, cfg.DomainPenaltyMax),
+		rep:      rep,
 	}
 }
 
@@ -92,6 +95,22 @@ func (d *Dispatcher) handleMessage(ctx context.Context, msg *model.Message) {
 		}
 		func() {
 			defer release()
+			if d.rep != nil {
+				if ok, reason := d.rep.Admit(domain, time.Now().UTC()); !ok {
+					reasons = append(reasons, rcpt+": reputation "+reason)
+					d.metricInc("worker_reputation_block")
+					switch reason {
+					case "warmup_limit":
+						d.metricInc("reputation_warmup_limit")
+					case "bounce_rate":
+						d.metricInc("reputation_bounce_rate_block")
+					case "complaint_rate":
+						d.metricInc("reputation_complaint_rate_block")
+					}
+					errs = append(errs, errors.New("reputation "+reason))
+					return
+				}
+			}
 			if d.sup != nil && d.sup.IsSuppressed(rcpt) {
 				reasons = append(reasons, rcpt+": suppressed")
 				d.metricInc("worker_suppressed_recipient")
@@ -101,6 +120,9 @@ func (d *Dispatcher) handleMessage(ctx context.Context, msg *model.Message) {
 				reasons = append(reasons, rcpt+": "+err.Error())
 				var smtpErr *delivery.SMTPResponseError
 				if errors.As(err, &smtpErr) && smtpErr.Permanent() {
+					if d.rep != nil {
+						d.rep.ObserveDelivery(domain, false, true)
+					}
 					d.emitHardBounceDSN(ctx, msg, rcpt, smtpErr.Error())
 					if d.throttle != nil {
 						d.throttle.observe(domain, false)
@@ -114,12 +136,18 @@ func (d *Dispatcher) handleMessage(ctx context.Context, msg *model.Message) {
 					return
 				}
 				d.metricInc("worker_temporary_failure")
+				if d.rep != nil {
+					d.rep.ObserveDelivery(domain, true, false)
+				}
 				d.emitSoftBounceDSN(ctx, msg, rcpt, err.Error())
 				if d.throttle != nil {
 					d.throttle.observe(domain, true)
 				}
 				errs = append(errs, err)
 			} else {
+				if d.rep != nil {
+					d.rep.ObserveDelivery(domain, false, false)
+				}
 				if d.throttle != nil {
 					d.throttle.observe(domain, false)
 				}

--- a/scripts/admin/orinoco_admin.sh
+++ b/scripts/admin/orinoco_admin.sh
@@ -56,6 +56,19 @@ case "${cmd}" in
     fi
     curl -fsS "${auth_args[@]}" -X POST "${url}"
     ;;
+  record-complaint)
+    domain="${1:-}"
+    curl -fsS "${auth_args[@]}" -X POST \
+      -d "{\"domain\":\"${domain}\"}" \
+      "${BASE_URL}/api/v1/reputation/complaints"
+    ;;
+  record-tlsrpt)
+    domain="${1:-}"
+    success="${2:-true}"
+    curl -fsS "${auth_args[@]}" -X POST \
+      -d "{\"domain\":\"${domain}\",\"success\":${success}}" \
+      "${BASE_URL}/api/v1/reputation/tlsrpt"
+    ;;
   *)
     echo "unknown command: ${cmd}" >&2
     exit 2


### PR DESCRIPTION
## 概要
- Issue #37 として、reputation 制御の最小実装を追加
- warm-up、bounce rate、complaint rate による自動送信抑止を worker に組み込んだ
- TLS-RPT / complaint の記録経路と `/reputation` 可視化を追加した

## 変更内容
- `internal/reputation`
  - warm-up ルール、bounce / complaint 閾値、TLS-RPT 集計を持つ tracker を追加
- `internal/worker/dispatcher.go`
  - 送信前に reputation 判定を実施
  - block 時に retry 扱いへ回す
  - reputation メトリクスを追加
- `internal/admin`
  - complaint 記録API
  - TLS-RPT 記録API
- `internal/observability/server.go`
  - `/reputation` エンドポイントを追加
- `cmd/mta` / `internal/config`
  - reputation 関連設定を追加して起動配線
- `scripts/admin/orinoco_admin.sh`
  - `record-complaint` / `record-tlsrpt` を追加
- `docs/runbooks/reputation_ops.md`
  - 運用手順を追加

## 検証
- `bash -n scripts/admin/orinoco_admin.sh`
- `go test ./internal/reputation ./internal/admin ./internal/worker ./internal/observability`
- `go build ./cmd/mta`

## 制約
- complaint / TLS-RPT の自動受信パーサは未実装で、現時点では API 経由の記録
- reputation 集計は現時点では in-memory

Close #37
