### PR TITLE
test: RFC 5321 の状態遷移準拠テストを追加

### DIFF
--- a/internal/smtp/conformance_test.go
+++ b/internal/smtp/conformance_test.go
@@ -41,6 +41,34 @@ func TestSMTPConformance(t *testing.T) {
 		expectRFCCode(t, "RFC 5321 4.1.1.5", "DATA after RSET", code, 503)
 	})
 
+	t.Run("RFC5321-4.1.1.3-RCPT-before-MAIL-must-fail-503", func(t *testing.T) {
+		r, w, cleanup := openTestSession(t, &Server{cfg: config.Config{Hostname: "mx.example.test"}})
+		defer cleanup()
+
+		_, _ = readSMTPResponse(t, r) // banner
+		mustWriteSMTPLine(t, w, "EHLO client.example")
+		_, _ = readSMTPResponse(t, r)
+
+		mustWriteSMTPLine(t, w, "RCPT TO:<bob@invalid.invalid>")
+		_, code := readSMTPResponse(t, r)
+		expectRFCCode(t, "RFC 5321 4.1.1.3", "RCPT before MAIL", code, 503)
+	})
+
+	t.Run("RFC5321-4.1.1.4-DATA-before-RCPT-must-fail-503", func(t *testing.T) {
+		r, w, cleanup := openTestSession(t, &Server{cfg: config.Config{Hostname: "mx.example.test"}})
+		defer cleanup()
+
+		_, _ = readSMTPResponse(t, r) // banner
+		mustWriteSMTPLine(t, w, "EHLO client.example")
+		_, _ = readSMTPResponse(t, r)
+		mustWriteSMTPLine(t, w, "MAIL FROM:<alice@invalid.invalid>")
+		_, _ = readSMTPResponse(t, r)
+
+		mustWriteSMTPLine(t, w, "DATA")
+		_, code := readSMTPResponse(t, r)
+		expectRFCCode(t, "RFC 5321 4.1.1.4", "DATA before RCPT", code, 503)
+	})
+
 	t.Run("RFC1870-6-SIZE-over-limit-must-fail-552", func(t *testing.T) {
 		r, w, cleanup := openTestSession(t, &Server{cfg: config.Config{Hostname: "mx.example.test", MaxMessageBytes: 1024}})
 		defer cleanup()


### PR DESCRIPTION
## Summary
- RFC 5321 の状態遷移で未カバーだった RCPT before MAIL と DATA before RCPT を追加
- SMTP サーバーの既存実装が返す 503 応答を節番号つきで検証
- #143 の RFC 5321 完全対応に向けた準拠テストを前進

## Changes
- internal/smtp/conformance_test.go に RFC 5321 4.1.1.3 の RCPT 順序違反ケースを追加
- internal/smtp/conformance_test.go に RFC 5321 4.1.1.4 の DATA 順序違反ケースを追加

## Validation
- go test ./internal/smtp

## Risks / Follow-ups
- #143 自体は継続中のため、本 PR では issue を close しません
- まだ未追加の SMTP 準拠ケースは引き続き別コミットで積み増します

Refs #143
