### PR TITLE
test: RFC 5321 の補助コマンド準拠テストを追加

### DIFF
--- a/internal/smtp/conformance_test.go
+++ b/internal/smtp/conformance_test.go
@@ -126,6 +126,46 @@ func TestSMTPConformance(t *testing.T) {
 		_, code := readSMTPResponse(t, r)
 		expectRFCCode(t, "RFC 5321 4.5.3.1.4", "command line length", code, 500)
 	})
+
+	t.Run("RFC5321-4.1.1.8-HELP-must-return-214", func(t *testing.T) {
+		r, w, cleanup := openTestSession(t, &Server{cfg: config.Config{Hostname: "mx.example.test"}})
+		defer cleanup()
+
+		_, _ = readSMTPResponse(t, r) // banner
+		mustWriteSMTPLine(t, w, "HELP")
+		_, code := readSMTPResponse(t, r)
+		expectRFCCode(t, "RFC 5321 4.1.1.8", "HELP", code, 214)
+	})
+
+	t.Run("RFC5321-3.5.2-VRFY-may-return-252", func(t *testing.T) {
+		r, w, cleanup := openTestSession(t, &Server{cfg: config.Config{Hostname: "mx.example.test"}})
+		defer cleanup()
+
+		_, _ = readSMTPResponse(t, r) // banner
+		mustWriteSMTPLine(t, w, "VRFY postmaster")
+		_, code := readSMTPResponse(t, r)
+		expectRFCCode(t, "RFC 5321 3.5.2", "VRFY", code, 252)
+	})
+
+	t.Run("RFC5321-3.5.1-EXPN-may-return-502", func(t *testing.T) {
+		r, w, cleanup := openTestSession(t, &Server{cfg: config.Config{Hostname: "mx.example.test"}})
+		defer cleanup()
+
+		_, _ = readSMTPResponse(t, r) // banner
+		mustWriteSMTPLine(t, w, "EXPN staff")
+		_, code := readSMTPResponse(t, r)
+		expectRFCCode(t, "RFC 5321 3.5.1", "EXPN", code, 502)
+	})
+
+	t.Run("RFC5321-4.1.1.10-QUIT-must-return-221", func(t *testing.T) {
+		r, w, cleanup := openTestSession(t, &Server{cfg: config.Config{Hostname: "mx.example.test"}})
+		defer cleanup()
+
+		_, _ = readSMTPResponse(t, r) // banner
+		mustWriteSMTPLine(t, w, "QUIT")
+		_, code := readSMTPResponse(t, r)
+		expectRFCCode(t, "RFC 5321 4.1.1.10", "QUIT", code, 221)
+	})
 }
 
 func openTestSession(t *testing.T, s *Server) (*bufio.Reader, *bufio.Writer, func()) {


### PR DESCRIPTION
## Summary
- RFC 5321 の補助コマンドで未カバーだった HELP / VRFY / EXPN / QUIT の準拠テストを追加
- 既存実装の応答コードを RFC の節番号つきで固定
- #143 の SMTP 完全対応に向けたテストカバレッジを前進

## Changes
- internal/smtp/conformance_test.go に HELP の 214 応答テストを追加
- internal/smtp/conformance_test.go に VRFY の 252 応答テストを追加
- internal/smtp/conformance_test.go に EXPN の 502 応答テストを追加
- internal/smtp/conformance_test.go に QUIT の 221 応答テストを追加

## Validation
- go test ./internal/smtp

## Risks / Follow-ups
- #143 は継続中のため、この PR では close しません
- 接続終了後のより厳密な QUIT 挙動や他の細かい SMTP ケースは引き続き積み増します

Refs #143
