### PR TITLE
test: RFC 5321 のセッション系準拠テストを追加

### DIFF
--- a/internal/smtp/conformance_test.go
+++ b/internal/smtp/conformance_test.go
@@ -2,9 +2,11 @@ package smtp
 
 import (
 	"bufio"
+	"io"
 	"net"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/tamago0224/orinoco-mta/internal/config"
 )
@@ -166,6 +168,50 @@ func TestSMTPConformance(t *testing.T) {
 		_, code := readSMTPResponse(t, r)
 		expectRFCCode(t, "RFC 5321 4.1.1.10", "QUIT", code, 221)
 	})
+
+	t.Run("RFC5321-4.1.1.9-NOOP-must-return-250", func(t *testing.T) {
+		r, w, cleanup := openTestSession(t, &Server{cfg: config.Config{Hostname: "mx.example.test"}})
+		defer cleanup()
+
+		_, _ = readSMTPResponse(t, r) // banner
+		mustWriteSMTPLine(t, w, "NOOP")
+		_, code := readSMTPResponse(t, r)
+		expectRFCCode(t, "RFC 5321 4.1.1.9", "NOOP", code, 250)
+	})
+
+	t.Run("RFC5321-4.2.4-unrecognized-command-must-return-500", func(t *testing.T) {
+		r, w, cleanup := openTestSession(t, &Server{cfg: config.Config{Hostname: "mx.example.test"}})
+		defer cleanup()
+
+		_, _ = readSMTPResponse(t, r) // banner
+		mustWriteSMTPLine(t, w, "FROBULATE")
+		_, code := readSMTPResponse(t, r)
+		expectRFCCode(t, "RFC 5321 4.2.4", "unrecognized command", code, 500)
+	})
+
+	t.Run("RFC5321-4.1.1.10-QUIT-must-close-connection", func(t *testing.T) {
+		client, r, w, cleanup := openRawTestSession(t, &Server{cfg: config.Config{Hostname: "mx.example.test"}})
+		defer cleanup()
+
+		_, _ = readSMTPResponse(t, r) // banner
+		mustWriteSMTPLine(t, w, "QUIT")
+		_, code := readSMTPResponse(t, r)
+		expectRFCCode(t, "RFC 5321 4.1.1.10", "QUIT response", code, 221)
+
+		if err := client.SetReadDeadline(time.Now().Add(200 * time.Millisecond)); err != nil {
+			t.Fatalf("set read deadline: %v", err)
+		}
+		_, err := r.ReadByte()
+		if err == nil {
+			t.Fatal("RFC 5321 4.1.1.10: expected connection close after QUIT")
+		}
+		if err != io.EOF {
+			if netErr, ok := err.(net.Error); !ok || !netErr.Timeout() {
+				t.Fatalf("RFC 5321 4.1.1.10: unexpected read error after QUIT: %v", err)
+			}
+			t.Fatal("RFC 5321 4.1.1.10: timed out waiting for connection close after QUIT")
+		}
+	})
 }
 
 func openTestSession(t *testing.T, s *Server) (*bufio.Reader, *bufio.Writer, func()) {
@@ -173,6 +219,16 @@ func openTestSession(t *testing.T, s *Server) (*bufio.Reader, *bufio.Writer, fun
 	client, server := net.Pipe()
 	go s.handleConn(server)
 	return bufio.NewReader(client), bufio.NewWriter(client), func() {
+		_ = client.Close()
+		_ = server.Close()
+	}
+}
+
+func openRawTestSession(t *testing.T, s *Server) (net.Conn, *bufio.Reader, *bufio.Writer, func()) {
+	t.Helper()
+	client, server := net.Pipe()
+	go s.handleConn(server)
+	return client, bufio.NewReader(client), bufio.NewWriter(client), func() {
 		_ = client.Close()
 		_ = server.Close()
 	}


### PR DESCRIPTION
## Summary
- RFC 5321 のセッション系コマンドで未カバーだった NOOP、未知コマンド、QUIT 後の切断確認を追加
- 既存 SMTP 実装の応答コードと接続終了動作を RFC の節番号つきで固定
- #143 の SMTP 完全対応に向けた準拠テストを前進

## Changes
- internal/smtp/conformance_test.go に NOOP の 250 応答テストを追加
- internal/smtp/conformance_test.go に未知コマンドの 500 応答テストを追加
- internal/smtp/conformance_test.go に QUIT 後に接続が閉じることを確認するテストを追加
- QUIT 後の接続確認用に test helper を追加

## Validation
- go test ./internal/smtp

## Risks / Follow-ups
- #143 は継続中のため、この PR では close しません
- まだ未整理の SMTP 準拠ケースは引き続き別コミットで積み増します

Refs #143
