### PR TITLE
test: RFC 5321 の構文系準拠テストを追加

### DIFF
--- a/internal/smtp/conformance_test.go
+++ b/internal/smtp/conformance_test.go
@@ -24,6 +24,40 @@ func TestSMTPConformance(t *testing.T) {
 		expectRFCCode(t, "RFC 5321 4.1.4", "MAIL before HELO/EHLO", code, 503)
 	})
 
+	t.Run("RFC5321-4.1.1.1-EHLO-without-domain-must-fail-501", func(t *testing.T) {
+		r, w, cleanup := openTestSession(t, &Server{cfg: config.Config{Hostname: "mx.example.test"}})
+		defer cleanup()
+
+		_, _ = readSMTPResponse(t, r) // banner
+		mustWriteSMTPLine(t, w, "EHLO")
+		_, code := readSMTPResponse(t, r)
+		expectRFCCode(t, "RFC 5321 4.1.1.1", "EHLO without domain", code, 501)
+	})
+
+	t.Run("RFC5321-4.1.1.1-HELO-without-domain-must-fail-501", func(t *testing.T) {
+		r, w, cleanup := openTestSession(t, &Server{cfg: config.Config{Hostname: "mx.example.test"}})
+		defer cleanup()
+
+		_, _ = readSMTPResponse(t, r) // banner
+		mustWriteSMTPLine(t, w, "HELO")
+		_, code := readSMTPResponse(t, r)
+		expectRFCCode(t, "RFC 5321 4.1.1.1", "HELO without domain", code, 501)
+	})
+
+	t.Run("RFC5321-4.1.4-MAIL-parameters-after-HELO-must-fail-555", func(t *testing.T) {
+		r, w, cleanup := openTestSession(t, &Server{cfg: config.Config{Hostname: "mx.example.test"}})
+		defer cleanup()
+
+		_, _ = readSMTPResponse(t, r) // banner
+		mustWriteSMTPLine(t, w, "HELO client.example")
+		_, heloCode := readSMTPResponse(t, r)
+		expectRFCCode(t, "RFC 5321 4.1.1.1", "HELO", heloCode, 250)
+
+		mustWriteSMTPLine(t, w, "MAIL FROM:<alice@invalid.invalid> SIZE=123")
+		_, code := readSMTPResponse(t, r)
+		expectRFCCode(t, "RFC 5321 4.1.4", "MAIL parameters after HELO", code, 555)
+	})
+
 	t.Run("RFC5321-4.1.1.5-RSET-must-clear-transaction", func(t *testing.T) {
 		r, w, cleanup := openTestSession(t, &Server{cfg: config.Config{Hostname: "mx.example.test"}})
 		defer cleanup()


### PR DESCRIPTION
## Summary
- RFC 5321 の構文エラー系で未カバーだった EHLO / HELO の引数不足と、HELO セッションでの MAIL 拡張パラメータ拒否を追加
- 既存 SMTP 実装の応答コードを RFC の節番号つきで固定
- #143 の SMTP 完全対応に向けた準拠テストを前進

## Changes
- internal/smtp/conformance_test.go に EHLO 引数なしの 501 応答テストを追加
- internal/smtp/conformance_test.go に HELO 引数なしの 501 応答テストを追加
- internal/smtp/conformance_test.go に HELO セッションで MAIL 拡張パラメータを使ったときの 555 応答テストを追加

## Validation
- go test ./internal/smtp

## Risks / Follow-ups
- #143 は継続中のため、この PR では close しません
- まだ未整理の SMTP 準拠ケースは引き続き別コミットで積み増します

Refs #143
