### PR TITLE
test: RFC 5321 の RSET と空コマンドの準拠テストを追加

### DIFF
--- a/internal/smtp/conformance_test.go
+++ b/internal/smtp/conformance_test.go
@@ -78,6 +78,26 @@ func TestSMTPConformance(t *testing.T) {
 		expectRFCCode(t, "RFC 5321 4.1.1.5", "DATA after RSET", code, 503)
 	})
 
+	t.Run("RFC5321-4.1.1.5-RSET-must-allow-new-mail-transaction", func(t *testing.T) {
+		r, w, cleanup := openTestSession(t, &Server{cfg: config.Config{Hostname: "mx.example.test"}})
+		defer cleanup()
+
+		_, _ = readSMTPResponse(t, r) // banner
+		mustWriteSMTPLine(t, w, "EHLO client.example")
+		_, _ = readSMTPResponse(t, r)
+		mustWriteSMTPLine(t, w, "MAIL FROM:<alice@invalid.invalid>")
+		_, _ = readSMTPResponse(t, r)
+		mustWriteSMTPLine(t, w, "RCPT TO:<bob@invalid.invalid>")
+		_, _ = readSMTPResponse(t, r)
+		mustWriteSMTPLine(t, w, "RSET")
+		_, resetCode := readSMTPResponse(t, r)
+		expectRFCCode(t, "RFC 5321 4.1.1.5", "RSET", resetCode, 250)
+
+		mustWriteSMTPLine(t, w, "MAIL FROM:<carol@invalid.invalid>")
+		_, code := readSMTPResponse(t, r)
+		expectRFCCode(t, "RFC 5321 4.1.1.5", "MAIL after RSET", code, 250)
+	})
+
 	t.Run("RFC5321-4.1.1.3-RCPT-before-MAIL-must-fail-503", func(t *testing.T) {
 		r, w, cleanup := openTestSession(t, &Server{cfg: config.Config{Hostname: "mx.example.test"}})
 		defer cleanup()
@@ -222,6 +242,16 @@ func TestSMTPConformance(t *testing.T) {
 		mustWriteSMTPLine(t, w, "FROBULATE")
 		_, code := readSMTPResponse(t, r)
 		expectRFCCode(t, "RFC 5321 4.2.4", "unrecognized command", code, 500)
+	})
+
+	t.Run("RFC5321-4.2.4-empty-command-must-return-500", func(t *testing.T) {
+		r, w, cleanup := openTestSession(t, &Server{cfg: config.Config{Hostname: "mx.example.test"}})
+		defer cleanup()
+
+		_, _ = readSMTPResponse(t, r) // banner
+		mustWriteSMTPLine(t, w, "")
+		_, code := readSMTPResponse(t, r)
+		expectRFCCode(t, "RFC 5321 4.2.4", "empty command", code, 500)
 	})
 
 	t.Run("RFC5321-4.1.1.10-QUIT-must-close-connection", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- RFC 5321 の RSET 後のトランザクション再開と空コマンドの応答に関する準拠テストを追加
- 既存 SMTP 実装の応答コードを RFC の節番号つきで固定
- #143 の SMTP 完全対応に向けた準拠テストを前進

## Changes
- internal/smtp/conformance_test.go に RSET 後の新しい MAIL FROM が受理されるテストを追加
- internal/smtp/conformance_test.go に空コマンドが 500 を返すテストを追加

## Validation
- go test ./internal/smtp

## Risks / Follow-ups
- #143 は継続中のため、この PR では close しません
- まだ未整理の SMTP 準拠ケースは引き続き別コミットで積み増します

Refs #143
