### PR TITLE
test: SMTP パラメータ検証の準拠テストを追加

### DIFF
--- a/internal/smtp/conformance_test.go
+++ b/internal/smtp/conformance_test.go
@@ -59,6 +59,32 @@ func TestSMTPConformance(t *testing.T) {
 		expectRFCCode(t, "RFC 5321 4.1.4", "MAIL parameters after HELO", code, 555)
 	})
 
+	t.Run("RFC5321-4.1.1.2-invalid-SIZE-parameter-must-fail-501", func(t *testing.T) {
+		r, w, cleanup := openTestSession(t, &Server{cfg: config.Config{Hostname: "mx.example.test"}})
+		defer cleanup()
+
+		_, _ = readSMTPResponse(t, r) // banner
+		mustWriteSMTPLine(t, w, "EHLO client.example")
+		_, _ = readSMTPResponse(t, r)
+
+		mustWriteSMTPLine(t, w, "MAIL FROM:<alice@invalid.invalid> SIZE=abc")
+		_, code := readSMTPResponse(t, r)
+		expectRFCCode(t, "RFC 5321 4.1.1.2", "invalid SIZE parameter", code, 501)
+	})
+
+	t.Run("RFC5321-4.1.1.2-invalid-BODY-parameter-must-fail-501", func(t *testing.T) {
+		r, w, cleanup := openTestSession(t, &Server{cfg: config.Config{Hostname: "mx.example.test"}})
+		defer cleanup()
+
+		_, _ = readSMTPResponse(t, r) // banner
+		mustWriteSMTPLine(t, w, "EHLO client.example")
+		_, _ = readSMTPResponse(t, r)
+
+		mustWriteSMTPLine(t, w, "MAIL FROM:<alice@invalid.invalid> BODY=BINARYMIME")
+		_, code := readSMTPResponse(t, r)
+		expectRFCCode(t, "RFC 5321 4.1.1.2", "invalid BODY parameter", code, 501)
+	})
+
 	t.Run("RFC5321-4.1.1.2-invalid-MAIL-syntax-must-fail-501", func(t *testing.T) {
 		r, w, cleanup := openTestSession(t, &Server{cfg: config.Config{Hostname: "mx.example.test"}})
 		defer cleanup()
@@ -152,6 +178,21 @@ func TestSMTPConformance(t *testing.T) {
 		mustWriteSMTPLine(t, w, "RCPT TO:<>")
 		_, code := readSMTPResponse(t, r)
 		expectRFCCode(t, "RFC 5321 4.1.1.3", "empty RCPT path", code, 501)
+	})
+
+	t.Run("RFC5321-4.1.1.3-unsupported-RCPT-parameter-must-fail-555", func(t *testing.T) {
+		r, w, cleanup := openTestSession(t, &Server{cfg: config.Config{Hostname: "mx.example.test"}})
+		defer cleanup()
+
+		_, _ = readSMTPResponse(t, r) // banner
+		mustWriteSMTPLine(t, w, "EHLO client.example")
+		_, _ = readSMTPResponse(t, r)
+		mustWriteSMTPLine(t, w, "MAIL FROM:<alice@invalid.invalid>")
+		_, _ = readSMTPResponse(t, r)
+
+		mustWriteSMTPLine(t, w, "RCPT TO:<bob@invalid.invalid> NOTIFY=SUCCESS")
+		_, code := readSMTPResponse(t, r)
+		expectRFCCode(t, "RFC 5321 4.1.1.3", "unsupported RCPT parameter", code, 555)
 	})
 
 	t.Run("RFC5321-4.1.1.4-DATA-before-RCPT-must-fail-503", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- RFC 5321 の MAIL FROM / RCPT TO パラメータ検証に関する準拠テストを追加
- 既存 SMTP 実装の 501 / 555 応答を RFC の節番号つきで固定
- #143 の SMTP 完全対応に向けた準拠テストを前進

## Changes
- internal/smtp/conformance_test.go に不正な SIZE パラメータが 501 になるテストを追加
- internal/smtp/conformance_test.go に不正な BODY パラメータが 501 になるテストを追加
- internal/smtp/conformance_test.go に未対応の RCPT パラメータが 555 になるテストを追加

## Validation
- go test ./internal/smtp

## Risks / Follow-ups
- #143 は継続中のため、この PR では close しません
- まだ未整理の SMTP 準拠ケースは引き続き別コミットで積み増します

Refs #143
