### PR TITLE
test: MAIL パス形式エラーの準拠テストを追加

### DIFF
--- a/internal/smtp/conformance_test.go
+++ b/internal/smtp/conformance_test.go
@@ -85,6 +85,19 @@ func TestSMTPConformance(t *testing.T) {
 		expectRFCCode(t, "RFC 5321 4.1.1.2", "invalid BODY parameter", code, 501)
 	})
 
+	t.Run("RFC5321-4.1.1.2-unsupported-MAIL-parameter-must-fail-555", func(t *testing.T) {
+		r, w, cleanup := openTestSession(t, &Server{cfg: config.Config{Hostname: "mx.example.test"}})
+		defer cleanup()
+
+		_, _ = readSMTPResponse(t, r) // banner
+		mustWriteSMTPLine(t, w, "EHLO client.example")
+		_, _ = readSMTPResponse(t, r)
+
+		mustWriteSMTPLine(t, w, "MAIL FROM:<alice@invalid.invalid> RET=FULL")
+		_, code := readSMTPResponse(t, r)
+		expectRFCCode(t, "RFC 5321 4.1.1.2", "unsupported MAIL parameter", code, 555)
+	})
+
 	t.Run("RFC5321-4.1.1.2-invalid-MAIL-syntax-must-fail-501", func(t *testing.T) {
 		r, w, cleanup := openTestSession(t, &Server{cfg: config.Config{Hostname: "mx.example.test"}})
 		defer cleanup()
@@ -96,6 +109,32 @@ func TestSMTPConformance(t *testing.T) {
 		mustWriteSMTPLine(t, w, "MAIL TO:<alice@invalid.invalid>")
 		_, code := readSMTPResponse(t, r)
 		expectRFCCode(t, "RFC 5321 4.1.1.2", "invalid MAIL syntax", code, 501)
+	})
+
+	t.Run("RFC5321-4.1.1.2-missing-MAIL-path-must-fail-501", func(t *testing.T) {
+		r, w, cleanup := openTestSession(t, &Server{cfg: config.Config{Hostname: "mx.example.test"}})
+		defer cleanup()
+
+		_, _ = readSMTPResponse(t, r) // banner
+		mustWriteSMTPLine(t, w, "EHLO client.example")
+		_, _ = readSMTPResponse(t, r)
+
+		mustWriteSMTPLine(t, w, "MAIL FROM:")
+		_, code := readSMTPResponse(t, r)
+		expectRFCCode(t, "RFC 5321 4.1.1.2", "missing MAIL path", code, 501)
+	})
+
+	t.Run("RFC5321-4.1.1.2-unclosed-MAIL-path-must-fail-501", func(t *testing.T) {
+		r, w, cleanup := openTestSession(t, &Server{cfg: config.Config{Hostname: "mx.example.test"}})
+		defer cleanup()
+
+		_, _ = readSMTPResponse(t, r) // banner
+		mustWriteSMTPLine(t, w, "EHLO client.example")
+		_, _ = readSMTPResponse(t, r)
+
+		mustWriteSMTPLine(t, w, "MAIL FROM:<alice@invalid.invalid")
+		_, code := readSMTPResponse(t, r)
+		expectRFCCode(t, "RFC 5321 4.1.1.2", "unclosed MAIL path", code, 501)
 	})
 
 	t.Run("RFC5321-4.1.1.5-RSET-must-clear-transaction", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- RFC 5321 の MAIL FROM パス形式エラーと未対応 MAIL パラメータに関する準拠テストを追加
- 既存 SMTP 実装の 501 / 555 応答を RFC の節番号つきで固定
- #143 の SMTP 完全対応に向けた準拠テストを前進

## Changes
- internal/smtp/conformance_test.go に未対応 MAIL パラメータが 555 になるテストを追加
- internal/smtp/conformance_test.go に MAIL パス欠落が 501 になるテストを追加
- internal/smtp/conformance_test.go に閉じられていない MAIL パスが 501 になるテストを追加

## Validation
- go test ./internal/smtp

## Risks / Follow-ups
- #143 は継続中のため、この PR では close しません
- まだ未整理の SMTP 準拠ケースは引き続き別コミットで積み増します

Refs #143
