### PR TITLE
test: RFC 5321 の Received トレース検証を追加

### DIFF
--- a/internal/smtp/server_test.go
+++ b/internal/smtp/server_test.go
@@ -591,6 +591,54 @@ func TestBuildReceivedHeaderSanitizesInput(t *testing.T) {
 	}
 }
 
+func TestBuildReceivedHeaderProtocolMarkersWithTLS(t *testing.T) {
+	now := time.Date(2026, 3, 21, 9, 15, 0, 0, time.UTC)
+
+	gotESMTPS := buildReceivedHeader(
+		"mx.example.test",
+		"client.example",
+		"192.0.2.10:2525",
+		"msg-esmtps",
+		now,
+		true,
+		true,
+	)
+	if !strings.Contains(gotESMTPS, " by mx.example.test with ESMTPS id msg-esmtps; ") {
+		t.Fatalf("expected ESMTPS marker: %q", gotESMTPS)
+	}
+	if !strings.Contains(gotESMTPS, now.Format(time.RFC1123Z)) {
+		t.Fatalf("expected RFC1123Z timestamp: %q", gotESMTPS)
+	}
+
+	gotSMTPS := buildReceivedHeader(
+		"mx.example.test",
+		"client.example",
+		"192.0.2.10:2525",
+		"msg-smtps",
+		now,
+		false,
+		true,
+	)
+	if !strings.Contains(gotSMTPS, " by mx.example.test with SMTPS id msg-smtps; ") {
+		t.Fatalf("expected SMTPS marker: %q", gotSMTPS)
+	}
+}
+
+func TestBuildReceivedHeaderUsesFallbackTokens(t *testing.T) {
+	got := buildReceivedHeader(
+		"",
+		"",
+		"not-an-ip",
+		"id-fallback",
+		time.Date(2026, 3, 21, 9, 30, 0, 0, time.UTC),
+		false,
+		false,
+	)
+	if !strings.Contains(got, "Received: from unknown (not-an-ip) by localhost with SMTP id id-fallback; ") {
+		t.Fatalf("unexpected fallback trace header: %q", got)
+	}
+}
+
 func TestMailFromSMTPUTF8ParameterRejected(t *testing.T) {
 	s := &Server{cfg: config.Config{Hostname: "mx.example.test"}}
 	client, server := net.Pipe()


### PR DESCRIPTION
## Summary
- RFC 5321 の Received トレース情報に関する根拠を補強するテストを追加
- TLS 有無と HELO/EHLO 状態に応じた with プロトコル表記を固定
- by / from のフォールバックと日時形式も検証し、#143 の棚卸しを前進

## Changes
- internal/smtp/server_test.go に ESMTPS / SMTPS の Received ヘッダ検証を追加
- internal/smtp/server_test.go に RFC 1123Z 形式の日時が入ることを確認するテストを追加
- internal/smtp/server_test.go に空の hostname / helo 時の localhost / unknown フォールバック検証を追加

## Validation
- go test ./internal/smtp

## Risks / Follow-ups
- #143 は継続中のため、この PR では close しません
- 次は README の RFC 5321 記述更新と、残っている境界ケースの最終棚卸しに進めます

Refs #143
