### PR TITLE
docs: RFC 5321 の対応状況を更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Orinoco は南米を流れる川の名前で、
 
 | RFC | 技術 | 対応状況 | 補足 |
 | --- | --- | --- | --- |
-| RFC 5321 | SMTP | 一部対応 | `EHLO/HELO`, `MAIL FROM`, `RCPT TO`, `DATA`, `RSET`, `NOOP`, `QUIT`, `HELP`, `VRFY` を実装。`EXPN` は `502`、一部拡張は別RFCとして実装 |
+| RFC 5321 | SMTP | 対応済み（実装範囲内） | `EHLO/HELO`, `MAIL FROM`, `RCPT TO`, `DATA`, `RSET`, `NOOP`, `QUIT`, `HELP`, `VRFY` を実装。`EXPN` は `502` 応答、`Received:` トレースヘッダ、`postmaster` 宛特例、主要な構文/状態遷移/行長制限のコンフォーマンステストを整備。拡張は各RFCで管理 |
 | RFC 3207 | SMTP STARTTLS | 対応済み（実装範囲内） | 受信側/送信側で STARTTLS 昇格を実装 |
 | RFC 1870 | SMTP SIZE | 対応済み（実装範囲内） | `SIZE` パラメータと最大メッセージサイズ制限を実装 |
 | RFC 6152 | 8BITMIME | 対応済み（実装範囲内） | `BODY=8BITMIME` と 8bit 本文受信を実装 |


### PR DESCRIPTION
## Summary
- RFC 5321 の実装状況を、現状のテスト根拠に合わせて README 上で更新
- Received、postmaster、主要な構文/状態遷移/行長制限の整備済みであることを明記
- #143 の受け入れ条件を README 側でも満たすよう整理

## Changes
- README.md の RFC 5321 行を 一部対応 から 対応済み（実装範囲内） に更新
- 補足に Received トレースヘッダ、postmaster 宛特例、主要コンフォーマンステスト整備済みであることを追記

## Validation
- go test ./internal/smtp

## Risks / Follow-ups
- 対応済み（実装範囲内）は README 注記どおり、Orinoco が対象とする SMTP コア範囲での完了を意味します
- 周辺拡張は引き続き各 RFC issue で管理します

Closes #143
