### PR TITLE
fix: tighten RFC 8461 policy validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Orinoco は南米を流れる川の名前で、
 | RFC 6376 | DKIM | 一部対応 | 受信時の DKIM 検証、複数署名評価、`l/t/x/h`、canonicalization、送信時 DKIM 署名を実装 |
 | RFC 7489 | DMARC | 一部対応 | SPF/DKIM alignment、`p/sp/pct/fo/rf/ri/rua/ruf`、サブドメインポリシー、集計/失敗レポート生成を実装 |
 | RFC 8617 | ARC | 一部対応 | ARC chain の構造検証・暗号検証、`i=` 連番検証、送信/中継時の ARC 署名付与、失敗時ポリシーを実装 |
-| RFC 8461 | MTA-STS | 一部対応 | TXT `id` 検証、policy 取得・キャッシュ、stale 利用、`mode=enforce/testing`、安全なロールオーバーを実装 |
+| RFC 8461 | MTA-STS | 一部対応 | TXT `id` 検証、policy 取得・キャッシュ、`text/plain` 検証、stale 利用、`mode=enforce/testing`、安全なロールオーバー、MX wildcard 制約を実装。詳細は [rfc_8461_gap.md](/home/tamago/ghq/github.com/tamago/orinoco-mta/docs/rfc_8461_gap.md) |
 | RFC 7672 | DANE for SMTP | 一部対応 | TLSA取得と優先適用（DANE > MTA-STS）を実装 |
 | RFC 3464 | DSN | 対応済み（実装範囲内） | DSN パース、DSN 生成（hard/soft bounce）、loop 防止、`Reporting-MTA` / `Status` 検証、相互運用テストを実装。詳細は [rfc_3464_gap.md](/home/tamago/ghq/github.com/tamago/orinoco-mta/docs/rfc_3464_gap.md) |
 

--- a/docs/rfc_8461_gap.md
+++ b/docs/rfc_8461_gap.md
@@ -1,0 +1,25 @@
+# RFC 8461 Gap Note
+
+`orinoco-mta` の MTA-STS 実装は、送信時のポリシー取得と適用を対象にしています。
+
+## 現在カバーしている内容
+
+- `_mta-sts.<domain>` TXT からの policy `id` 検出
+- HTTPS による policy 取得、証明書検証、redirect 拒否
+- `text/plain` media type の確認
+- `mode=enforce/testing/none`、`mx`、`max_age` の policy パース
+- stale policy 利用、TXT `id` 変化時の安全な rollover
+- DANE 優先、MTA-STS 次順位の配送ポリシー適用
+- wildcard MX の左端 1 ラベル一致制約
+
+## 実装範囲外として扱う内容
+
+- smart host 固有の policy domain 選択ロジック
+- policy fetch の proactive refresh スケジューリング
+- TLSRPT の収集と分析
+- 応答サイズ上限や fetch cadence の細かな運用最適化
+
+## 判断メモ
+
+README の RFC 8461 行は、上記の送信側 enforcement 実装を指します。
+RFC 8461 の運用上の推奨事項や周辺 RFC を含む全面実装を意味するものではありません。

--- a/internal/delivery/mta_sts.go
+++ b/internal/delivery/mta_sts.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"net"
 	"net/http"
 	"net/url"
@@ -15,6 +16,8 @@ import (
 	"sync"
 	"time"
 )
+
+const maxMTASTSPolicyAge = 31557600 * time.Second
 
 type MTASTSPolicy struct {
 	Version   string
@@ -34,7 +37,7 @@ func (p MTASTSPolicy) AllowsMX(host string) bool {
 		}
 		if strings.HasPrefix(pat, "*.") {
 			suffix := strings.TrimPrefix(pat, "*.")
-			if strings.HasSuffix(host, "."+suffix) {
+			if parts := strings.SplitN(host, ".", 2); len(parts) == 2 && parts[1] == suffix {
 				return true
 			}
 			continue
@@ -305,6 +308,9 @@ func parseMTASTSPolicy(raw string) (MTASTSPolicy, error) {
 	if p.MaxAge <= 0 {
 		return MTASTSPolicy{}, errors.New("max_age must be positive")
 	}
+	if p.MaxAge > maxMTASTSPolicyAge {
+		return MTASTSPolicy{}, errors.New("max_age exceeds RFC 8461 maximum")
+	}
 	if p.Mode != "none" && len(p.MX) == 0 {
 		return MTASTSPolicy{}, errors.New("mx is required for non-none mode")
 	}
@@ -330,12 +336,25 @@ func fetchMTASTSPolicyTextHTTP(timeout time.Duration) func(context.Context, stri
 		if resp.StatusCode < 200 || resp.StatusCode > 299 {
 			return "", fmt.Errorf("unexpected status %d", resp.StatusCode)
 		}
+		if ct := strings.TrimSpace(resp.Header.Get("Content-Type")); ct != "" {
+			mediaType, params, err := mime.ParseMediaType(ct)
+			if err != nil {
+				return "", fmt.Errorf("invalid content-type: %w", err)
+			}
+			if !isAllowedMTASTSPolicyMediaType(mediaType, params) {
+				return "", fmt.Errorf("unexpected content-type %q", ct)
+			}
+		}
 		b, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 		if err != nil {
 			return "", err
 		}
 		return string(b), nil
 	}
+}
+
+func isAllowedMTASTSPolicyMediaType(mediaType string, _ map[string]string) bool {
+	return strings.EqualFold(strings.TrimSpace(mediaType), "text/plain")
 }
 
 func newMTASTSHTTPClient(timeout time.Duration) *http.Client {

--- a/internal/delivery/mta_sts_test.go
+++ b/internal/delivery/mta_sts_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/x509"
 	"errors"
+	"mime"
 	"net/http"
 	"net/url"
 	"testing"
@@ -24,10 +25,45 @@ func TestParseMTASTSPolicy(t *testing.T) {
 	}
 }
 
+func TestParseMTASTSPolicyRejectsTooLargeMaxAge(t *testing.T) {
+	raw := "version: STSv1\nmode: enforce\nmx: mx.example.net\nmax_age: 31557601\n"
+	if _, err := parseMTASTSPolicy(raw); err == nil {
+		t.Fatal("expected max_age upper bound error")
+	}
+}
+
+func TestIsAllowedMTASTSPolicyMediaType(t *testing.T) {
+	tests := []struct {
+		contentType string
+		want        bool
+	}{
+		{contentType: "text/plain", want: true},
+		{contentType: "text/plain; charset=utf-8", want: true},
+		{contentType: "text/plain; charset=us-ascii", want: true},
+		{contentType: "text/plain; charset=utf-8; foo=bar", want: true},
+		{contentType: "text/html", want: false},
+		{contentType: "application/json", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.contentType, func(t *testing.T) {
+			mt, params, err := mime.ParseMediaType(tc.contentType)
+			if err != nil {
+				t.Fatalf("parse media type: %v", err)
+			}
+			if got := isAllowedMTASTSPolicyMediaType(mt, params); got != tc.want {
+				t.Fatalf("got=%v want=%v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestMTASTSAllowsMX(t *testing.T) {
 	p := MTASTSPolicy{Mode: "enforce", MX: []string{"*.example.net", "mail.example.org"}}
 	if !p.AllowsMX("mx1.example.net") {
 		t.Fatal("wildcard should match")
+	}
+	if p.AllowsMX("mx1.sub.example.net") {
+		t.Fatal("wildcard should only match the left-most label")
 	}
 	if !p.AllowsMX("mail.example.org") {
 		t.Fatal("exact match should match")


### PR DESCRIPTION
## Summary
- tighten RFC 8461 MTA-STS policy validation around `max_age`, policy media type, and MX wildcard matching
- document the supported MTA-STS scope and residual non-goals for the current implementation range

## Changes
- reject `max_age` values above the RFC 8461 upper bound
- require `text/plain` media type when fetching MTA-STS policies
- limit wildcard MX matches to a single left-most label
- add tests for the new policy validation rules and update README/docs

## Validation
- `env GOCACHE=/tmp/go-build GOMODCACHE=/home/tamago/go/pkg/mod go test ./internal/delivery`

## Risks / Follow-ups
- this still focuses on outbound MTA-STS enforcement and does not implement every operational recommendation around refresh cadence or TLSRPT collection

Closes #149