### PR TITLE
fix: add DANE-TA hostname verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Orinoco は南米を流れる川の名前で、
 | RFC 7489 | DMARC | 一部対応 | SPF/DKIM alignment、`p/sp/pct/fo/rf/ri/rua/ruf`、サブドメインポリシー、集計/失敗レポート生成を実装 |
 | RFC 8617 | ARC | 一部対応 | ARC chain の構造検証・暗号検証、`i=` 連番検証、送信/中継時の ARC 署名付与、失敗時ポリシーを実装 |
 | RFC 8461 | MTA-STS | 一部対応 | TXT `id` 検証、policy 取得・キャッシュ、`text/plain` 検証、stale 利用、`mode=enforce/testing`、安全なロールオーバー、MX wildcard 制約を実装。詳細は [rfc_8461_gap.md](/home/tamago/ghq/github.com/tamago/orinoco-mta/docs/rfc_8461_gap.md) |
-| RFC 7672 | DANE for SMTP | 一部対応 | TLSA取得と優先適用（DANE > MTA-STS）を実装 |
+| RFC 7672 | DANE for SMTP | 一部対応 | TLSA取得、CNAME 展開、`DANE-TA(2)` の証明書名チェック、優先適用（DANE > MTA-STS）を実装。詳細は [rfc_7672_gap.md](/home/tamago/ghq/github.com/tamago/orinoco-mta/docs/rfc_7672_gap.md) |
 | RFC 3464 | DSN | 対応済み（実装範囲内） | DSN パース、DSN 生成（hard/soft bounce）、loop 防止、`Reporting-MTA` / `Status` 検証、相互運用テストを実装。詳細は [rfc_3464_gap.md](/home/tamago/ghq/github.com/tamago/orinoco-mta/docs/rfc_3464_gap.md) |
 
 ## 実行方法

--- a/docs/rfc_7672_gap.md
+++ b/docs/rfc_7672_gap.md
@@ -1,0 +1,24 @@
+# RFC 7672 Gap Note
+
+`orinoco-mta` の DANE 実装は、送信時の TLSA 取得と証明書照合を対象にしています。
+
+## 現在カバーしている内容
+
+- MX ごとの `_25._tcp.<mx-host>` TLSA 取得
+- DNS 応答の AD bit を使った DNSSEC 保護前提の usable 判定
+- `2 0 1`, `2 1 1`, `3 0 1`, `3 1 1` プロファイルの照合
+- CNAME で参照される TLSA owner name の探索
+- DANE 優先、MTA-STS 次順位の配送ポリシー適用
+- `DANE-TA(2)` のときの証明書名チェック
+
+## 実装範囲外として扱う内容
+
+- SMTP hop 名以外の追加 reference identifier まで含む完全な名前照合戦略
+- TLSA fetch の TCP fallback や DNS メッセージサイズ最適化
+- DNSSEC 検証自体のローカル実装
+- 証明書更新と TLSA 更新の運用オーケストレーション
+
+## 判断メモ
+
+README の RFC 7672 行は、上記の送信側 TLSA 検証範囲を指します。
+RFC 7672 のすべての相互運用シナリオを網羅する全面実装を意味するものではありません。

--- a/internal/delivery/dane.go
+++ b/internal/delivery/dane.go
@@ -80,7 +80,7 @@ func isSupportedTLSAProfile(rec TLSARecord) bool {
 	}
 }
 
-func verifyPeerCertificatesWithTLSA(peerCerts []*x509.Certificate, records []TLSARecord) error {
+func verifyPeerCertificatesWithTLSA(host string, peerCerts []*x509.Certificate, records []TLSARecord) error {
 	if len(peerCerts) == 0 {
 		return errors.New("no peer certificates")
 	}
@@ -94,6 +94,11 @@ func verifyPeerCertificatesWithTLSA(peerCerts []*x509.Certificate, records []TLS
 		candidates := peerCertCandidatesForUsage(peerCerts, rec.Usage)
 		for _, cert := range candidates {
 			if matchTLSARecord(cert, rec) {
+				if rec.Usage == 2 {
+					if err := cert.VerifyHostname(host); err != nil {
+						continue
+					}
+				}
 				return nil
 			}
 		}

--- a/internal/delivery/dane_test.go
+++ b/internal/delivery/dane_test.go
@@ -210,9 +210,25 @@ func TestVerifyPeerCertificatesWithTLSA_Match(t *testing.T) {
 		},
 	}
 	for i, rec := range cases {
-		if err := verifyPeerCertificatesWithTLSA([]*x509.Certificate{cert}, []TLSARecord{rec}); err != nil {
+		if err := verifyPeerCertificatesWithTLSA("mx.example.net", []*x509.Certificate{cert}, []TLSARecord{rec}); err != nil {
 			t.Fatalf("case %d expected match: %v", i, err)
 		}
+	}
+}
+
+func TestVerifyPeerCertificatesWithTLSA_DANETARequiresHostnameMatch(t *testing.T) {
+	cert := mustCreateTestCert(t)
+	rec := TLSARecord{
+		Usage:                  2,
+		Selector:               1,
+		MatchingType:           1,
+		CertificateAssociation: digestTLSA(cert, 1, 1),
+	}
+	if err := verifyPeerCertificatesWithTLSA("wrong.example.net", []*x509.Certificate{cert}, []TLSARecord{rec}); err == nil {
+		t.Fatal("expected dane-ta hostname mismatch error")
+	}
+	if err := verifyPeerCertificatesWithTLSA("mx.example.net", []*x509.Certificate{cert}, []TLSARecord{rec}); err != nil {
+		t.Fatalf("expected dane-ta match with hostname validation: %v", err)
 	}
 }
 
@@ -224,7 +240,7 @@ func TestVerifyPeerCertificatesWithTLSA_NoMatch(t *testing.T) {
 		MatchingType:           1,
 		CertificateAssociation: []byte{0x00, 0x01, 0x02},
 	}
-	if err := verifyPeerCertificatesWithTLSA([]*x509.Certificate{cert}, []TLSARecord{rec}); err == nil {
+	if err := verifyPeerCertificatesWithTLSA("mx.example.net", []*x509.Certificate{cert}, []TLSARecord{rec}); err == nil {
 		t.Fatal("expected mismatch error")
 	}
 }
@@ -238,6 +254,7 @@ func mustCreateTestCert(t *testing.T) *x509.Certificate {
 	tmpl := &x509.Certificate{
 		SerialNumber: big.NewInt(1),
 		Subject:      pkix.Name{CommonName: "mx.example.net"},
+		DNSNames:     []string{"mx.example.net"},
 		NotBefore:    time.Now().Add(-time.Hour),
 		NotAfter:     time.Now().Add(time.Hour),
 		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,

--- a/internal/delivery/smtp_client.go
+++ b/internal/delivery/smtp_client.go
@@ -232,7 +232,7 @@ func (c *Client) deliverHost(ctx context.Context, host string, port int, msg *mo
 			}
 			if daneRes != nil {
 				state := tlsConn.ConnectionState()
-				if err := verifyPeerCertificatesWithTLSA(state.PeerCertificates, daneRes.Records); err != nil {
+				if err := verifyPeerCertificatesWithTLSA(host, state.PeerCertificates, daneRes.Records); err != nil {
 					return &SMTPResponseError{Code: 550, Line: "dane authentication failed"}
 				}
 			}


### PR DESCRIPTION
## Summary
- add RFC 7672-aligned hostname verification for `DANE-TA(2)` certificate matches
- document the supported DANE scope and current non-goals for the outbound implementation

## Changes
- require hostname validation when a TLSA match uses certificate usage `2` (DANE-TA)
- keep `DANE-EE(3)` behavior unchanged while tightening only the trust-anchor path
- add focused tests and update README/docs for the current RFC 7672 support boundary

## Validation
- `env GOCACHE=/tmp/go-build GOMODCACHE=/home/tamago/go/pkg/mod go test ./internal/delivery`

## Risks / Follow-ups
- this still focuses on outbound TLSA validation and does not yet cover every RFC 7672 interoperability edge case

Closes #148