### PR TITLE
fix: support AUTH LOGIN initial response

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Orinoco は南米を流れる川の名前で、
 | RFC 3207 | SMTP STARTTLS | 対応済み（実装範囲内） | 受信側/送信側で STARTTLS 昇格を実装 |
 | RFC 1870 | SMTP SIZE | 対応済み（実装範囲内） | `SIZE` パラメータと最大メッセージサイズ制限を実装 |
 | RFC 6152 | 8BITMIME | 対応済み（実装範囲内） | `BODY=8BITMIME` と 8bit 本文受信を実装 |
-| RFC 4954 | SMTP AUTH | 一部対応 | Submission 経路で `AUTH PLAIN` / `AUTH LOGIN` を実装 |
+| RFC 4954 | SMTP AUTH | 一部対応 | Submission 経路で `AUTH PLAIN` / `AUTH LOGIN`、`AUTH LOGIN` initial response、認証失敗後の再試行を実装。詳細は [rfc_4954_gap.md](/home/tamago/ghq/github.com/tamago/orinoco-mta/docs/rfc_4954_gap.md) |
 | RFC 6409 | Message Submission | 一部対応 | Submission リスナ、認証必須化、送信者ドメイン制約を実装 |
 | RFC 6531 | SMTPUTF8 | 非対応（方針確定） | `SMTPUTF8` パラメータと UTF-8 メールアドレスは明示的に拒否（`555`/`553`） |
 | RFC 7208 | SPF | 一部対応 | `ip4`, `ip6`, `a`, `mx`, `include`, `exists`, `ptr`, `redirect`, `exp`, macro 展開、lookup 制限、HELO/MAIL FROM ポリシー分離を実装 |

--- a/docs/rfc_4954_gap.md
+++ b/docs/rfc_4954_gap.md
@@ -1,0 +1,23 @@
+# RFC 4954 Gap Note
+
+`orinoco-mta` の SMTP AUTH 実装は、Submission 経路での基本的なユーザ認証を対象にしています。
+
+## 現在カバーしている内容
+
+- `AUTH PLAIN` と `AUTH LOGIN`
+- `AUTH LOGIN` の challenge-response 形式と initial response 形式
+- 認証必須 Submission での未認証 `MAIL FROM` 拒否
+- 認証失敗後の再試行
+- 認証済みユーザと `MAIL FROM` ドメインの整合制約
+
+## 実装範囲外として扱う内容
+
+- CRAM-MD5, SCRAM, OAuth Bearer など追加 SASL mechanism
+- `MAIL FROM AUTH=` パラメータ
+- SASL security layer negotiation
+- 外部 identity provider や多要素認証との統合
+
+## 判断メモ
+
+README の RFC 4954 行は、上記の Submission 向け基本認証フローを指します。
+RFC 4954 のすべての SASL 拡張や運用パターンを網羅する全面実装を意味するものではありません。

--- a/internal/smtp/server.go
+++ b/internal/smtp/server.go
@@ -797,16 +797,25 @@ func (s *Server) handleAuth(r *bufio.Reader, w *bufio.Writer, arg string) (strin
 		}
 		return user, s.authBackend.Validate(user, pass), nil
 	case "LOGIN":
-		if err := writeLine(w, "334 VXNlcm5hbWU6"); err != nil {
-			return "", false, err
-		}
-		userLine, err := r.ReadString('\n')
-		if err != nil {
-			return "", false, err
-		}
-		userRaw, err := decodeBase64Line(userLine)
-		if err != nil {
-			return "", false, errors.New("invalid base64 username")
+		var userRaw []byte
+		if len(parts) >= 2 {
+			var err error
+			userRaw, err = decodeBase64Line(parts[1])
+			if err != nil {
+				return "", false, errors.New("invalid base64 username")
+			}
+		} else {
+			if err := writeLine(w, "334 VXNlcm5hbWU6"); err != nil {
+				return "", false, err
+			}
+			userLine, err := r.ReadString('\n')
+			if err != nil {
+				return "", false, err
+			}
+			userRaw, err = decodeBase64Line(userLine)
+			if err != nil {
+				return "", false, errors.New("invalid base64 username")
+			}
 		}
 		if err := writeLine(w, "334 UGFzc3dvcmQ6"); err != nil {
 			return "", false, err

--- a/internal/smtp/server_test.go
+++ b/internal/smtp/server_test.go
@@ -1022,6 +1022,70 @@ func TestSubmissionAuthLoginSuccess(t *testing.T) {
 	}
 }
 
+func TestSubmissionAuthLoginWithInitialResponse(t *testing.T) {
+	backend, err := userauth.NewStatic("alice@example.com:s3cr3t")
+	if err != nil {
+		t.Fatalf("new static backend: %v", err)
+	}
+	s := &Server{
+		cfg:         config.Config{Hostname: "sub.example.test", SubmissionAuth: true},
+		submission:  true,
+		authBackend: backend,
+	}
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	go s.handleConn(server)
+
+	r := bufio.NewReader(client)
+	w := bufio.NewWriter(client)
+	_, _ = readSMTPResponse(t, r)
+	mustWriteSMTPLine(t, w, "EHLO client.example")
+	_, _ = readSMTPResponse(t, r)
+	mustWriteSMTPLine(t, w, "AUTH LOGIN YWxpY2VAZXhhbXBsZS5jb20=")
+	_, code := readSMTPResponse(t, r)
+	if code != 334 {
+		t.Fatalf("password challenge code=%d want=334", code)
+	}
+	mustWriteSMTPLine(t, w, "czNjcjN0")
+	_, code = readSMTPResponse(t, r)
+	if code != 235 {
+		t.Fatalf("final auth code=%d want=235", code)
+	}
+}
+
+func TestSubmissionAuthFailureAllowsRetry(t *testing.T) {
+	backend, err := userauth.NewStatic("alice@example.com:s3cr3t")
+	if err != nil {
+		t.Fatalf("new static backend: %v", err)
+	}
+	s := &Server{
+		cfg:         config.Config{Hostname: "sub.example.test", SubmissionAuth: true},
+		submission:  true,
+		authBackend: backend,
+	}
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	go s.handleConn(server)
+
+	r := bufio.NewReader(client)
+	w := bufio.NewWriter(client)
+	_, _ = readSMTPResponse(t, r)
+	mustWriteSMTPLine(t, w, "EHLO client.example")
+	_, _ = readSMTPResponse(t, r)
+	mustWriteSMTPLine(t, w, "AUTH PLAIN AGFsaWNlQGV4YW1wbGUuY29tAHdyb25n")
+	_, code := readSMTPResponse(t, r)
+	if code != 535 {
+		t.Fatalf("first auth code=%d want=535", code)
+	}
+	mustWriteSMTPLine(t, w, "AUTH PLAIN AGFsaWNlQGV4YW1wbGUuY29tAHMzY3IzdA==")
+	_, code = readSMTPResponse(t, r)
+	if code != 235 {
+		t.Fatalf("retry auth code=%d want=235", code)
+	}
+}
+
 func TestSubmissionSenderIdentityMismatchRejected(t *testing.T) {
 	backend, err := userauth.NewStatic("alice@example.com:s3cr3t")
 	if err != nil {


### PR DESCRIPTION
## Summary
- improve RFC 4954 interoperability for Submission by accepting `AUTH LOGIN` with an initial response
- document the supported SMTP AUTH scope and current non-goals for the implementation

## Changes
- accept `AUTH LOGIN <base64-username>` in addition to the existing challenge-response flow
- add tests for login initial response and retrying authentication after a failed attempt
- update README and add an RFC 4954 gap note for the current support boundary

## Validation
- `env GOCACHE=/tmp/go-build GOMODCACHE=/home/tamago/go/pkg/mod go test ./internal/smtp`

## Risks / Follow-ups
- the implementation still focuses on `PLAIN` and `LOGIN` and does not yet cover additional SASL mechanisms or `MAIL FROM AUTH=`

Closes #147