### PR TITLE
test: tighten RFC 8617 ARC coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Orinoco は南米を流れる川の名前で、
 | RFC 7208 | SPF | 一部対応 | `ip4`, `ip6`, `a`, `mx`, `include`, `exists`, `ptr`, `redirect`, `exp`, macro 展開、lookup 制限、HELO/MAIL FROM ポリシー分離を実装 |
 | RFC 6376 | DKIM | 一部対応 | 受信時の DKIM 検証、複数署名評価、`l/t/x/h`、canonicalization、送信時 DKIM 署名を実装 |
 | RFC 7489 | DMARC | 一部対応 | SPF/DKIM alignment、`p/sp/pct/fo/rf/ri/rua/ruf`、サブドメインポリシー、`fo`/`rf` の RFC 準拠パース、集計/失敗レポート生成を実装。詳細は [rfc_7489_gap.md](/home/tamago/ghq/github.com/tamago/orinoco-mta/docs/rfc_7489_gap.md) |
-| RFC 8617 | ARC | 一部対応 | ARC chain の構造検証・暗号検証、`i=` 連番検証、送信/中継時の ARC 署名付与、失敗時ポリシーを実装 |
+| RFC 8617 | ARC | 一部対応 | ARC chain の構造検証・暗号検証、`i=` 連番検証、複数 hop 検証、ARC ヘッダ未付与メールへの署名付与、失敗時ポリシーを実装。既存 chain の継続署名は未対応。詳細は [rfc_8617_gap.md](/home/tamago/ghq/github.com/tamago/orinoco-mta/docs/rfc_8617_gap.md) |
 | RFC 8461 | MTA-STS | 一部対応 | TXT `id` 検証、policy 取得・キャッシュ、`text/plain` 検証、stale 利用、`mode=enforce/testing`、安全なロールオーバー、MX wildcard 制約を実装。詳細は [rfc_8461_gap.md](/home/tamago/ghq/github.com/tamago/orinoco-mta/docs/rfc_8461_gap.md) |
 | RFC 7672 | DANE for SMTP | 一部対応 | TLSA取得、CNAME 展開、`DANE-TA(2)` の証明書名チェック、優先適用（DANE > MTA-STS）を実装。詳細は [rfc_7672_gap.md](/home/tamago/ghq/github.com/tamago/orinoco-mta/docs/rfc_7672_gap.md) |
 | RFC 3464 | DSN | 対応済み（実装範囲内） | DSN パース、DSN 生成（hard/soft bounce）、loop 防止、`Reporting-MTA` / `Status` 検証、相互運用テストを実装。詳細は [rfc_3464_gap.md](/home/tamago/ghq/github.com/tamago/orinoco-mta/docs/rfc_3464_gap.md) |

--- a/docs/rfc_8617_gap.md
+++ b/docs/rfc_8617_gap.md
@@ -1,0 +1,23 @@
+# RFC 8617 Gap Note
+
+`orinoco-mta` の ARC 実装は、受信時の chain 検証と ARC ヘッダ未付与メールへの署名付与を対象にしています。
+
+## 現在カバーしている内容
+
+- `ARC-Seal` / `ARC-Message-Signature` / `ARC-Authentication-Results` の 3 点セット検証
+- `i=` の連番、重複、欠落、`cv` 制約の検証
+- 1 hop と複数 hop の ARC chain に対する暗号検証テスト
+- 受信ポリシーとしての `accept` / `quarantine` / `reject`
+- ARC ヘッダがまだ無いメッセージへの新規 ARC セット付与
+- 鍵ローテーション時の ARC 署名キー再読込
+
+## 実装範囲外として扱う内容
+
+- 既存 ARC chain を持つメッセージに対する次 hop の継続署名
+- `cv=fail` を伴う受信チェーンを引き継いだうえでの再署名方針
+- 外部 MTA 実装との差異を吸収するための広範な相互運用マトリクス
+
+## 判断メモ
+
+README の RFC 8617 行は、受信検証と単独メッセージへの ARC 署名付与を指します。
+既存 ARC chain の継続署名が未実装のため、現時点では `対応済み` ではなく `一部対応` のままとします。

--- a/internal/mailauth/arc_test.go
+++ b/internal/mailauth/arc_test.go
@@ -142,3 +142,93 @@ func TestEvalARCCryptoPass(t *testing.T) {
 		t.Fatalf("result=%s reason=%s", res.Result, res.Reason)
 	}
 }
+
+func TestEvalARCMultiHopCryptoPass(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	pubDER, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		t.Fatalf("marshal pubkey: %v", err)
+	}
+	origLookup := dkimLookupTXT
+	t.Cleanup(func() {
+		dkimLookupTXT = origLookup
+	})
+	dkimLookupTXT = func(_ context.Context, name string) ([]string, error) {
+		if name == "s1._domainkey.example.com" {
+			return []string{"v=DKIM1; k=rsa; p=" + base64.StdEncoding.EncodeToString(pubDER)}, nil
+		}
+		return nil, nil
+	}
+
+	body := "hello\r\n"
+	bodyHash := sha256.Sum256(canonicalizeBody(body, "simple"))
+	bh := base64.StdEncoding.EncodeToString(bodyHash[:])
+
+	ams1Base := "i=1; a=rsa-sha256; d=example.com; s=s1; c=simple/simple; h=from:to:subject; bh=" + bh + "; b="
+	seal1Base := "i=1; cv=none; a=rsa-sha256; d=example.com; s=s1; b="
+	ams2Base := "i=2; a=rsa-sha256; d=example.com; s=s1; c=simple/simple; h=from:to:subject; bh=" + bh + "; b="
+	seal2Base := "i=2; cv=pass; a=rsa-sha256; d=example.com; s=s1; b="
+	headers := []Header{
+		{Name: "From", Value: "a@example.com"},
+		{Name: "To", Value: "b@example.net"},
+		{Name: "Subject", Value: "arc multi hop"},
+		{Name: "ARC-Authentication-Results", Value: "i=1; mx=mx1.example.net; dmarc=pass"},
+		{Name: "ARC-Message-Signature", Value: ams1Base},
+		{Name: "ARC-Seal", Value: seal1Base},
+		{Name: "ARC-Authentication-Results", Value: "i=2; mx=mx2.example.net; dmarc=pass"},
+		{Name: "ARC-Message-Signature", Value: ams2Base},
+		{Name: "ARC-Seal", Value: seal2Base},
+	}
+
+	ams1Data, err := buildSignedData(headers, "from:to:subject", ams1Base, "simple", "ARC-Message-Signature")
+	if err != nil {
+		t.Fatalf("build ams1 data: %v", err)
+	}
+	ams1Hash := sha256.Sum256([]byte(ams1Data))
+	ams1Sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, ams1Hash[:])
+	if err != nil {
+		t.Fatalf("sign ams1: %v", err)
+	}
+	headers[4].Value = ams1Base + base64.StdEncoding.EncodeToString(ams1Sig)
+
+	seal1Data, err := buildARCSealSignedData(headers, 1)
+	if err != nil {
+		t.Fatalf("build seal1 data: %v", err)
+	}
+	seal1Hash := sha256.Sum256([]byte(seal1Data))
+	seal1Sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, seal1Hash[:])
+	if err != nil {
+		t.Fatalf("sign seal1: %v", err)
+	}
+	headers[5].Value = seal1Base + base64.StdEncoding.EncodeToString(seal1Sig)
+
+	ams2Data, err := buildSignedData(headers, "from:to:subject", ams2Base, "simple", "ARC-Message-Signature")
+	if err != nil {
+		t.Fatalf("build ams2 data: %v", err)
+	}
+	ams2Hash := sha256.Sum256([]byte(ams2Data))
+	ams2Sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, ams2Hash[:])
+	if err != nil {
+		t.Fatalf("sign ams2: %v", err)
+	}
+	headers[7].Value = ams2Base + base64.StdEncoding.EncodeToString(ams2Sig)
+
+	seal2Data, err := buildARCSealSignedData(headers, 2)
+	if err != nil {
+		t.Fatalf("build seal2 data: %v", err)
+	}
+	seal2Hash := sha256.Sum256([]byte(seal2Data))
+	seal2Sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, seal2Hash[:])
+	if err != nil {
+		t.Fatalf("sign seal2: %v", err)
+	}
+	headers[8].Value = seal2Base + base64.StdEncoding.EncodeToString(seal2Sig)
+
+	res := EvalARC(headers, body)
+	if res.Result != "pass" {
+		t.Fatalf("result=%s reason=%s", res.Result, res.Reason)
+	}
+}


### PR DESCRIPTION
## Summary
- add a multi-hop ARC cryptographic verification test
- document the remaining RFC 8617 gap around continuing an existing ARC chain
- update the README RFC matrix for ARC coverage

## Verification
- go test ./internal/mailauth ./internal/dkim

Closes #150