### PR TITLE
test: tighten RFC 3207 STARTTLS coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Orinoco は南米を流れる川の名前で、
 | RFC | 技術 | 対応状況 | 補足 |
 | --- | --- | --- | --- |
 | RFC 5321 | SMTP | 対応済み（実装範囲内） | `EHLO/HELO`, `MAIL FROM`, `RCPT TO`, `DATA`, `RSET`, `NOOP`, `QUIT`, `HELP`, `VRFY` を実装。`EXPN` は `502` 応答、`Received:` トレースヘッダ、`postmaster` 宛特例、主要な構文/状態遷移/行長制限のコンフォーマンステストを整備。拡張は各RFCで管理 |
-| RFC 3207 | SMTP STARTTLS | 対応済み（実装範囲内） | 受信側/送信側で STARTTLS 昇格を実装 |
+| RFC 3207 | SMTP STARTTLS | 対応済み（実装範囲内） | 受信側/送信側で STARTTLS 昇格、TLS 後の再 EHLO、セッション再初期化を実装。詳細は [rfc_3207_gap.md](/home/tamago/ghq/github.com/tamago/orinoco-mta/docs/rfc_3207_gap.md) |
 | RFC 1870 | SMTP SIZE | 対応済み（実装範囲内） | EHLO での `SIZE` 広告、`MAIL FROM SIZE=`、上限超過拒否、境界値テストを実装。詳細は [rfc_1870_gap.md](/home/tamago/ghq/github.com/tamago/orinoco-mta/docs/rfc_1870_gap.md) |
 | RFC 6152 | 8BITMIME | 対応済み（実装範囲内） | EHLO での `8BITMIME` 広告、`BODY=8BITMIME` / `BODY=7BIT`、8bit 本文の受理/拒否を実装。詳細は [rfc_6152_gap.md](/home/tamago/ghq/github.com/tamago/orinoco-mta/docs/rfc_6152_gap.md) |
 | RFC 4954 | SMTP AUTH | 一部対応 | Submission 経路で `AUTH PLAIN` / `AUTH LOGIN`、`AUTH LOGIN` initial response、認証失敗後の再試行を実装。詳細は [rfc_4954_gap.md](/home/tamago/ghq/github.com/tamago/orinoco-mta/docs/rfc_4954_gap.md) |

--- a/docs/rfc_3207_gap.md
+++ b/docs/rfc_3207_gap.md
@@ -1,0 +1,23 @@
+# RFC 3207 Gap Note
+
+`orinoco-mta` の STARTTLS 実装は、受信側 SMTP サーバと送信側 SMTP クライアントでの TLS 昇格フローを対象にしています。
+
+## 現在カバーしている内容
+
+- 受信側 EHLO での `STARTTLS` 広告
+- `STARTTLS` 成功後の TLS ハンドシェイク
+- TLS 昇格後の SMTP セッション再初期化と EHLO 再実行要求
+- TLS 有効時に `STARTTLS` を再広告しない挙動
+- 送信側での `STARTTLS` 検出、TLS 昇格、再 EHLO
+- TLS 必須ポリシー時の失敗処理
+
+## 実装範囲外として扱う内容
+
+- クライアント証明書認証
+- 明示的な downgrade attack 検知ロジック
+- TLS-RPT など周辺レポート仕様そのもの
+
+## 判断メモ
+
+README の RFC 3207 行は、SMTP セッション中の STARTTLS 昇格と再初期化の実装範囲を指します。
+この範囲では受信側・送信側の主要挙動をカバーできているため、`対応済み（実装範囲内）` を維持します。

--- a/internal/smtp/server_test.go
+++ b/internal/smtp/server_test.go
@@ -950,9 +950,12 @@ func TestSTARTTLSWithTLSConfigUpgradesConnection(t *testing.T) {
 	if err := wt.Flush(); err != nil {
 		t.Fatalf("flush EHLO over TLS: %v", err)
 	}
-	_, code = readSMTPResponse(t, rt)
+	resp, code = readSMTPResponse(t, rt)
 	if code != 250 {
 		t.Fatalf("code=%d want=250", code)
+	}
+	if strings.Contains(resp, "STARTTLS") {
+		t.Fatalf("STARTTLS must not be advertised after TLS is active: %q", resp)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add coverage that STARTTLS is not re-advertised after TLS is active
- document the inbound and outbound RFC 3207 implementation scope
- keep the README RFC matrix aligned with the tested behavior

## Verification
- go test ./internal/smtp

Closes #141