### PR TITLE
[codex] add YAML config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,21 @@ go run ./cmd/kuroshio
 
 デフォルトでは `:2525` でSMTP待受します。
 
+## YAML設定
+
+`MTA_CONFIG_FILE` に YAML ファイルを指定すると、`gopkg.in/yaml.v3` で設定を読み込みます。未指定でも作業ディレクトリ直下の `config.yaml` または `config.yml` があれば自動で読み込みます。
+
+```bash
+MTA_CONFIG_FILE=./config.yaml go run ./cmd/kuroshio
+```
+
+サンプルは [config.example.yaml](/home/tamago/ghq/github.com/tamago/kuroshio-mta/config.example.yaml) に置いてあります。
+
+補足:
+- YAML は `internal/config.Config` に対応する値をまとめて持てます
+- `MTA_SUBMISSION_USERS_FILE` と `MTA_ADMIN_TOKENS_FILE` はこれまで通りシークレットファイル用途で使えます
+- 同じ設定を YAML と環境変数の両方で指定した場合は、環境変数が優先されます
+
 ## 主要環境変数
 
 - `MTA_LISTEN_ADDR` (default: `:2525`)

--- a/cmd/kuroshio/main.go
+++ b/cmd/kuroshio/main.go
@@ -27,7 +27,10 @@ import (
 )
 
 func main() {
-	cfg := config.Load()
+	cfg, err := config.Load()
+	if err != nil {
+		fatal("config load failed", "error", err)
+	}
 	slog.SetDefault(logging.New(cfg.LogLevel, os.Stdout))
 	slog.Info("audit event", "component", "audit", "event", "config_loaded", "queue_backend", cfg.QueueBackend, "submission_enabled", cfg.SubmissionAddr != "", "delivery_mode", cfg.DeliveryMode)
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,68 @@
+listen_addr: ":2525"
+submission_addr: ":587"
+submission_auth_required: true
+submission_users: "alice@example.com:s3cr3t"
+submission_enforce_sender_identity: true
+log_level: info
+observability_addr: ":9090"
+admin_addr: ":8080"
+admin_tokens: "viewer-token:viewer,operator-token:operator"
+hostname: orinoco.local
+queue_dir: ./var/queue
+queue_backend: local
+kafka_brokers:
+  - localhost:9092
+kafka_consumer_group: kuroshio-mta
+kafka_topic_inbound: mail.inbound
+kafka_topic_retry: mail.retry
+kafka_topic_dlq: mail.dlq
+kafka_topic_sent: mail.sent
+tls_cert_file: ./certs/tls.crt
+tls_key_file: ./certs/tls.key
+ingress_rate_limit_per_minute: 100
+rate_limit_rules: "connect:ip:100:1m"
+dnsbl_zones:
+  - zen.spamhaus.org
+dnsbl_cache_ttl: 5m
+dane_dnssec_trust_model: ad_required
+mta_sts_cache_ttl: 1h
+mta_sts_fetch_timeout: 5s
+delivery_mode: mx
+local_spool_dir: ./var/spool
+relay_host: smtp.relay.local
+relay_port: 587
+relay_require_tls: true
+max_message_bytes: 10485760
+worker_count: 4
+max_attempts: 12
+max_retry_age: 120h
+retry_schedule:
+  - 5m
+  - 30m
+  - 2h
+  - 6h
+  - 24h
+scan_interval: 5s
+dial_timeout: 8s
+send_timeout: 20s
+dkim_sign_domain: example.com
+dkim_sign_selector: default
+dkim_private_key_file: ./keys/dkim.pem
+dkim_sign_headers: from:to:subject:date:message-id
+arc_failure_policy: accept
+spf_helo_policy: advisory
+spf_mailfrom_policy: advisory
+domain_max_concurrent_default: 8
+domain_max_concurrent_rules: "gmail.com:2,yahoo.com:1"
+domain_adaptive_throttle: true
+domain_tempfail_threshold: 0.3
+domain_penalty_max: 5s
+data_retention_sent: 720h
+data_retention_dlq: 2160h
+data_retention_poison: 4320h
+retention_sweep_interval: 1h
+reputation_start_date: "2026-01-01"
+reputation_warmup_rules: "0:100,7:1000,14:5000"
+reputation_bounce_threshold: 0.05
+reputation_complaint_threshold: 0.001
+reputation_min_samples: 100

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,5 @@ require (
 	github.com/klauspost/compress v1.15.9 // indirect
 	github.com/pierrec/lz4/v4 v4.1.15 // indirect
 	github.com/segmentio/kafka-go v0.4.47 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -56,4 +56,5 @@ golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,10 +1,13 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 type Config struct {
@@ -71,90 +74,503 @@ type Config struct {
 	ReputationMinSamples       int
 }
 
-func Load() Config {
+type yamlConfig struct {
+	ListenAddr                 *string  `yaml:"listen_addr"`
+	SubmissionAddr             *string  `yaml:"submission_addr"`
+	SubmissionAuth             *bool    `yaml:"submission_auth_required"`
+	SubmissionUsers            *string  `yaml:"submission_users"`
+	SubmissionSenderID         *bool    `yaml:"submission_enforce_sender_identity"`
+	LogLevel                   *string  `yaml:"log_level"`
+	ObservabilityAddr          *string  `yaml:"observability_addr"`
+	AdminAddr                  *string  `yaml:"admin_addr"`
+	AdminTokens                *string  `yaml:"admin_tokens"`
+	Hostname                   *string  `yaml:"hostname"`
+	QueueDir                   *string  `yaml:"queue_dir"`
+	QueueBackend               *string  `yaml:"queue_backend"`
+	KafkaBrokers               []string `yaml:"kafka_brokers"`
+	KafkaConsumerGroup         *string  `yaml:"kafka_consumer_group"`
+	KafkaTopicInbound          *string  `yaml:"kafka_topic_inbound"`
+	KafkaTopicRetry            *string  `yaml:"kafka_topic_retry"`
+	KafkaTopicDLQ              *string  `yaml:"kafka_topic_dlq"`
+	KafkaTopicSent             *string  `yaml:"kafka_topic_sent"`
+	TLSCertFile                *string  `yaml:"tls_cert_file"`
+	TLSKeyFile                 *string  `yaml:"tls_key_file"`
+	IngressRateLimit           *int     `yaml:"ingress_rate_limit_per_minute"`
+	RateLimitRules             *string  `yaml:"rate_limit_rules"`
+	DNSBLZones                 []string `yaml:"dnsbl_zones"`
+	DNSBLCacheTTL              *string  `yaml:"dnsbl_cache_ttl"`
+	DANEDNSSECTrustModel       *string  `yaml:"dane_dnssec_trust_model"`
+	MTASTSCacheTTL             *string  `yaml:"mta_sts_cache_ttl"`
+	MTASTSFetchTimeout         *string  `yaml:"mta_sts_fetch_timeout"`
+	DeliveryMode               *string  `yaml:"delivery_mode"`
+	LocalSpoolDir              *string  `yaml:"local_spool_dir"`
+	RelayHost                  *string  `yaml:"relay_host"`
+	RelayPort                  *int     `yaml:"relay_port"`
+	RelayRequireTLS            *bool    `yaml:"relay_require_tls"`
+	MaxMessageBytes            *int64   `yaml:"max_message_bytes"`
+	WorkerCount                *int     `yaml:"worker_count"`
+	MaxAttempts                *int     `yaml:"max_attempts"`
+	MaxRetryAge                *string  `yaml:"max_retry_age"`
+	RetrySchedule              []string `yaml:"retry_schedule"`
+	ScanInterval               *string  `yaml:"scan_interval"`
+	DialTimeout                *string  `yaml:"dial_timeout"`
+	SendTimeout                *string  `yaml:"send_timeout"`
+	DKIMSignDomain             *string  `yaml:"dkim_sign_domain"`
+	DKIMSignSelector           *string  `yaml:"dkim_sign_selector"`
+	DKIMPrivateKeyFile         *string  `yaml:"dkim_private_key_file"`
+	DKIMSignHeaders            *string  `yaml:"dkim_sign_headers"`
+	ARCFailurePolicy           *string  `yaml:"arc_failure_policy"`
+	SPFHeloPolicy              *string  `yaml:"spf_helo_policy"`
+	SPFMailFromPolicy          *string  `yaml:"spf_mailfrom_policy"`
+	DomainMaxConcurrentDefault *int     `yaml:"domain_max_concurrent_default"`
+	DomainMaxConcurrentRules   *string  `yaml:"domain_max_concurrent_rules"`
+	DomainAdaptiveThrottle     *bool    `yaml:"domain_adaptive_throttle"`
+	DomainTempFailThreshold    *float64 `yaml:"domain_tempfail_threshold"`
+	DomainPenaltyMax           *string  `yaml:"domain_penalty_max"`
+	DataRetentionSent          *string  `yaml:"data_retention_sent"`
+	DataRetentionDLQ           *string  `yaml:"data_retention_dlq"`
+	DataRetentionPoison        *string  `yaml:"data_retention_poison"`
+	RetentionSweepInterval     *string  `yaml:"retention_sweep_interval"`
+	ReputationStartDate        *string  `yaml:"reputation_start_date"`
+	ReputationWarmupRules      *string  `yaml:"reputation_warmup_rules"`
+	ReputationBounceThreshold  *float64 `yaml:"reputation_bounce_threshold"`
+	ReputationComplaintThresh  *float64 `yaml:"reputation_complaint_threshold"`
+	ReputationMinSamples       *int     `yaml:"reputation_min_samples"`
+}
+
+func Load() (Config, error) {
+	cfg := defaultConfig()
+
+	configPath, explicit := resolveConfigPath()
+	if configPath != "" {
+		loaded, err := loadYAMLConfig(configPath, cfg)
+		if err != nil {
+			return Config{}, err
+		}
+		cfg = loaded
+	} else if explicit {
+		return Config{}, fmt.Errorf("config file %q not found", os.Getenv("MTA_CONFIG_FILE"))
+	}
+
+	cfg.ListenAddr = env("MTA_LISTEN_ADDR", cfg.ListenAddr)
+	cfg.SubmissionAddr = env("MTA_SUBMISSION_ADDR", cfg.SubmissionAddr)
+	cfg.SubmissionAuth = envBool("MTA_SUBMISSION_AUTH_REQUIRED", cfg.SubmissionAuth)
+	cfg.SubmissionUsers = envOrFile("MTA_SUBMISSION_USERS", "MTA_SUBMISSION_USERS_FILE", cfg.SubmissionUsers)
+	cfg.SubmissionSenderID = envBool("MTA_SUBMISSION_ENFORCE_SENDER_IDENTITY", cfg.SubmissionSenderID)
+	cfg.LogLevel = env("MTA_LOG_LEVEL", cfg.LogLevel)
+	cfg.ObservabilityAddr = env("MTA_OBSERVABILITY_ADDR", cfg.ObservabilityAddr)
+	cfg.AdminAddr = env("MTA_ADMIN_ADDR", cfg.AdminAddr)
+	cfg.AdminTokens = envOrFile("MTA_ADMIN_TOKENS", "MTA_ADMIN_TOKENS_FILE", cfg.AdminTokens)
+	cfg.Hostname = env("MTA_HOSTNAME", cfg.Hostname)
+	cfg.QueueDir = env("MTA_QUEUE_DIR", cfg.QueueDir)
+	cfg.QueueBackend = env("MTA_QUEUE_BACKEND", cfg.QueueBackend)
+	cfg.KafkaBrokers = envCSV("MTA_KAFKA_BROKERS", cfg.KafkaBrokers)
+	cfg.KafkaConsumerGroup = env("MTA_KAFKA_CONSUMER_GROUP", cfg.KafkaConsumerGroup)
+	cfg.KafkaTopicInbound = env("MTA_KAFKA_TOPIC_INBOUND", cfg.KafkaTopicInbound)
+	cfg.KafkaTopicRetry = env("MTA_KAFKA_TOPIC_RETRY", cfg.KafkaTopicRetry)
+	cfg.KafkaTopicDLQ = env("MTA_KAFKA_TOPIC_DLQ", cfg.KafkaTopicDLQ)
+	cfg.KafkaTopicSent = env("MTA_KAFKA_TOPIC_SENT", cfg.KafkaTopicSent)
+	cfg.TLSCertFile = env("MTA_TLS_CERT_FILE", cfg.TLSCertFile)
+	cfg.TLSKeyFile = env("MTA_TLS_KEY_FILE", cfg.TLSKeyFile)
+	cfg.IngressRateLimit = envInt("MTA_INGRESS_RATE_LIMIT_PER_MINUTE", cfg.IngressRateLimit)
+	cfg.RateLimitRules = env("MTA_RATE_LIMIT_RULES", cfg.RateLimitRules)
+	cfg.DNSBLZones = envCSV("MTA_DNSBL_ZONES", cfg.DNSBLZones)
+	cfg.DNSBLCacheTTL = envDuration("MTA_DNSBL_CACHE_TTL", cfg.DNSBLCacheTTL)
+	cfg.DANEDNSSECTrustModel = envEnum("MTA_DANE_DNSSEC_TRUST_MODEL", cfg.DANEDNSSECTrustModel, []string{"ad_required", "insecure_allow_unsigned"})
+	cfg.MTASTSCacheTTL = envDuration("MTA_MTA_STS_CACHE_TTL", cfg.MTASTSCacheTTL)
+	cfg.MTASTSFetchTimeout = envDuration("MTA_MTA_STS_FETCH_TIMEOUT", cfg.MTASTSFetchTimeout)
+	cfg.DeliveryMode = env("MTA_DELIVERY_MODE", cfg.DeliveryMode)
+	cfg.LocalSpoolDir = env("MTA_LOCAL_SPOOL_DIR", cfg.LocalSpoolDir)
+	cfg.RelayHost = env("MTA_RELAY_HOST", cfg.RelayHost)
+	cfg.RelayPort = envInt("MTA_RELAY_PORT", cfg.RelayPort)
+	cfg.RelayRequireTLS = envBool("MTA_RELAY_REQUIRE_TLS", cfg.RelayRequireTLS)
+	cfg.MaxMessageBytes = envInt64("MTA_MAX_MESSAGE_BYTES", cfg.MaxMessageBytes)
+	cfg.WorkerCount = envInt("MTA_WORKER_COUNT", cfg.WorkerCount)
+	cfg.MaxAttempts = envInt("MTA_MAX_ATTEMPTS", cfg.MaxAttempts)
+	cfg.MaxRetryAge = envDuration("MTA_MAX_RETRY_AGE", cfg.MaxRetryAge)
+	cfg.RetrySchedule = envDurationList("MTA_RETRY_SCHEDULE", cfg.RetrySchedule)
+	cfg.ScanInterval = envDuration("MTA_SCAN_INTERVAL", cfg.ScanInterval)
+	cfg.DialTimeout = envDuration("MTA_DIAL_TIMEOUT", cfg.DialTimeout)
+	cfg.SendTimeout = envDuration("MTA_SEND_TIMEOUT", cfg.SendTimeout)
+	cfg.DKIMSignDomain = env("MTA_DKIM_SIGN_DOMAIN", cfg.DKIMSignDomain)
+	cfg.DKIMSignSelector = env("MTA_DKIM_SIGN_SELECTOR", cfg.DKIMSignSelector)
+	cfg.DKIMPrivateKeyFile = env("MTA_DKIM_PRIVATE_KEY_FILE", cfg.DKIMPrivateKeyFile)
+	cfg.DKIMSignHeaders = env("MTA_DKIM_SIGN_HEADERS", cfg.DKIMSignHeaders)
+	cfg.ARCFailurePolicy = envEnum("MTA_ARC_FAILURE_POLICY", cfg.ARCFailurePolicy, []string{"accept", "quarantine", "reject"})
+	cfg.SPFHeloPolicy = envEnum("MTA_SPF_HELO_POLICY", cfg.SPFHeloPolicy, []string{"off", "advisory", "enforce"})
+	cfg.SPFMailFromPolicy = envEnum("MTA_SPF_MAILFROM_POLICY", cfg.SPFMailFromPolicy, []string{"off", "advisory", "enforce"})
+	cfg.DomainMaxConcurrentDefault = envInt("MTA_DOMAIN_MAX_CONCURRENT_DEFAULT", cfg.DomainMaxConcurrentDefault)
+	cfg.DomainMaxConcurrentRules = env("MTA_DOMAIN_MAX_CONCURRENT_RULES", cfg.DomainMaxConcurrentRules)
+	cfg.DomainAdaptiveThrottle = envBool("MTA_DOMAIN_ADAPTIVE_THROTTLE", cfg.DomainAdaptiveThrottle)
+	cfg.DomainTempFailThreshold = envFloat64("MTA_DOMAIN_TEMPFAIL_THRESHOLD", cfg.DomainTempFailThreshold)
+	cfg.DomainPenaltyMax = envDuration("MTA_DOMAIN_PENALTY_MAX", cfg.DomainPenaltyMax)
+	cfg.DataRetentionSent = envDuration("MTA_DATA_RETENTION_SENT", cfg.DataRetentionSent)
+	cfg.DataRetentionDLQ = envDuration("MTA_DATA_RETENTION_DLQ", cfg.DataRetentionDLQ)
+	cfg.DataRetentionPoison = envDuration("MTA_DATA_RETENTION_POISON", cfg.DataRetentionPoison)
+	cfg.RetentionSweepInterval = envDuration("MTA_RETENTION_SWEEP_INTERVAL", cfg.RetentionSweepInterval)
+	cfg.ReputationStartDate = env("MTA_REPUTATION_START_DATE", cfg.ReputationStartDate)
+	cfg.ReputationWarmupRules = env("MTA_REPUTATION_WARMUP_RULES", cfg.ReputationWarmupRules)
+	cfg.ReputationBounceThreshold = envFloat64("MTA_REPUTATION_BOUNCE_THRESHOLD", cfg.ReputationBounceThreshold)
+	cfg.ReputationComplaintThresh = envFloat64("MTA_REPUTATION_COMPLAINT_THRESHOLD", cfg.ReputationComplaintThresh)
+	cfg.ReputationMinSamples = envInt("MTA_REPUTATION_MIN_SAMPLES", cfg.ReputationMinSamples)
+
+	return cfg, nil
+}
+
+func defaultConfig() Config {
 	return Config{
-		ListenAddr:         env("MTA_LISTEN_ADDR", ":2525"),
-		SubmissionAddr:     env("MTA_SUBMISSION_ADDR", ""),
-		SubmissionAuth:     envBool("MTA_SUBMISSION_AUTH_REQUIRED", true),
-		SubmissionUsers:    envOrFile("MTA_SUBMISSION_USERS", "MTA_SUBMISSION_USERS_FILE", ""),
-		SubmissionSenderID: envBool("MTA_SUBMISSION_ENFORCE_SENDER_IDENTITY", true),
-		LogLevel:           env("MTA_LOG_LEVEL", "info"),
-		ObservabilityAddr:  env("MTA_OBSERVABILITY_ADDR", ":9090"),
-		AdminAddr:          env("MTA_ADMIN_ADDR", ""),
-		AdminTokens:        envOrFile("MTA_ADMIN_TOKENS", "MTA_ADMIN_TOKENS_FILE", ""),
-		Hostname:           env("MTA_HOSTNAME", "orinoco.local"),
-		QueueDir:           env("MTA_QUEUE_DIR", "./var/queue"),
-		QueueBackend:       env("MTA_QUEUE_BACKEND", "local"),
-		KafkaBrokers:       envCSV("MTA_KAFKA_BROKERS", []string{"localhost:9092"}),
-		KafkaConsumerGroup: env("MTA_KAFKA_CONSUMER_GROUP", "kuroshio-mta"),
-		KafkaTopicInbound:  env("MTA_KAFKA_TOPIC_INBOUND", "mail.inbound"),
-		KafkaTopicRetry:    env("MTA_KAFKA_TOPIC_RETRY", "mail.retry"),
-		KafkaTopicDLQ:      env("MTA_KAFKA_TOPIC_DLQ", "mail.dlq"),
-		KafkaTopicSent:     env("MTA_KAFKA_TOPIC_SENT", "mail.sent"),
-		TLSCertFile:        env("MTA_TLS_CERT_FILE", ""),
-		TLSKeyFile:         env("MTA_TLS_KEY_FILE", ""),
-		IngressRateLimit:   envInt("MTA_INGRESS_RATE_LIMIT_PER_MINUTE", 100),
-		RateLimitRules:     env("MTA_RATE_LIMIT_RULES", ""),
-		DNSBLZones:         envCSV("MTA_DNSBL_ZONES", []string{}),
-		DNSBLCacheTTL:      envDuration("MTA_DNSBL_CACHE_TTL", 5*time.Minute),
-		DANEDNSSECTrustModel: envEnum(
-			"MTA_DANE_DNSSEC_TRUST_MODEL",
-			"ad_required",
-			[]string{"ad_required", "insecure_allow_unsigned"},
-		),
-		MTASTSCacheTTL:     envDuration("MTA_MTA_STS_CACHE_TTL", time.Hour),
-		MTASTSFetchTimeout: envDuration("MTA_MTA_STS_FETCH_TIMEOUT", 5*time.Second),
-		DeliveryMode:       env("MTA_DELIVERY_MODE", "mx"),
-		LocalSpoolDir:      env("MTA_LOCAL_SPOOL_DIR", "./var/spool"),
-		RelayHost:          env("MTA_RELAY_HOST", ""),
-		RelayPort:          envInt("MTA_RELAY_PORT", 25),
-		RelayRequireTLS:    envBool("MTA_RELAY_REQUIRE_TLS", false),
-		MaxMessageBytes:    envInt64("MTA_MAX_MESSAGE_BYTES", 10*1024*1024),
-		WorkerCount:        envInt("MTA_WORKER_COUNT", 4),
-		MaxAttempts:        envInt("MTA_MAX_ATTEMPTS", 12),
-		MaxRetryAge:        envDuration("MTA_MAX_RETRY_AGE", 5*24*time.Hour),
-		RetrySchedule: envDurationList(
-			"MTA_RETRY_SCHEDULE",
-			[]time.Duration{5 * time.Minute, 30 * time.Minute, 2 * time.Hour, 6 * time.Hour, 24 * time.Hour},
-		),
-		ScanInterval:               envDuration("MTA_SCAN_INTERVAL", 5*time.Second),
-		DialTimeout:                envDuration("MTA_DIAL_TIMEOUT", 8*time.Second),
-		SendTimeout:                envDuration("MTA_SEND_TIMEOUT", 20*time.Second),
-		DKIMSignDomain:             env("MTA_DKIM_SIGN_DOMAIN", ""),
-		DKIMSignSelector:           env("MTA_DKIM_SIGN_SELECTOR", ""),
-		DKIMPrivateKeyFile:         env("MTA_DKIM_PRIVATE_KEY_FILE", ""),
-		DKIMSignHeaders:            env("MTA_DKIM_SIGN_HEADERS", "from:to:subject:date:message-id"),
-		ARCFailurePolicy:           envEnum("MTA_ARC_FAILURE_POLICY", "accept", []string{"accept", "quarantine", "reject"}),
-		SPFHeloPolicy:              envEnum("MTA_SPF_HELO_POLICY", "advisory", []string{"off", "advisory", "enforce"}),
-		SPFMailFromPolicy:          envEnum("MTA_SPF_MAILFROM_POLICY", "advisory", []string{"off", "advisory", "enforce"}),
-		DomainMaxConcurrentDefault: envInt("MTA_DOMAIN_MAX_CONCURRENT_DEFAULT", 8),
-		DomainMaxConcurrentRules:   env("MTA_DOMAIN_MAX_CONCURRENT_RULES", ""),
-		DomainAdaptiveThrottle:     envBool("MTA_DOMAIN_ADAPTIVE_THROTTLE", true),
-		DomainTempFailThreshold:    envFloat64("MTA_DOMAIN_TEMPFAIL_THRESHOLD", 0.3),
-		DomainPenaltyMax:           envDuration("MTA_DOMAIN_PENALTY_MAX", 5*time.Second),
-		DataRetentionSent:          envDuration("MTA_DATA_RETENTION_SENT", 30*24*time.Hour),
-		DataRetentionDLQ:           envDuration("MTA_DATA_RETENTION_DLQ", 90*24*time.Hour),
-		DataRetentionPoison:        envDuration("MTA_DATA_RETENTION_POISON", 180*24*time.Hour),
-		RetentionSweepInterval:     envDuration("MTA_RETENTION_SWEEP_INTERVAL", time.Hour),
-		ReputationStartDate:        env("MTA_REPUTATION_START_DATE", ""),
-		ReputationWarmupRules:      env("MTA_REPUTATION_WARMUP_RULES", ""),
-		ReputationBounceThreshold:  envFloat64("MTA_REPUTATION_BOUNCE_THRESHOLD", 0.05),
-		ReputationComplaintThresh:  envFloat64("MTA_REPUTATION_COMPLAINT_THRESHOLD", 0.001),
-		ReputationMinSamples:       envInt("MTA_REPUTATION_MIN_SAMPLES", 100),
+		ListenAddr:                 ":2525",
+		SubmissionAddr:             "",
+		SubmissionAuth:             true,
+		SubmissionUsers:            "",
+		SubmissionSenderID:         true,
+		LogLevel:                   "info",
+		ObservabilityAddr:          ":9090",
+		AdminAddr:                  "",
+		AdminTokens:                "",
+		Hostname:                   "orinoco.local",
+		QueueDir:                   "./var/queue",
+		QueueBackend:               "local",
+		KafkaBrokers:               []string{"localhost:9092"},
+		KafkaConsumerGroup:         "kuroshio-mta",
+		KafkaTopicInbound:          "mail.inbound",
+		KafkaTopicRetry:            "mail.retry",
+		KafkaTopicDLQ:              "mail.dlq",
+		KafkaTopicSent:             "mail.sent",
+		TLSCertFile:                "",
+		TLSKeyFile:                 "",
+		IngressRateLimit:           100,
+		RateLimitRules:             "",
+		DNSBLZones:                 []string{},
+		DNSBLCacheTTL:              5 * time.Minute,
+		DANEDNSSECTrustModel:       "ad_required",
+		MTASTSCacheTTL:             time.Hour,
+		MTASTSFetchTimeout:         5 * time.Second,
+		DeliveryMode:               "mx",
+		LocalSpoolDir:              "./var/spool",
+		RelayHost:                  "",
+		RelayPort:                  25,
+		RelayRequireTLS:            false,
+		MaxMessageBytes:            10 * 1024 * 1024,
+		WorkerCount:                4,
+		MaxAttempts:                12,
+		MaxRetryAge:                5 * 24 * time.Hour,
+		RetrySchedule:              []time.Duration{5 * time.Minute, 30 * time.Minute, 2 * time.Hour, 6 * time.Hour, 24 * time.Hour},
+		ScanInterval:               5 * time.Second,
+		DialTimeout:                8 * time.Second,
+		SendTimeout:                20 * time.Second,
+		DKIMSignDomain:             "",
+		DKIMSignSelector:           "",
+		DKIMPrivateKeyFile:         "",
+		DKIMSignHeaders:            "from:to:subject:date:message-id",
+		ARCFailurePolicy:           "accept",
+		SPFHeloPolicy:              "advisory",
+		SPFMailFromPolicy:          "advisory",
+		DomainMaxConcurrentDefault: 8,
+		DomainMaxConcurrentRules:   "",
+		DomainAdaptiveThrottle:     true,
+		DomainTempFailThreshold:    0.3,
+		DomainPenaltyMax:           5 * time.Second,
+		DataRetentionSent:          30 * 24 * time.Hour,
+		DataRetentionDLQ:           90 * 24 * time.Hour,
+		DataRetentionPoison:        180 * 24 * time.Hour,
+		RetentionSweepInterval:     time.Hour,
+		ReputationStartDate:        "",
+		ReputationWarmupRules:      "0:100,7:1000,14:5000",
+		ReputationBounceThreshold:  0.05,
+		ReputationComplaintThresh:  0.001,
+		ReputationMinSamples:       100,
 	}
 }
 
-func envEnum(k, def string, allowed []string) string {
-	v := strings.TrimSpace(strings.ToLower(os.Getenv(k)))
-	if v == "" {
+func resolveConfigPath() (string, bool) {
+	if v := strings.TrimSpace(os.Getenv("MTA_CONFIG_FILE")); v != "" {
+		if _, err := os.Stat(v); err == nil {
+			return v, true
+		}
+		return "", true
+	}
+	for _, candidate := range []string{"config.yaml", "config.yml"} {
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, false
+		}
+	}
+	return "", false
+}
+
+func loadYAMLConfig(path string, base Config) (Config, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return Config{}, fmt.Errorf("read config file %q: %w", path, err)
+	}
+
+	var raw yamlConfig
+	if err := yaml.Unmarshal(b, &raw); err != nil {
+		return Config{}, fmt.Errorf("parse config file %q: %w", path, err)
+	}
+
+	cfg := base
+	if raw.ListenAddr != nil {
+		cfg.ListenAddr = *raw.ListenAddr
+	}
+	if raw.SubmissionAddr != nil {
+		cfg.SubmissionAddr = *raw.SubmissionAddr
+	}
+	if raw.SubmissionAuth != nil {
+		cfg.SubmissionAuth = *raw.SubmissionAuth
+	}
+	if raw.SubmissionUsers != nil {
+		cfg.SubmissionUsers = *raw.SubmissionUsers
+	}
+	if raw.SubmissionSenderID != nil {
+		cfg.SubmissionSenderID = *raw.SubmissionSenderID
+	}
+	if raw.LogLevel != nil {
+		cfg.LogLevel = *raw.LogLevel
+	}
+	if raw.ObservabilityAddr != nil {
+		cfg.ObservabilityAddr = *raw.ObservabilityAddr
+	}
+	if raw.AdminAddr != nil {
+		cfg.AdminAddr = *raw.AdminAddr
+	}
+	if raw.AdminTokens != nil {
+		cfg.AdminTokens = *raw.AdminTokens
+	}
+	if raw.Hostname != nil {
+		cfg.Hostname = *raw.Hostname
+	}
+	if raw.QueueDir != nil {
+		cfg.QueueDir = *raw.QueueDir
+	}
+	if raw.QueueBackend != nil {
+		cfg.QueueBackend = *raw.QueueBackend
+	}
+	if raw.KafkaBrokers != nil {
+		cfg.KafkaBrokers = append([]string(nil), raw.KafkaBrokers...)
+	}
+	if raw.KafkaConsumerGroup != nil {
+		cfg.KafkaConsumerGroup = *raw.KafkaConsumerGroup
+	}
+	if raw.KafkaTopicInbound != nil {
+		cfg.KafkaTopicInbound = *raw.KafkaTopicInbound
+	}
+	if raw.KafkaTopicRetry != nil {
+		cfg.KafkaTopicRetry = *raw.KafkaTopicRetry
+	}
+	if raw.KafkaTopicDLQ != nil {
+		cfg.KafkaTopicDLQ = *raw.KafkaTopicDLQ
+	}
+	if raw.KafkaTopicSent != nil {
+		cfg.KafkaTopicSent = *raw.KafkaTopicSent
+	}
+	if raw.TLSCertFile != nil {
+		cfg.TLSCertFile = *raw.TLSCertFile
+	}
+	if raw.TLSKeyFile != nil {
+		cfg.TLSKeyFile = *raw.TLSKeyFile
+	}
+	if raw.IngressRateLimit != nil {
+		cfg.IngressRateLimit = *raw.IngressRateLimit
+	}
+	if raw.RateLimitRules != nil {
+		cfg.RateLimitRules = *raw.RateLimitRules
+	}
+	if raw.DNSBLZones != nil {
+		cfg.DNSBLZones = append([]string(nil), raw.DNSBLZones...)
+	}
+	if raw.DNSBLCacheTTL != nil {
+		cfg.DNSBLCacheTTL, err = parseYAMLDuration(*raw.DNSBLCacheTTL, "dnsbl_cache_ttl")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if raw.DANEDNSSECTrustModel != nil {
+		cfg.DANEDNSSECTrustModel = normalizeEnum(*raw.DANEDNSSECTrustModel, cfg.DANEDNSSECTrustModel, []string{"ad_required", "insecure_allow_unsigned"})
+	}
+	if raw.MTASTSCacheTTL != nil {
+		cfg.MTASTSCacheTTL, err = parseYAMLDuration(*raw.MTASTSCacheTTL, "mta_sts_cache_ttl")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if raw.MTASTSFetchTimeout != nil {
+		cfg.MTASTSFetchTimeout, err = parseYAMLDuration(*raw.MTASTSFetchTimeout, "mta_sts_fetch_timeout")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if raw.DeliveryMode != nil {
+		cfg.DeliveryMode = *raw.DeliveryMode
+	}
+	if raw.LocalSpoolDir != nil {
+		cfg.LocalSpoolDir = *raw.LocalSpoolDir
+	}
+	if raw.RelayHost != nil {
+		cfg.RelayHost = *raw.RelayHost
+	}
+	if raw.RelayPort != nil {
+		cfg.RelayPort = *raw.RelayPort
+	}
+	if raw.RelayRequireTLS != nil {
+		cfg.RelayRequireTLS = *raw.RelayRequireTLS
+	}
+	if raw.MaxMessageBytes != nil {
+		cfg.MaxMessageBytes = *raw.MaxMessageBytes
+	}
+	if raw.WorkerCount != nil {
+		cfg.WorkerCount = *raw.WorkerCount
+	}
+	if raw.MaxAttempts != nil {
+		cfg.MaxAttempts = *raw.MaxAttempts
+	}
+	if raw.MaxRetryAge != nil {
+		cfg.MaxRetryAge, err = parseYAMLDuration(*raw.MaxRetryAge, "max_retry_age")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if raw.RetrySchedule != nil {
+		cfg.RetrySchedule, err = parseYAMLDurations(raw.RetrySchedule, "retry_schedule")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if raw.ScanInterval != nil {
+		cfg.ScanInterval, err = parseYAMLDuration(*raw.ScanInterval, "scan_interval")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if raw.DialTimeout != nil {
+		cfg.DialTimeout, err = parseYAMLDuration(*raw.DialTimeout, "dial_timeout")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if raw.SendTimeout != nil {
+		cfg.SendTimeout, err = parseYAMLDuration(*raw.SendTimeout, "send_timeout")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if raw.DKIMSignDomain != nil {
+		cfg.DKIMSignDomain = *raw.DKIMSignDomain
+	}
+	if raw.DKIMSignSelector != nil {
+		cfg.DKIMSignSelector = *raw.DKIMSignSelector
+	}
+	if raw.DKIMPrivateKeyFile != nil {
+		cfg.DKIMPrivateKeyFile = *raw.DKIMPrivateKeyFile
+	}
+	if raw.DKIMSignHeaders != nil {
+		cfg.DKIMSignHeaders = *raw.DKIMSignHeaders
+	}
+	if raw.ARCFailurePolicy != nil {
+		cfg.ARCFailurePolicy = normalizeEnum(*raw.ARCFailurePolicy, cfg.ARCFailurePolicy, []string{"accept", "quarantine", "reject"})
+	}
+	if raw.SPFHeloPolicy != nil {
+		cfg.SPFHeloPolicy = normalizeEnum(*raw.SPFHeloPolicy, cfg.SPFHeloPolicy, []string{"off", "advisory", "enforce"})
+	}
+	if raw.SPFMailFromPolicy != nil {
+		cfg.SPFMailFromPolicy = normalizeEnum(*raw.SPFMailFromPolicy, cfg.SPFMailFromPolicy, []string{"off", "advisory", "enforce"})
+	}
+	if raw.DomainMaxConcurrentDefault != nil {
+		cfg.DomainMaxConcurrentDefault = *raw.DomainMaxConcurrentDefault
+	}
+	if raw.DomainMaxConcurrentRules != nil {
+		cfg.DomainMaxConcurrentRules = *raw.DomainMaxConcurrentRules
+	}
+	if raw.DomainAdaptiveThrottle != nil {
+		cfg.DomainAdaptiveThrottle = *raw.DomainAdaptiveThrottle
+	}
+	if raw.DomainTempFailThreshold != nil {
+		cfg.DomainTempFailThreshold = *raw.DomainTempFailThreshold
+	}
+	if raw.DomainPenaltyMax != nil {
+		cfg.DomainPenaltyMax, err = parseYAMLDuration(*raw.DomainPenaltyMax, "domain_penalty_max")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if raw.DataRetentionSent != nil {
+		cfg.DataRetentionSent, err = parseYAMLDuration(*raw.DataRetentionSent, "data_retention_sent")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if raw.DataRetentionDLQ != nil {
+		cfg.DataRetentionDLQ, err = parseYAMLDuration(*raw.DataRetentionDLQ, "data_retention_dlq")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if raw.DataRetentionPoison != nil {
+		cfg.DataRetentionPoison, err = parseYAMLDuration(*raw.DataRetentionPoison, "data_retention_poison")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if raw.RetentionSweepInterval != nil {
+		cfg.RetentionSweepInterval, err = parseYAMLDuration(*raw.RetentionSweepInterval, "retention_sweep_interval")
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	if raw.ReputationStartDate != nil {
+		cfg.ReputationStartDate = *raw.ReputationStartDate
+	}
+	if raw.ReputationWarmupRules != nil {
+		cfg.ReputationWarmupRules = *raw.ReputationWarmupRules
+	}
+	if raw.ReputationBounceThreshold != nil {
+		cfg.ReputationBounceThreshold = *raw.ReputationBounceThreshold
+	}
+	if raw.ReputationComplaintThresh != nil {
+		cfg.ReputationComplaintThresh = *raw.ReputationComplaintThresh
+	}
+	if raw.ReputationMinSamples != nil {
+		cfg.ReputationMinSamples = *raw.ReputationMinSamples
+	}
+
+	return cfg, nil
+}
+
+func parseYAMLDuration(v, field string) (time.Duration, error) {
+	d, err := time.ParseDuration(strings.TrimSpace(v))
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s duration %q: %w", field, v, err)
+	}
+	return d, nil
+}
+
+func parseYAMLDurations(values []string, field string) ([]time.Duration, error) {
+	out := make([]time.Duration, 0, len(values))
+	for _, value := range values {
+		d, err := parseYAMLDuration(value, field)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, d)
+	}
+	return out, nil
+}
+
+func normalizeEnum(v, def string, allowed []string) string {
+	value := strings.TrimSpace(strings.ToLower(v))
+	if value == "" {
 		return def
 	}
-	for _, a := range allowed {
-		if v == strings.ToLower(strings.TrimSpace(a)) {
-			return v
+	for _, candidate := range allowed {
+		if value == strings.ToLower(strings.TrimSpace(candidate)) {
+			return value
 		}
 	}
 	return def
+}
+
+func envEnum(k, def string, allowed []string) string {
+	return normalizeEnum(os.Getenv(k), def, allowed)
 }
 
 func env(k, def string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,9 +2,19 @@ package config
 
 import (
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
+
+func mustLoadForTest(t *testing.T) Config {
+	t.Helper()
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	return cfg
+}
 
 func TestEnvDurationList(t *testing.T) {
 	def := []time.Duration{time.Minute, 2 * time.Minute}
@@ -62,7 +72,7 @@ func TestEnvBool(t *testing.T) {
 
 func TestLoadRateLimitRules(t *testing.T) {
 	t.Setenv("MTA_RATE_LIMIT_RULES", "connect:ip:10:1m")
-	cfg := Load()
+	cfg := mustLoadForTest(t)
 	if cfg.RateLimitRules != "connect:ip:10:1m" {
 		t.Fatalf("unexpected rules: %q", cfg.RateLimitRules)
 	}
@@ -74,7 +84,7 @@ func TestLoadSubmissionConfig(t *testing.T) {
 	t.Setenv("MTA_SUBMISSION_USERS", "alice@example.com:s3cr3t")
 	t.Setenv("MTA_SUBMISSION_ENFORCE_SENDER_IDENTITY", "true")
 
-	cfg := Load()
+	cfg := mustLoadForTest(t)
 	if cfg.SubmissionAddr != ":587" {
 		t.Fatalf("submission addr=%q", cfg.SubmissionAddr)
 	}
@@ -97,7 +107,7 @@ func TestLoadSubmissionUsersFromFile(t *testing.T) {
 	t.Setenv("MTA_SUBMISSION_USERS", "envuser@example.com:envpass")
 	t.Setenv("MTA_SUBMISSION_USERS_FILE", fp)
 
-	cfg := Load()
+	cfg := mustLoadForTest(t)
 	if cfg.SubmissionUsers != "fileuser@example.com:filepass" {
 		t.Fatalf("submission users should prefer file value, got=%q", cfg.SubmissionUsers)
 	}
@@ -105,7 +115,7 @@ func TestLoadSubmissionUsersFromFile(t *testing.T) {
 
 func TestLoadLogLevel(t *testing.T) {
 	t.Setenv("MTA_LOG_LEVEL", "debug")
-	cfg := Load()
+	cfg := mustLoadForTest(t)
 	if cfg.LogLevel != "debug" {
 		t.Fatalf("log level=%q", cfg.LogLevel)
 	}
@@ -116,7 +126,7 @@ func TestLoadDKIMSigningConfig(t *testing.T) {
 	t.Setenv("MTA_DKIM_SIGN_SELECTOR", "s1")
 	t.Setenv("MTA_DKIM_PRIVATE_KEY_FILE", "/tmp/dkim.pem")
 	t.Setenv("MTA_DKIM_SIGN_HEADERS", "from:to:subject")
-	cfg := Load()
+	cfg := mustLoadForTest(t)
 	if cfg.DKIMSignDomain != "example.com" || cfg.DKIMSignSelector != "s1" {
 		t.Fatalf("unexpected dkim config: domain=%q selector=%q", cfg.DKIMSignDomain, cfg.DKIMSignSelector)
 	}
@@ -131,7 +141,7 @@ func TestLoadDKIMSigningConfig(t *testing.T) {
 func TestLoadSPFPolicyConfig(t *testing.T) {
 	t.Setenv("MTA_SPF_HELO_POLICY", "off")
 	t.Setenv("MTA_SPF_MAILFROM_POLICY", "advisory")
-	cfg := Load()
+	cfg := mustLoadForTest(t)
 	if cfg.SPFHeloPolicy != "off" {
 		t.Fatalf("helo policy=%q", cfg.SPFHeloPolicy)
 	}
@@ -141,7 +151,7 @@ func TestLoadSPFPolicyConfig(t *testing.T) {
 
 	t.Setenv("MTA_SPF_HELO_POLICY", "invalid")
 	t.Setenv("MTA_SPF_MAILFROM_POLICY", "invalid")
-	cfg = Load()
+	cfg = mustLoadForTest(t)
 	if cfg.SPFHeloPolicy != "advisory" {
 		t.Fatalf("helo invalid should fallback, got=%q", cfg.SPFHeloPolicy)
 	}
@@ -152,13 +162,13 @@ func TestLoadSPFPolicyConfig(t *testing.T) {
 
 func TestLoadARCFailurePolicyConfig(t *testing.T) {
 	t.Setenv("MTA_ARC_FAILURE_POLICY", "reject")
-	cfg := Load()
+	cfg := mustLoadForTest(t)
 	if cfg.ARCFailurePolicy != "reject" {
 		t.Fatalf("arc policy=%q", cfg.ARCFailurePolicy)
 	}
 
 	t.Setenv("MTA_ARC_FAILURE_POLICY", "invalid")
-	cfg = Load()
+	cfg = mustLoadForTest(t)
 	if cfg.ARCFailurePolicy != "accept" {
 		t.Fatalf("arc invalid should fallback, got=%q", cfg.ARCFailurePolicy)
 	}
@@ -170,7 +180,7 @@ func TestLoadDomainThrottleConfig(t *testing.T) {
 	t.Setenv("MTA_DOMAIN_ADAPTIVE_THROTTLE", "true")
 	t.Setenv("MTA_DOMAIN_TEMPFAIL_THRESHOLD", "0.5")
 	t.Setenv("MTA_DOMAIN_PENALTY_MAX", "3s")
-	cfg := Load()
+	cfg := mustLoadForTest(t)
 	if cfg.DomainMaxConcurrentDefault != 4 {
 		t.Fatalf("default concurrency=%d", cfg.DomainMaxConcurrentDefault)
 	}
@@ -193,7 +203,7 @@ func TestLoadRetentionConfig(t *testing.T) {
 	t.Setenv("MTA_DATA_RETENTION_DLQ", "2160h")
 	t.Setenv("MTA_DATA_RETENTION_POISON", "4320h")
 	t.Setenv("MTA_RETENTION_SWEEP_INTERVAL", "30m")
-	cfg := Load()
+	cfg := mustLoadForTest(t)
 	if cfg.DataRetentionSent != 720*time.Hour {
 		t.Fatalf("retention sent=%s", cfg.DataRetentionSent)
 	}
@@ -210,14 +220,138 @@ func TestLoadRetentionConfig(t *testing.T) {
 
 func TestLoadDANEDNSSECTrustModel(t *testing.T) {
 	t.Setenv("MTA_DANE_DNSSEC_TRUST_MODEL", "insecure_allow_unsigned")
-	cfg := Load()
+	cfg := mustLoadForTest(t)
 	if cfg.DANEDNSSECTrustModel != "insecure_allow_unsigned" {
 		t.Fatalf("trust model=%q", cfg.DANEDNSSECTrustModel)
 	}
 
 	t.Setenv("MTA_DANE_DNSSEC_TRUST_MODEL", "invalid")
-	cfg = Load()
+	cfg = mustLoadForTest(t)
 	if cfg.DANEDNSSECTrustModel != "ad_required" {
 		t.Fatalf("invalid trust model should fallback, got=%q", cfg.DANEDNSSECTrustModel)
+	}
+}
+
+func TestLoadYAMLConfig(t *testing.T) {
+	fp := t.TempDir() + "/config.yaml"
+	content := strings.TrimSpace(`
+listen_addr: ":2526"
+submission_addr: ":587"
+submission_auth_required: false
+submission_users: "yaml-user@example.com:yaml-pass"
+log_level: debug
+hostname: yaml.local
+queue_backend: kafka
+kafka_brokers:
+  - kafka-1:9092
+  - kafka-2:9092
+dnsbl_zones:
+  - zen.example.org
+  - bl.example.net
+dnsbl_cache_ttl: 10m
+retry_schedule:
+  - 1m
+  - 15m
+max_retry_age: 48h
+worker_count: 8
+domain_tempfail_threshold: 0.4
+`)
+	if err := os.WriteFile(fp, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config file: %v", err)
+	}
+	t.Setenv("MTA_CONFIG_FILE", fp)
+
+	cfg := mustLoadForTest(t)
+	if cfg.ListenAddr != ":2526" {
+		t.Fatalf("listen addr=%q", cfg.ListenAddr)
+	}
+	if cfg.SubmissionAddr != ":587" {
+		t.Fatalf("submission addr=%q", cfg.SubmissionAddr)
+	}
+	if cfg.SubmissionAuth {
+		t.Fatal("submission auth should be false from yaml")
+	}
+	if cfg.SubmissionUsers != "yaml-user@example.com:yaml-pass" {
+		t.Fatalf("submission users=%q", cfg.SubmissionUsers)
+	}
+	if cfg.LogLevel != "debug" {
+		t.Fatalf("log level=%q", cfg.LogLevel)
+	}
+	if cfg.Hostname != "yaml.local" {
+		t.Fatalf("hostname=%q", cfg.Hostname)
+	}
+	if cfg.QueueBackend != "kafka" {
+		t.Fatalf("queue backend=%q", cfg.QueueBackend)
+	}
+	if len(cfg.KafkaBrokers) != 2 || cfg.KafkaBrokers[0] != "kafka-1:9092" || cfg.KafkaBrokers[1] != "kafka-2:9092" {
+		t.Fatalf("kafka brokers=%v", cfg.KafkaBrokers)
+	}
+	if len(cfg.DNSBLZones) != 2 || cfg.DNSBLZones[0] != "zen.example.org" || cfg.DNSBLZones[1] != "bl.example.net" {
+		t.Fatalf("dnsbl zones=%v", cfg.DNSBLZones)
+	}
+	if cfg.DNSBLCacheTTL != 10*time.Minute {
+		t.Fatalf("dnsbl cache ttl=%s", cfg.DNSBLCacheTTL)
+	}
+	if len(cfg.RetrySchedule) != 2 || cfg.RetrySchedule[0] != time.Minute || cfg.RetrySchedule[1] != 15*time.Minute {
+		t.Fatalf("retry schedule=%v", cfg.RetrySchedule)
+	}
+	if cfg.MaxRetryAge != 48*time.Hour {
+		t.Fatalf("max retry age=%s", cfg.MaxRetryAge)
+	}
+	if cfg.WorkerCount != 8 {
+		t.Fatalf("worker count=%d", cfg.WorkerCount)
+	}
+	if cfg.DomainTempFailThreshold != 0.4 {
+		t.Fatalf("threshold=%v", cfg.DomainTempFailThreshold)
+	}
+}
+
+func TestLoadYAMLConfigEnvOverrides(t *testing.T) {
+	fp := t.TempDir() + "/config.yaml"
+	content := strings.TrimSpace(`
+listen_addr: ":2526"
+log_level: info
+queue_backend: local
+retry_schedule:
+  - 1m
+  - 15m
+`)
+	if err := os.WriteFile(fp, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config file: %v", err)
+	}
+	t.Setenv("MTA_CONFIG_FILE", fp)
+	t.Setenv("MTA_LISTEN_ADDR", ":2600")
+	t.Setenv("MTA_LOG_LEVEL", "warn")
+	t.Setenv("MTA_QUEUE_BACKEND", "kafka")
+	t.Setenv("MTA_RETRY_SCHEDULE", "5m,30m")
+
+	cfg := mustLoadForTest(t)
+	if cfg.ListenAddr != ":2600" {
+		t.Fatalf("listen addr=%q", cfg.ListenAddr)
+	}
+	if cfg.LogLevel != "warn" {
+		t.Fatalf("log level=%q", cfg.LogLevel)
+	}
+	if cfg.QueueBackend != "kafka" {
+		t.Fatalf("queue backend=%q", cfg.QueueBackend)
+	}
+	if len(cfg.RetrySchedule) != 2 || cfg.RetrySchedule[0] != 5*time.Minute || cfg.RetrySchedule[1] != 30*time.Minute {
+		t.Fatalf("retry schedule=%v", cfg.RetrySchedule)
+	}
+}
+
+func TestLoadInvalidYAMLDuration(t *testing.T) {
+	fp := t.TempDir() + "/config.yaml"
+	if err := os.WriteFile(fp, []byte("dnsbl_cache_ttl: definitely-not-a-duration\n"), 0o644); err != nil {
+		t.Fatalf("write config file: %v", err)
+	}
+	t.Setenv("MTA_CONFIG_FILE", fp)
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected yaml duration parse error")
+	}
+	if !strings.Contains(err.Error(), "dnsbl_cache_ttl") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- add YAML-based config loading via `gopkg.in/yaml.v3`
- keep environment variables as the final override layer for backward compatibility
- add config loading tests and a sample `config.example.yaml`

## Why
The service was effectively configured only through environment variables, which made larger local or deployment config sets harder to manage. This change lets us move most stable settings into YAML while keeping env vars for overrides and secret-file flows.

## Impact
- `MTA_CONFIG_FILE` can point to a YAML config file
- `config.yaml` / `config.yml` in the working directory are auto-discovered
- `MTA_SUBMISSION_USERS_FILE` and `MTA_ADMIN_TOKENS_FILE` remain available for secrets
- env vars still win when both YAML and env specify the same setting

## Validation
- `go test ./internal/config ./cmd/kuroshio`
- `go test ./...`
