### PR TITLE
feat: allow config file path via CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@
 ## 実行方法
 
 ```bash
-go run ./cmd/kuroshio
+go run ./cmd/kuroshio -config ./config.yaml
 ```
 
-デフォルトでは `:2525` でSMTP待受します。
+`-config` を省略した場合は、`MTA_CONFIG_FILE` またはカレントディレクトリの `config.yaml` / `config.yml` を順に参照します。デフォルトでは `:2525` でSMTP待受します。
 
 ## 設定
 

--- a/cmd/kuroshio/main.go
+++ b/cmd/kuroshio/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"flag"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -27,7 +28,10 @@ import (
 )
 
 func main() {
-	cfg, err := config.Load()
+	configPath := flag.String("config", "", "path to YAML config file")
+	flag.Parse()
+
+	cfg, err := config.LoadWithPath(*configPath)
 	if err != nil {
 		fatal("config load failed", "error", err)
 	}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,13 +5,13 @@
 ## 基本方針
 
 1. デフォルト値
-2. `MTA_CONFIG_FILE` で指定した YAML、またはカレントディレクトリの `config.yaml` / `config.yml`
+2. 起動引数 `-config` で指定した YAML、未指定なら `MTA_CONFIG_FILE`、さらに未指定ならカレントディレクトリの `config.yaml` / `config.yml`
 3. 環境変数
 
-同じ設定を複数の方法で指定した場合は、最後に評価される環境変数が優先されます。`MTA_CONFIG_FILE` を指定した場合は、そのパスにファイルが存在しないと起動時にエラーになります。
+同じ設定を複数の方法で指定した場合は、最後に評価される環境変数が優先されます。`-config` または `MTA_CONFIG_FILE` を指定した場合は、そのパスにファイルが存在しないと起動時にエラーになります。
 
 ```bash
-MTA_CONFIG_FILE=./config.yaml go run ./cmd/kuroshio
+go run ./cmd/kuroshio -config ./config.yaml
 ```
 
 サンプルは [config.example.yaml](/home/tamago/ghq/github.com/tamago/kuroshio-mta/config.example.yaml) にあります。
@@ -26,11 +26,15 @@ MTA_CONFIG_FILE=./config.yaml go run ./cmd/kuroshio
 
 | YAML property | 環境変数 | default | 説明 |
 | --- | --- | --- | --- |
-| `-` | `MTA_CONFIG_FILE` | unset | 読み込む設定ファイルを明示します |
+| `-` | `MTA_CONFIG_FILE` | unset | 互換用の設定ファイル指定です。通常は起動引数 `-config` を優先して使います |
 | `submission_users` | `MTA_SUBMISSION_USERS` | unset | Submission 認証ユーザーを `user@example.com:password,...` 形式で指定します |
 | `-` | `MTA_SUBMISSION_USERS_FILE` | unset | `MTA_SUBMISSION_USERS` の代わりにファイルから Submission 認証情報を読み込みます |
 | `admin_tokens` | `MTA_ADMIN_TOKENS` | unset | Admin API の Bearer token と role を `token:role,...` 形式で指定します |
 | `-` | `MTA_ADMIN_TOKENS_FILE` | unset | `MTA_ADMIN_TOKENS` の代わりにファイルから管理トークンを読み込みます |
+
+補足:
+- 起動引数 `-config <path>` が、設定ファイルを明示する第一選択です
+- `-config` と `MTA_CONFIG_FILE` を同時に使った場合は `-config` が優先されます
 
 ## SMTP 受信と Submission
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -151,9 +151,13 @@ type yamlConfig struct {
 }
 
 func Load() (Config, error) {
+	return LoadWithPath("")
+}
+
+func LoadWithPath(explicitPath string) (Config, error) {
 	cfg := defaultConfig()
 
-	configPath, explicit := resolveConfigPath()
+	configPath, requestedPath, explicit := resolveConfigPath(explicitPath)
 	if configPath != "" {
 		loaded, err := loadYAMLConfig(configPath, cfg)
 		if err != nil {
@@ -161,7 +165,7 @@ func Load() (Config, error) {
 		}
 		cfg = loaded
 	} else if explicit {
-		return Config{}, fmt.Errorf("config file %q not found", os.Getenv("MTA_CONFIG_FILE"))
+		return Config{}, fmt.Errorf("config file %q not found", requestedPath)
 	}
 
 	cfg.ListenAddr = env("MTA_LISTEN_ADDR", cfg.ListenAddr)
@@ -307,19 +311,25 @@ func defaultConfig() Config {
 	}
 }
 
-func resolveConfigPath() (string, bool) {
+func resolveConfigPath(explicitPath string) (string, string, bool) {
+	if v := strings.TrimSpace(explicitPath); v != "" {
+		if _, err := os.Stat(v); err == nil {
+			return v, v, true
+		}
+		return "", v, true
+	}
 	if v := strings.TrimSpace(os.Getenv("MTA_CONFIG_FILE")); v != "" {
 		if _, err := os.Stat(v); err == nil {
-			return v, true
+			return v, v, true
 		}
-		return "", true
+		return "", v, true
 	}
 	for _, candidate := range []string{"config.yaml", "config.yml"} {
 		if _, err := os.Stat(candidate); err == nil {
-			return candidate, false
+			return candidate, "", false
 		}
 	}
-	return "", false
+	return "", "", false
 }
 
 func loadYAMLConfig(path string, base Config) (Config, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -16,6 +16,15 @@ func mustLoadForTest(t *testing.T) Config {
 	return cfg
 }
 
+func mustLoadWithPathForTest(t *testing.T, path string) Config {
+	t.Helper()
+	cfg, err := LoadWithPath(path)
+	if err != nil {
+		t.Fatalf("LoadWithPath() error: %v", err)
+	}
+	return cfg
+}
+
 func TestEnvDurationList(t *testing.T) {
 	def := []time.Duration{time.Minute, 2 * time.Minute}
 
@@ -281,9 +290,7 @@ domain_tempfail_threshold: 0.4
 	if err := os.WriteFile(fp, []byte(content), 0o644); err != nil {
 		t.Fatalf("write config file: %v", err)
 	}
-	t.Setenv("MTA_CONFIG_FILE", fp)
-
-	cfg := mustLoadForTest(t)
+	cfg := mustLoadWithPathForTest(t, fp)
 	if cfg.ListenAddr != ":2526" {
 		t.Fatalf("listen addr=%q", cfg.ListenAddr)
 	}
@@ -340,6 +347,24 @@ domain_tempfail_threshold: 0.4
 	}
 }
 
+func TestLoadWithPathOverridesEnvConfigFile(t *testing.T) {
+	explicitPath := t.TempDir() + "/explicit.yaml"
+	if err := os.WriteFile(explicitPath, []byte("listen_addr: \":2527\"\n"), 0o644); err != nil {
+		t.Fatalf("write explicit config file: %v", err)
+	}
+
+	envPath := t.TempDir() + "/env.yaml"
+	if err := os.WriteFile(envPath, []byte("listen_addr: \":2626\"\n"), 0o644); err != nil {
+		t.Fatalf("write env config file: %v", err)
+	}
+	t.Setenv("MTA_CONFIG_FILE", envPath)
+
+	cfg := mustLoadWithPathForTest(t, explicitPath)
+	if cfg.ListenAddr != ":2527" {
+		t.Fatalf("listen addr=%q", cfg.ListenAddr)
+	}
+}
+
 func TestLoadYAMLConfigEnvOverrides(t *testing.T) {
 	fp := t.TempDir() + "/config.yaml"
 	content := strings.TrimSpace(`
@@ -386,6 +411,18 @@ func TestLoadInvalidYAMLDuration(t *testing.T) {
 		t.Fatal("expected yaml duration parse error")
 	}
 	if !strings.Contains(err.Error(), "dnsbl_cache_ttl") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadWithPathMissingFile(t *testing.T) {
+	missing := t.TempDir() + "/missing.yaml"
+
+	_, err := LoadWithPath(missing)
+	if err == nil {
+		t.Fatal("expected missing file error")
+	}
+	if !strings.Contains(err.Error(), missing) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- add -config support to cmd/kuroshio so the YAML config path can be passed as a startup argument
- keep MTA_CONFIG_FILE as a compatibility fallback while making the CLI flag take precedence
- update config tests and configuration docs to reflect the new loading order

## Verification
- go test ./internal/config ./cmd/kuroshio
- git diff --check