### PR TITLE
fix: handle pages enablement in deploy workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,9 +45,6 @@ jobs:
           node-version: "22"
           cache: npm
 
-      - name: Configure Pages
-        uses: actions/configure-pages@v5
-
       - name: Install Dependencies
         run: npm ci
 
@@ -69,6 +66,12 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+        with:
+          token: ${{ secrets.PAGES_ADMIN_TOKEN != '' && secrets.PAGES_ADMIN_TOKEN || github.token }}
+          enablement: ${{ secrets.PAGES_ADMIN_TOKEN != '' }}
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ go run ./cmd/kuroshio -config ./config.yaml
 - docs 関連の変更では GitHub Actions が自動で build します
 - `main` にマージされた docs 関連変更は GitHub Pages へ自動 deploy します
 - 初回だけ GitHub の `Settings > Pages` で publish source を `GitHub Actions` に設定してください
+- もしくは `PAGES_ADMIN_TOKEN` secret を設定すると、workflow が Pages 有効化を試みます
 - deploy workflow は [docs.yml](/home/tamago/ghq/github.com/tamago/kuroshio-mta/.github/workflows/docs.yml) です
 
 ## 補足


### PR DESCRIPTION
## Summary
- move Pages configuration to the deploy job so pull request builds do not require Pages to be enabled
- support optional automatic Pages enablement via the PAGES_ADMIN_TOKEN secret
- document the Pages setup options in the README

## Verification
- git diff --check
- no local runtime tests run (workflow and docs change only)