### PR TITLE
docs: add getting started guide

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -12,6 +12,7 @@ export default defineConfig({
   themeConfig: {
     logo: "/logo.svg",
     nav: [
+      { text: "Getting Started", link: "/getting-started" },
       { text: "Guide", link: "/configuration" },
       { text: "Architecture", link: "/architecture/normalization_policy" },
       { text: "Runbooks", link: "/runbooks/admin_api" },
@@ -25,6 +26,7 @@ export default defineConfig({
         text: "Getting Started",
         items: [
           { text: "Home", link: "/" },
+          { text: "Getting Started", link: "/getting-started" },
           { text: "Configuration", link: "/configuration" },
           { text: "Rate Limit", link: "/rate_limit" },
           { text: "Kafka Queue Mode", link: "/kafka_queue_mode" }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,65 @@
+# Getting Started
+
+`kuroshio-mta` をローカルで立ち上げて、次にどのドキュメントを読めばよいかをまとめた入口ページです。
+
+## 1. 前提
+
+- Go `1.25.x`
+- リポジトリを clone 済み
+- ローカルで `:2525` や `:9090` を使えること
+
+VitePress の docs サイトをローカル確認したい場合だけ、追加で Node.js が必要です。
+
+## 2. サンプル設定を用意する
+
+まずは [config.example.yaml](https://github.com/tamago0224/kuroshio-mta/blob/main/config.example.yaml) を元に
+`config.yaml` を作るのがいちばん簡単です。
+
+最低限見ることが多い項目:
+
+- `listen_addr`
+- `hostname`
+- `queue_dir`
+- `queue_backend`
+- `delivery_mode`
+
+設定項目の全体像は [Configuration](/configuration) にまとまっています。
+
+## 3. MTA を起動する
+
+```bash
+go run ./cmd/kuroshio -config ./config.yaml
+```
+
+`-config` を省略した場合は、`MTA_CONFIG_FILE` またはカレントディレクトリの
+`config.yaml` / `config.yml` が使われます。
+
+## 4. 起動後に見る場所
+
+- SMTP listener: `:2525`
+- Observability: `:9090`
+- ローカルキュー: `./var/queue`
+
+Admin API を有効化する場合は [Admin API](/runbooks/admin_api)、
+SLO を見たい場合は [SLO Delivery](/runbooks/slo_delivery) を参照してください。
+
+## 5. よく読む関連ドキュメント
+
+- 初期設定: [Configuration](/configuration)
+- 受信制御: [Rate Limit](/rate_limit)
+- Kafka バックエンド: [Kafka Queue Mode](/kafka_queue_mode)
+- 設計メモ: [Normalization Policy](/architecture/normalization_policy)
+- HA 構成: [HA Reference](/architecture/ha_reference)
+
+## 6. docs サイトをローカル確認する
+
+```bash
+npm install
+npm run docs:dev
+```
+
+静的 build だけ確認したい場合は次を使います。
+
+```bash
+npm run docs:build
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,16 +7,18 @@ hero:
   tagline: 設定、RFC 対応、運用 runbook、アーキテクチャ方針をブラウザでたどれるように整理したドキュメントサイトです。
   actions:
     - theme: brand
+      text: Getting Started を見る
+      link: /getting-started
+    - theme: alt
       text: 設定ガイドを見る
       link: /configuration
-    - theme: alt
-      text: 正規化方針を見る
-      link: /architecture/normalization_policy
     - theme: alt
       text: GitHub Repository
       link: https://github.com/tamago0224/kuroshio-mta
 
 features:
+  - title: Getting Started
+    details: サンプル設定の作成から `go run ./cmd/kuroshio -config ./config.yaml` での起動までを最短手順で追えます。
   - title: 設定と運用
     details: YAML ベースの設定、Rate Limit、Kafka Queue モード、Admin API や SLO runbook までまとめて参照できます。
   - title: RFC 対応状況
@@ -28,6 +30,7 @@ features:
 
 ## よく使うページ
 
+- [Getting Started](/getting-started)
 - [設定ガイド](/configuration)
 - [Rate Limit](/rate_limit)
 - [Kafka Queue モード](/kafka_queue_mode)


### PR DESCRIPTION
## Summary
- add a dedicated Getting Started guide for first-time readers
- update the VitePress home page and sidebar to lead with Getting Started
- reorganize the docs entry flow so setup and next steps are easier to find

## Verification
- npm run docs:build
- git diff --check