### PR TITLE
fix: bump Go to 1.25.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.8'
+          go-version: '1.25.9'
           cache: true
 
       - name: Go Version
@@ -52,7 +52,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.8'
+          go-version: '1.25.9'
           cache: true
 
       - name: Download Dependencies

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.8'
+          go-version: '1.25.9'
           cache: true
 
       - name: Install govulncheck
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.8'
+          go-version: '1.25.9'
           cache: true
 
       - name: Generate SBOM

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/tamago0224/kuroshio-mta
 
 go 1.25
 
-toolchain go1.25.8
+toolchain go1.25.9
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect


### PR DESCRIPTION
## Summary
- bump the repository toolchain from Go 1.25.8 to 1.25.9
- update CI and Security workflows to use Go 1.25.9 consistently
- address the govulncheck failure caused by standard library vulnerabilities fixed in 1.25.9

## Verification
- git diff --check
- go test ./...