### PR TITLE
docs: add feature tutorials

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -13,6 +13,7 @@ export default defineConfig({
     logo: "/logo.svg",
     nav: [
       { text: "Getting Started", link: "/getting-started" },
+      { text: "Tutorials", link: "/tutorials/basic-mail-flow" },
       { text: "Guide", link: "/configuration" },
       { text: "Architecture", link: "/architecture/normalization_policy" },
       { text: "Runbooks", link: "/runbooks/admin_api" },
@@ -27,6 +28,11 @@ export default defineConfig({
         items: [
           { text: "Home", link: "/" },
           { text: "Getting Started", link: "/getting-started" },
+          { text: "Basic Mail Flow", link: "/tutorials/basic-mail-flow" },
+          { text: "Mail Authentication", link: "/tutorials/mail-auth" },
+          { text: "TLS Delivery Policies", link: "/tutorials/tls-policy" },
+          { text: "Rate Limit Tutorial", link: "/tutorials/rate-limit" },
+          { text: "Admin API Tutorial", link: "/tutorials/admin-operations" },
           { text: "Configuration", link: "/configuration" },
           { text: "Rate Limit", link: "/rate_limit" },
           { text: "Kafka Queue Mode", link: "/kafka_queue_mode" }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,7 +43,15 @@ go run ./cmd/kuroshio -config ./config.yaml
 Admin API を有効化する場合は [Admin API](/runbooks/admin_api)、
 SLO を見たい場合は [SLO Delivery](/runbooks/slo_delivery) を参照してください。
 
-## 5. よく読む関連ドキュメント
+## 5. 次に試すチュートリアル
+
+- 最初の 1 通を受ける: [最小メールフローを試す](/tutorials/basic-mail-flow)
+- 認証評価を見る: [メール認証を試す](/tutorials/mail-auth)
+- STARTTLS / MTA-STS / DANE を追う: [TLS 配送ポリシーを試す](/tutorials/tls-policy)
+- 受信制御を試す: [Rate Limit を試す](/tutorials/rate-limit)
+- queue 操作を試す: [Admin API を試す](/tutorials/admin-operations)
+
+## 6. よく読む関連ドキュメント
 
 - 初期設定: [Configuration](/configuration)
 - 受信制御: [Rate Limit](/rate_limit)
@@ -51,7 +59,7 @@ SLO を見たい場合は [SLO Delivery](/runbooks/slo_delivery) を参照して
 - 設計メモ: [Normalization Policy](/architecture/normalization_policy)
 - HA 構成: [HA Reference](/architecture/ha_reference)
 
-## 6. docs サイトをローカル確認する
+## 7. docs サイトをローカル確認する
 
 ```bash
 npm install

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: kuroshio-mta
   text: Go で実装した MTA の設計と運用ドキュメント
-  tagline: 設定、RFC 対応、運用 runbook、アーキテクチャ方針をブラウザでたどれるように整理したドキュメントサイトです。
+  tagline: Getting Started、機能チュートリアル、RFC 対応、運用 runbook、アーキテクチャ方針をブラウザでたどれるように整理したドキュメントサイトです。
   actions:
     - theme: brand
       text: Getting Started を見る
@@ -13,12 +13,17 @@ hero:
       text: 設定ガイドを見る
       link: /configuration
     - theme: alt
+      text: チュートリアルを見る
+      link: /tutorials/basic-mail-flow
+    - theme: alt
       text: GitHub Repository
       link: https://github.com/tamago0224/kuroshio-mta
 
 features:
   - title: Getting Started
     details: サンプル設定の作成から `go run ./cmd/kuroshio -config ./config.yaml` での起動までを最短手順で追えます。
+  - title: 機能チュートリアル
+    details: 最小メールフロー、メール認証、TLS 配送、Rate Limit、Admin API など主要機能を順に試せます。
   - title: 設定と運用
     details: YAML ベースの設定、Rate Limit、Kafka Queue モード、Admin API や SLO runbook までまとめて参照できます。
   - title: RFC 対応状況
@@ -31,6 +36,11 @@ features:
 ## よく使うページ
 
 - [Getting Started](/getting-started)
+- [最小メールフローを試す](/tutorials/basic-mail-flow)
+- [メール認証を試す](/tutorials/mail-auth)
+- [TLS 配送ポリシーを試す](/tutorials/tls-policy)
+- [Rate Limit を試す](/tutorials/rate-limit)
+- [Admin API を試す](/tutorials/admin-operations)
 - [設定ガイド](/configuration)
 - [Rate Limit](/rate_limit)
 - [Kafka Queue モード](/kafka_queue_mode)

--- a/docs/tutorials/admin-operations.md
+++ b/docs/tutorials/admin-operations.md
@@ -1,0 +1,55 @@
+# Admin API を試す
+
+`kuroshio-mta` の運用向け API を使って、queue の確認や requeue、suppression 操作を試すハンズオンです。
+
+## 前提
+
+- [Getting Started](/getting-started) を完了している
+- `queue_backend: local` を使っている
+- Admin API 用の token を設定している
+
+## 1. Admin API を有効化する
+
+`config.yaml` または環境変数で Admin API を有効化します。
+
+```bash
+MTA_ADMIN_ADDR=:9091
+MTA_ADMIN_TOKENS=viewer-token:viewer,operator-token:operator
+```
+
+## 2. MTA を起動する
+
+```bash
+go run ./cmd/kuroshio -config ./config.yaml
+```
+
+## 3. 付属 CLI を使う
+
+```bash
+export ORINOCO_ADMIN_URL=http://127.0.0.1:9091
+export ORINOCO_ADMIN_TOKEN=operator-token
+export ORINOCO_ADMIN_ACTOR=oncall@example.com
+
+scripts/admin/orinoco_admin.sh list-suppressions
+scripts/admin/orinoco_admin.sh list-queue dlq 20
+```
+
+## 4. dry-run で安全に試す
+
+いきなり本操作をせず、まず dry-run で確認できます。
+
+```bash
+scripts/admin/orinoco_admin.sh requeue dlq msg-1 --dry-run
+```
+
+## 5. 制約
+
+- queue 操作は現時点ではローカルファイルバックエンド専用です
+- Kafka バックエンドの運用 API は別対応です
+
+## 次に読むページ
+
+- API 詳細: [Admin API Runbook](/runbooks/admin_api)
+- Kafka で動かす: [Kafka Queue モード](/kafka_queue_mode)
+- reputation 運用: [Reputation Ops](/runbooks/reputation_ops)
+

--- a/docs/tutorials/basic-mail-flow.md
+++ b/docs/tutorials/basic-mail-flow.md
@@ -1,0 +1,57 @@
+# 最小メールフローを試す
+
+`kuroshio-mta` を起動して、SMTP で 1 通受け取り、ローカル queue に入るところまでを確認する最小ハンズオンです。
+
+## 前提
+
+- [Getting Started](/getting-started) を完了している
+- `queue_backend: local` で起動している
+- `listen_addr` が `:2525` になっている
+
+## 1. MTA を起動する
+
+```bash
+go run ./cmd/kuroshio -config ./config.yaml
+```
+
+## 2. SMTP で 1 通投入する
+
+別ターミナルで `nc` を使い、最小の SMTP セッションを流します。
+
+```bash
+cat <<'EOF' | nc 127.0.0.1 2525
+EHLO localhost
+MAIL FROM:<sender@example.net>
+RCPT TO:<user@example.com>
+DATA
+Subject: kuroshio test
+
+hello from kuroshio-mta
+.
+QUIT
+EOF
+```
+
+成功すると、`MAIL FROM` / `RCPT TO` / `DATA` に対して `250` または `354` が返ります。
+
+## 3. ローカル queue を確認する
+
+`queue_backend: local` の場合、受信したメッセージは `queue_dir` 配下に JSON で保存されます。
+
+```bash
+find ./var/queue -maxdepth 2 -type f | sort
+```
+
+通常は `mail.inbound` や `mail.retry` などのディレクトリが見えます。
+
+## 4. 次に見る場所
+
+- 設定を見直す: [Configuration](/configuration)
+- Admin API で queue を操作する: [Admin API を試す](/tutorials/admin-operations)
+- レート制限を加える: [Rate Limit を試す](/tutorials/rate-limit)
+
+## 補足
+
+- 送信先 MX が到達不能な環境では、worker が再送キューへ移すことがあります
+- SMTP コマンドの RFC 要件を確認したい場合は、`go test ./internal/smtp -run '^TestSMTPConformance$' -v` を使えます
+

--- a/docs/tutorials/mail-auth.md
+++ b/docs/tutorials/mail-auth.md
@@ -1,0 +1,55 @@
+# メール認証を試す
+
+`kuroshio-mta` が持つ SPF / DKIM / DMARC / ARC 周辺の主要機能を、どこから確認するとよいかをまとめたハンズオンです。
+
+## 何を確認するか
+
+- 受信時の SPF / DKIM / DMARC / ARC 評価
+- 送信時の DKIM / ARC 署名付与
+- DMARC レポートや評価の前提となる実装範囲
+
+## 1. まず実装範囲を押さえる
+
+細かな対応状況は RFC ギャップメモにまとまっています。
+
+- SPF: [RFC 7208 Gap Note](/rfc_7208_gap)
+- DKIM: [RFC 6376 Gap Note](/rfc_6376_gap)
+- DMARC: [RFC 7489 Gap Note](/rfc_7489_gap)
+- ARC: [RFC 8617 Gap Note](/rfc_8617_gap)
+
+## 2. 正規化と判定前提を確認する
+
+認証評価の前段にある envelope や生成メッセージの扱いは、[Normalization Policy](/architecture/normalization_policy) に整理されています。
+
+特に見るとよい項目:
+
+- envelope sender / recipient の扱い
+- `postmaster` の補完
+- DSN / DMARC report 生成時の正規化
+
+## 3. 送信署名を試す
+
+DKIM 署名付与の挙動はテストから追うのが最短です。
+
+```bash
+go test ./internal/dkim -run TestFileSignerSignInjectsDKIMHeader -v
+```
+
+`DKIM-Signature:` が先頭に付くことを確認できます。
+
+## 4. 受信評価を試す
+
+SPF / DKIM / DMARC の受信評価は `mailauth` パッケージのテストから追えます。
+
+```bash
+go test ./internal/mailauth ./internal/smtp
+```
+
+SMTP 受信時にどこまで認証結果を扱うかは [README](https://github.com/tamago0224/kuroshio-mta/blob/main/README.md) の RFC 対応表もあわせて確認してください。
+
+## 5. 次に読むドキュメント
+
+- TLS 配送ポリシーも試す: [TLS 配送ポリシーを試す](/tutorials/tls-policy)
+- DSN を試す: [RFC 3464 Gap Note](/rfc_3464_gap)
+- Reputation 系の運用を見る: [Reputation Ops](/runbooks/reputation_ops)
+

--- a/docs/tutorials/rate-limit.md
+++ b/docs/tutorials/rate-limit.md
@@ -1,0 +1,63 @@
+# Rate Limit を試す
+
+YAML でルールを書き、`kuroshio-mta` の受信レート制限がどう効くかを確かめるハンズオンです。
+
+## 前提
+
+- [Getting Started](/getting-started) を完了している
+- まずは `rate_limit_backend: memory` で試す
+- 複数ノード構成を試したい場合だけ Redis / Valkey を使う
+
+## 1. ルールを書く
+
+まずは `config.yaml` に最小のルールを入れます。
+
+```yaml
+ingress_rate_limit_per_minute: 10
+rate_limit_backend: memory
+rate_limit_rules: "connect:ip:3:1m;mailfrom:ip+mailfrom:2:1m"
+```
+
+設定フォーマットの詳細は [Rate Limit 設定](/rate_limit) を参照してください。
+
+## 2. MTA を起動する
+
+```bash
+go run ./cmd/kuroshio -config ./config.yaml
+```
+
+## 3. 制限を超えるように接続する
+
+短時間に複数回 SMTP セッションを張ると、接続元 IP や `MAIL FROM` 単位のルールに達します。
+
+負荷をかけて挙動を見るなら、既存の load script が使えます。
+
+```bash
+scripts/load/run_smtp_load.sh normal 127.0.0.1:2525
+```
+
+## 4. Redis / Valkey に切り替える
+
+複数ノードで共有したい場合は、状態だけ Redis / Valkey に外部化できます。
+
+```yaml
+rate_limit_backend: redis
+rate_limit_redis_addrs:
+  - localhost:6379
+rate_limit_redis_key_prefix: kuroshio:ratelimit
+```
+
+## 5. どこまで外部化されるか
+
+現在 Redis / Valkey に出しているのは RateLimiter のヒット状態だけです。
+
+- RateLimiter 状態: 外部化対象
+- DNSBL キャッシュ: 外部化対象外
+- 配送側 throttle: 外部化対象外
+
+## 次に読むページ
+
+- 詳細設定: [Rate Limit 設定](/rate_limit)
+- 負荷試験: [Load / Chaos](/runbooks/load_chaos)
+- Admin API: [Admin API を試す](/tutorials/admin-operations)
+

--- a/docs/tutorials/tls-policy.md
+++ b/docs/tutorials/tls-policy.md
@@ -1,0 +1,49 @@
+# TLS 配送ポリシーを試す
+
+`kuroshio-mta` の STARTTLS、MTA-STS、DANE といった配送時セキュリティ機能を確認するための入口です。
+
+## 何を確認するか
+
+- SMTP セッションでの STARTTLS 昇格
+- 送信側の MTA-STS / DANE の優先と失敗時挙動
+- TLS 周辺の実装範囲
+
+## 1. STARTTLS の実装範囲を確認する
+
+まずは [RFC 3207 Gap Note](/rfc_3207_gap) を読み、`kuroshio-mta` がどこまで STARTTLS を実装しているかを確認します。
+
+確認ポイント:
+
+- EHLO で `STARTTLS` を広告するか
+- TLS 昇格後に再 EHLO を要求するか
+- すでに TLS 下のセッションで再度 `STARTTLS` を拒否するか
+
+## 2. コンフォーマンステストを実行する
+
+STARTTLS を含む SMTP 基本フローは、次のテストで確認できます。
+
+```bash
+go test ./internal/smtp -run '^TestSMTPConformance$' -v
+```
+
+## 3. 送信側ポリシーを追う
+
+MTA-STS と DANE の実装範囲は次を参照します。
+
+- [RFC 8461 Gap Note](/rfc_8461_gap)
+- [RFC 7672 Gap Note](/rfc_7672_gap)
+
+README では DANE が MTA-STS より優先される実装方針も案内しています。
+
+## 4. 運用確認につなげる
+
+配送まわりの健全性を見る場合は、SLO runbook もあわせて使います。
+
+- [SLO Delivery](/runbooks/slo_delivery)
+- [SLO Retry](/runbooks/slo_retry)
+
+## 次に読むページ
+
+- 認証系を見る: [メール認証を試す](/tutorials/mail-auth)
+- 負荷下で試す: [Load / Chaos](/runbooks/load_chaos)
+


### PR DESCRIPTION
## Summary
- add hands-on tutorials for the main kuroshio-mta features after Getting Started
- reorganize the VitePress home, nav, and sidebar to surface the new tutorial flow
- connect Getting Started to the new feature guides for basic mail flow, mail auth, TLS policies, rate limiting, and admin operations

## Related Issue
- None

## Validation
- [ ] go vet ./...
- [ ] go test ./...
- [ ] go test -race ./...
- [x] npm run docs:build
- [x] git diff --check

## TDD Checklist
- [ ] Red: failing test was added first
- [ ] Green: minimal implementation to pass tests
- [ ] Refactor: cleanup completed without behavior change
