### PR TITLE
build: add container image definition

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+.agents
+.codex
+node_modules
+docs/.vitepress/cache
+docs/.vitepress/dist
+var
+certs
+keys
+test
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM golang:1.25.9 AS builder
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o /out/kuroshio ./cmd/kuroshio
+
+FROM gcr.io/distroless/base-debian12:nonroot
+
+WORKDIR /app
+
+COPY --from=builder /out/kuroshio /usr/local/bin/kuroshio
+
+EXPOSE 2525 587 8080 9090
+
+ENTRYPOINT ["/usr/local/bin/kuroshio"]
+CMD ["-config", "/etc/kuroshio/config.yaml"]

--- a/README.md
+++ b/README.md
@@ -46,6 +46,31 @@ go run ./cmd/kuroshio -config ./config.yaml
 
 `-config` を省略した場合は、`MTA_CONFIG_FILE` またはカレントディレクトリの `config.yaml` / `config.yml` を順に参照します。デフォルトでは `:2525` でSMTP待受します。
 
+## Docker
+
+本体用の [Dockerfile](/home/tamago/ghq/github.com/tamago/kuroshio-mta/Dockerfile) を用意しています。
+
+build:
+
+```bash
+docker build -t kuroshio-mta:latest .
+```
+
+run:
+
+```bash
+docker run --rm \
+  -p 2525:2525 \
+  -p 9090:9090 \
+  -v "$(pwd)/config.yaml:/etc/kuroshio/config.yaml:ro" \
+  kuroshio-mta:latest
+```
+
+補足:
+- デフォルトでは `-config /etc/kuroshio/config.yaml` を使います
+- TLS 証明書、鍵、queue ディレクトリ、spool ディレクトリを使う場合は必要なパスを追加で mount してください
+- `submission_addr` や `admin_addr` を有効にする場合は、必要なポートも `-p` で公開してください
+
 ## 設定
 
 - 設定全体と YAML / 環境変数の対応表: [configuration.md](/home/tamago/ghq/github.com/tamago/kuroshio-mta/docs/configuration.md)


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile for building and running kuroshio-mta in a container
- add a .dockerignore to keep the image build context small
- document docker build and run usage in README

## Related Issue
- None

## Validation
- [ ] go vet ./...
- [ ] go test ./...
- [ ] go test -race ./...
- [x] go test ./cmd/kuroshio
- [x] git diff --check
- [ ] docker build -t kuroshio-mta:test . (Docker daemon permission unavailable in this environment)

## TDD Checklist
- [ ] Red: failing test was added first
- [ ] Green: minimal implementation to pass tests
- [ ] Refactor: cleanup completed without behavior change
