### PR TITLE
docs: separate configuration from getting started

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -27,16 +27,26 @@ export default defineConfig({
         text: "Getting Started",
         items: [
           { text: "Home", link: "/" },
-          { text: "Getting Started", link: "/getting-started" },
-          { text: "Basic Mail Flow", link: "/tutorials/basic-mail-flow" },
-          { text: "Mail Authentication", link: "/tutorials/mail-auth" },
-          { text: "TLS Delivery Policies", link: "/tutorials/tls-policy" },
-          { text: "Rate Limit Tutorial", link: "/tutorials/rate-limit" },
-          { text: "Admin API Tutorial", link: "/tutorials/admin-operations" },
+          { text: "Getting Started", link: "/getting-started" }
+        ]
+      },
+      {
+        text: "Guide",
+        items: [
           { text: "Configuration", link: "/configuration" },
           { text: "S3 Spool Backend", link: "/s3_spool_backend" },
           { text: "Rate Limit", link: "/rate_limit" },
           { text: "Kafka Queue Mode", link: "/kafka_queue_mode" }
+        ]
+      },
+      {
+        text: "Tutorials",
+        items: [
+          { text: "Basic Mail Flow", link: "/tutorials/basic-mail-flow" },
+          { text: "Mail Authentication", link: "/tutorials/mail-auth" },
+          { text: "TLS Delivery Policies", link: "/tutorials/tls-policy" },
+          { text: "Rate Limit Tutorial", link: "/tutorials/rate-limit" },
+          { text: "Admin API Tutorial", link: "/tutorials/admin-operations" }
         ]
       },
       {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,16 +52,19 @@ SLO を見たい場合は [SLO Delivery](/runbooks/slo_delivery) を参照して
 - 受信制御を試す: [Rate Limit を試す](/tutorials/rate-limit)
 - queue 操作を試す: [Admin API を試す](/tutorials/admin-operations)
 
-## 6. よく読む関連ドキュメント
+## 6. 次に読む Guide
 
-- 初期設定: [Configuration](/configuration)
+- 設定全体: [Configuration](/configuration)
 - 受信制御: [Rate Limit](/rate_limit)
 - S3-compatible 保存先: [S3 Spool Backend](/s3_spool_backend)
 - Kafka バックエンド: [Kafka Queue Mode](/kafka_queue_mode)
+
+## 7. 設計と運用のドキュメント
+
 - 設計メモ: [Normalization Policy](/architecture/normalization_policy)
 - HA 構成: [HA Reference](/architecture/ha_reference)
 
-## 7. docs サイトをローカル確認する
+## 8. docs サイトをローカル確認する
 
 ```bash
 npm install


### PR DESCRIPTION
## Summary
- move Configuration-related pages out of the Getting Started sidebar section
- add a dedicated Guide section in the docs sidebar
- update Getting Started to point to Guide docs as the next reading step

## Related Issue
- N/A

## Validation
- [x] git diff --check
- [x] npm run docs:build
- [ ] go vet ./...
- [ ] go test ./...
- [ ] go test -race ./...

## TDD Checklist
- [ ] Red: failing test was added first
- [ ] Green: minimal implementation to pass tests
- [ ] Refactor: cleanup completed without behavior change
