### PR TITLE
docs: organize tutorial navigation

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -13,7 +13,7 @@ export default defineConfig({
     logo: "/kuroshio-logo.png",
     nav: [
       { text: "Getting Started", link: "/getting-started" },
-      { text: "Tutorials", link: "/tutorials/basic-mail-flow" },
+      { text: "Tutorials", link: "/tutorials/" },
       { text: "Guide", link: "/configuration" },
       { text: "Architecture", link: "/architecture/normalization_policy" },
       { text: "Runbooks", link: "/runbooks/admin_api" },
@@ -42,6 +42,7 @@ export default defineConfig({
       {
         text: "Tutorials",
         items: [
+          { text: "Tutorials Home", link: "/tutorials/" },
           { text: "Basic Mail Flow", link: "/tutorials/basic-mail-flow" },
           { text: "Mail Authentication", link: "/tutorials/mail-auth" },
           { text: "TLS Delivery Policies", link: "/tutorials/tls-policy" },

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -46,6 +46,8 @@ SLO を見たい場合は [SLO Delivery](/runbooks/slo_delivery) を参照して
 
 ## 5. 次に試すチュートリアル
 
+compose ベースの tutorial 一覧は [Tutorials](/tutorials/) にまとめています。
+
 - 最初の 1 通を受ける: [最小メールフローを試す](/tutorials/basic-mail-flow)
 - 認証評価を見る: [メール認証を試す](/tutorials/mail-auth)
 - STARTTLS / MTA-STS / DANE を追う: [TLS 配送ポリシーを試す](/tutorials/tls-policy)

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,17 +4,17 @@ layout: home
 hero:
   name: kuroshio-mta
   text: Go で実装した MTA の設計と運用ドキュメント
-  tagline: Getting Started、機能チュートリアル、RFC 対応、運用 runbook、アーキテクチャ方針をブラウザでたどれるように整理したドキュメントサイトです。
+  tagline: Getting Started、compose で試せる機能チュートリアル、RFC 対応、運用 runbook、アーキテクチャ方針をブラウザでたどれるように整理したドキュメントサイトです。
   actions:
     - theme: brand
       text: Getting Started を見る
       link: /getting-started
     - theme: alt
+      text: Tutorials を見る
+      link: /tutorials/
+    - theme: alt
       text: 設定ガイドを見る
       link: /configuration
-    - theme: alt
-      text: チュートリアルを見る
-      link: /tutorials/basic-mail-flow
     - theme: alt
       text: GitHub Repository
       link: https://github.com/tamago0224/kuroshio-mta
@@ -23,7 +23,7 @@ features:
   - title: Getting Started
     details: サンプル設定の作成から `go run ./cmd/kuroshio -config ./config.yaml` での起動までを最短手順で追えます。
   - title: 機能チュートリアル
-    details: 最小メールフロー、メール認証、TLS 配送、Rate Limit、Admin API など主要機能を順に試せます。
+    details: 最小メールフロー、メール認証、TLS 配送、Rate Limit、Admin API など主要機能を `docker compose` で順に試せます。
   - title: 設定と運用
     details: YAML ベースの設定、Rate Limit、Kafka Queue モード、Admin API や SLO runbook までまとめて参照できます。
   - title: RFC 対応状況
@@ -36,6 +36,7 @@ features:
 ## よく使うページ
 
 - [Getting Started](/getting-started)
+- [Tutorials](/tutorials/)
 - [最小メールフローを試す](/tutorials/basic-mail-flow)
 - [メール認証を試す](/tutorials/mail-auth)
 - [TLS 配送ポリシーを試す](/tutorials/tls-policy)

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,0 +1,29 @@
+# Tutorials
+
+`kuroshio-mta` の主要機能を、手元で実際に動かしながら確認するための入口です。
+
+ほとんどの tutorial は `docker compose` で最小環境を起動し、SMTP・Admin API・DNS・MTA-STS policy などをそのまま確認できるようにしています。
+
+## まずどこから試すか
+
+| Tutorial | 何を確認するか | 主な環境 |
+| --- | --- | --- |
+| [最小メールフローを試す](/tutorials/basic-mail-flow) | SMTP で 1 通受信し、local queue に入るところ | `kuroshio` + `smtp-client` |
+| [Rate Limit を試す](/tutorials/rate-limit) | 接続元 IP や `MAIL FROM` 単位の制限 | `kuroshio` + `smtp-client` |
+| [Admin API を試す](/tutorials/admin-operations) | queue 操作と Admin API / CLI | `kuroshio` + `smtp-client` |
+| [メール認証を試す](/tutorials/mail-auth) | SPF / DMARC 評価、DKIM / ARC 署名 | `CoreDNS` + `policy` + `tester` |
+| [TLS 配送ポリシーを試す](/tutorials/tls-policy) | STARTTLS、MTA-STS、DANE | `CoreDNS` + `policy` + `tester` |
+
+## compose ベースの tutorial 環境
+
+- 基本 SMTP: [examples/tutorials/basic-mail-flow](https://github.com/tamago0224/kuroshio-mta/tree/main/examples/tutorials/basic-mail-flow)
+- Rate Limit: [examples/tutorials/rate-limit](https://github.com/tamago0224/kuroshio-mta/tree/main/examples/tutorials/rate-limit)
+- Admin API: [examples/tutorials/admin-operations](https://github.com/tamago0224/kuroshio-mta/tree/main/examples/tutorials/admin-operations)
+- DNS / Web: [examples/tutorials/dns-services](https://github.com/tamago0224/kuroshio-mta/tree/main/examples/tutorials/dns-services)
+
+## 進み方のおすすめ
+
+1. [Getting Started](/getting-started) で最初の起動方法を確認する
+2. [最小メールフローを試す](/tutorials/basic-mail-flow) で 1 通受ける
+3. [Rate Limit を試す](/tutorials/rate-limit) と [Admin API を試す](/tutorials/admin-operations) で運用系を見る
+4. [メール認証を試す](/tutorials/mail-auth) と [TLS 配送ポリシーを試す](/tutorials/tls-policy) で DNS / policy 系を確認する


### PR DESCRIPTION
## Summary
- add a tutorials landing page that explains what each tutorial verifies
- update the docs home page and Getting Started to point to the tutorials entrypoint
- align VitePress navigation so Tutorials goes to the landing page instead of a single tutorial

## Related Issue
- N/A

## Validation
- [x] git diff --check
- [x] npm run docs:build
- [ ] go vet ./...
- [ ] go test ./...
- [ ] go test -race ./...

## TDD Checklist
- [ ] Red: failing test was added first
- [ ] Green: minimal implementation to pass tests
- [ ] Refactor: cleanup completed without behavior change
