### PR TITLE
feat: 配送経路の OTEL trace を追加

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -60,6 +60,11 @@ reputation tracker を有効にしている場合だけ値が返ります。
 - 現在 span を付与している箇所:
   - SMTP session
   - worker の message 処理
+  - queue の enqueue / due / ack / retry / fail
+  - MX lookup
+  - DANE lookup
+  - MTA-STS lookup
+  - 配送先ホストごとの SMTP 試行
 
 現状の observability を一言で言うと:
 

--- a/internal/delivery/dane.go
+++ b/internal/delivery/dane.go
@@ -13,12 +13,18 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 )
 
 const (
 	dnsTypeTLSA = 52
 	dnsClassIN  = 1
 )
+
+var daneTracer = otel.Tracer("github.com/tamago0224/kuroshio-mta/internal/delivery/dane")
 
 type TLSARecord struct {
 	Usage                  uint8
@@ -163,14 +169,25 @@ func NewDANEResolver(timeout time.Duration, lookupFn func(context.Context, strin
 }
 
 func (r *DANEResolver) LookupHost(ctx context.Context, host string, port int) (DANEResult, error) {
+	ctx, span := daneTracer.Start(ctx, "delivery.lookup_dane")
+	span.SetAttributes(
+		attribute.String("delivery.host", host),
+		attribute.Int("delivery.port", port),
+	)
+	defer span.End()
+
 	host = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
 	if host == "" {
-		return DANEResult{}, errors.New("empty host")
+		err := errors.New("empty host")
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return DANEResult{}, err
 	}
 	if port <= 0 {
 		port = 25
 	}
 	candidates := r.expandDANECandidates(ctx, host)
+	span.SetAttributes(attribute.Int("delivery.dane_candidate_count", len(candidates)))
 	merged := DANEResult{}
 	var lastErr error
 	for _, cand := range candidates {
@@ -187,9 +204,15 @@ func (r *DANEResolver) LookupHost(ctx context.Context, host string, port int) (D
 		}
 	}
 	if len(merged.Records) > 0 {
+		span.SetAttributes(
+			attribute.Bool("delivery.dane_authenticated_data", merged.AuthenticatedData),
+			attribute.Int("delivery.dane_tlsa_record_count", len(merged.Records)),
+		)
 		return merged, nil
 	}
 	if lastErr != nil {
+		span.RecordError(lastErr)
+		span.SetStatus(codes.Error, lastErr.Error())
 		return DANEResult{}, lastErr
 	}
 	return DANEResult{}, nil

--- a/internal/delivery/mta_sts.go
+++ b/internal/delivery/mta_sts.go
@@ -15,9 +15,15 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 )
 
 const maxMTASTSPolicyAge = 31557600 * time.Second
+
+var mtaSTSTracer = otel.Tracer("github.com/tamago0224/kuroshio-mta/internal/delivery/mta_sts")
 
 type MTASTSPolicy struct {
 	Version   string
@@ -98,9 +104,16 @@ func NewMTASTSResolver(ttl, fetchTimeout time.Duration, fetchFunc func(ctx conte
 }
 
 func (r *MTASTSResolver) Lookup(ctx context.Context, domain string) (MTASTSPolicy, error) {
+	ctx, span := mtaSTSTracer.Start(ctx, "delivery.lookup_mta_sts")
+	span.SetAttributes(attribute.String("mail.domain", domain))
+	defer span.End()
+
 	domain = strings.ToLower(strings.TrimSpace(domain))
 	if domain == "" {
-		return MTASTSPolicy{}, errors.New("empty domain")
+		err := errors.New("empty domain")
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return MTASTSPolicy{}, err
 	}
 	now := r.nowFn().UTC()
 	policyID, hasPolicyID := r.lookupPolicyID(ctx, domain)
@@ -112,6 +125,10 @@ func (r *MTASTSResolver) Lookup(ctx context.Context, domain string) (MTASTSPolic
 	if p, ok := r.cache[domain]; ok {
 		refreshByID := hasPolicyID && p.PolicyID != "" && policyID != p.PolicyID
 		if now.Before(p.ExpiresAt) && !refreshByID {
+			span.SetAttributes(
+				attribute.Bool("delivery.mta_sts_cache_hit", true),
+				attribute.String("delivery.mta_sts_mode", p.Mode),
+			)
 			r.mu.Unlock()
 			return p, nil
 		}
@@ -131,6 +148,8 @@ func (r *MTASTSResolver) Lookup(ctx context.Context, domain string) (MTASTSPolic
 
 	text, err := r.fetchFunc(ctx, domain)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		if hasStale {
 			r.mu.Lock()
 			failures := r.retryFailures[domain] + 1
@@ -143,6 +162,8 @@ func (r *MTASTSResolver) Lookup(ctx context.Context, domain string) (MTASTSPolic
 	}
 	p, err := parseMTASTSPolicy(text)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		if hasStale {
 			r.mu.Lock()
 			failures := r.retryFailures[domain] + 1
@@ -176,6 +197,11 @@ func (r *MTASTSResolver) Lookup(ctx context.Context, domain string) (MTASTSPolic
 	r.cache[domain] = p
 	delete(r.rollovers, domain)
 	r.mu.Unlock()
+	span.SetAttributes(
+		attribute.Bool("delivery.mta_sts_cache_hit", false),
+		attribute.String("delivery.mta_sts_mode", p.Mode),
+		attribute.Int("delivery.mta_sts_mx_count", len(p.MX)),
+	)
 	return p, nil
 }
 

--- a/internal/delivery/smtp_client.go
+++ b/internal/delivery/smtp_client.go
@@ -18,6 +18,10 @@ import (
 	"github.com/tamago0224/kuroshio-mta/internal/model"
 	"github.com/tamago0224/kuroshio-mta/internal/router"
 	"github.com/tamago0224/kuroshio-mta/internal/util"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
 
 type messageSigner interface {
@@ -33,6 +37,8 @@ type spoolBackendFunc func(*model.Message, string) error
 func (f spoolBackendFunc) Store(msg *model.Message, rcpt string) error {
 	return f(msg, rcpt)
 }
+
+var deliveryTracer = otel.Tracer("github.com/tamago0224/kuroshio-mta/internal/delivery")
 
 type Client struct {
 	cfg                            config.Config
@@ -75,33 +81,55 @@ func NewClient(cfg config.Config) *Client {
 }
 
 func (c *Client) Deliver(ctx context.Context, msg *model.Message, rcpt string) error {
+	rcptDomain, _ := util.DomainOf(rcpt)
 	mode := strings.ToLower(strings.TrimSpace(c.cfg.DeliveryMode))
 	if mode == "" {
 		mode = "mx"
 	}
+	ctx, span := deliveryTracer.Start(ctx, "delivery.deliver")
+	span.SetAttributes(
+		attribute.String("delivery.mode", mode),
+		attribute.String("mail.message_id", msg.ID),
+		attribute.Int("mail.attempt", msg.Attempts),
+		attribute.String("mail.rcpt_domain", rcptDomain),
+	)
+	defer span.End()
+
+	var err error
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
+	}()
+
 	switch mode {
 	case "mx":
-		return c.deliverByMX(ctx, msg, rcpt)
+		err = c.deliverByMX(ctx, msg, rcpt)
 	case "local_spool":
 		if c.spoolStoreErr != nil {
-			return c.spoolStoreErr
+			err = c.spoolStoreErr
+			break
 		}
 		if c.spoolStore == nil {
-			return errors.New("spool backend is not configured")
+			err = errors.New("spool backend is not configured")
+			break
 		}
-		return c.spoolStore.Store(msg, rcpt)
+		err = c.spoolStore.Store(msg, rcpt)
 	case "relay":
 		if strings.TrimSpace(c.cfg.RelayHost) == "" {
-			return errors.New("relay mode requires MTA_RELAY_HOST")
+			err = errors.New("relay mode requires MTA_RELAY_HOST")
+			break
 		}
 		port := c.cfg.RelayPort
 		if port <= 0 {
 			port = 25
 		}
-		return c.deliverHostFn(ctx, c.cfg.RelayHost, port, msg, rcpt, c.cfg.RelayRequireTLS, nil)
+		err = c.deliverHostFn(ctx, c.cfg.RelayHost, port, msg, rcpt, c.cfg.RelayRequireTLS, nil)
 	default:
-		return fmt.Errorf("unknown delivery mode: %s", mode)
+		err = fmt.Errorf("unknown delivery mode: %s", mode)
 	}
+	return err
 }
 
 func (c *Client) newSpoolBackend() (spoolBackend, error) {
@@ -120,11 +148,30 @@ func (c *Client) newSpoolBackend() (spoolBackend, error) {
 }
 
 func (c *Client) deliverByMX(ctx context.Context, msg *model.Message, rcpt string) error {
+	ctx, span := deliveryTracer.Start(ctx, "delivery.mx")
+	defer span.End()
+
 	domain, ok := util.DomainOf(rcpt)
 	if !ok {
-		return errors.New("invalid rcpt domain")
+		err := errors.New("invalid rcpt domain")
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
 	}
+	span.SetAttributes(attribute.String("mail.rcpt_domain", domain))
+
+	_, lookupSpan := deliveryTracer.Start(ctx, "delivery.lookup_mx", trace.WithAttributes(
+		attribute.String("mail.rcpt_domain", domain),
+	))
 	mxHosts, err := c.resolveMXFn(domain, c.cfg.DialTimeout)
+	if err == nil {
+		lookupSpan.SetAttributes(attribute.Int("delivery.mx_count", len(mxHosts)))
+	}
+	if err != nil {
+		lookupSpan.RecordError(err)
+		lookupSpan.SetStatus(codes.Error, err.Error())
+	}
+	lookupSpan.End()
 	if err != nil {
 		return fmt.Errorf("mx lookup failed: %w", err)
 	}
@@ -182,10 +229,21 @@ func (c *Client) deliverByMX(ctx context.Context, msg *model.Message, rcpt strin
 				daneRes = &cp
 			}
 		}
-		err := c.deliverHostFn(ctx, mx.Host, 25, msg, rcpt, requireTLS, daneRes)
+		attemptCtx, attemptSpan := deliveryTracer.Start(ctx, "delivery.attempt_host")
+		attemptSpan.SetAttributes(
+			attribute.String("delivery.mx_host", mx.Host),
+			attribute.Bool("delivery.require_tls", requireTLS),
+			attribute.Bool("delivery.dane_active", daneActive),
+		)
+		err := c.deliverHostFn(attemptCtx, mx.Host, 25, msg, rcpt, requireTLS, daneRes)
 		if daneActive {
 			err = classifyDANEFailure(err)
 		}
+		if err != nil {
+			attemptSpan.RecordError(err)
+			attemptSpan.SetStatus(codes.Error, err.Error())
+		}
+		attemptSpan.End()
 		if err == nil {
 			return nil
 		} else {
@@ -214,6 +272,23 @@ func classifyDANEFailure(err error) error {
 }
 
 func (c *Client) deliverHost(ctx context.Context, host string, port int, msg *model.Message, rcpt string, requireTLS bool, daneRes *DANEResult) error {
+	ctx, span := deliveryTracer.Start(ctx, "delivery.smtp_attempt")
+	span.SetAttributes(
+		attribute.String("delivery.host", host),
+		attribute.Int("delivery.port", port),
+		attribute.Bool("delivery.require_tls", requireTLS),
+		attribute.Bool("delivery.dane_tlsa", daneRes != nil && len(daneRes.Records) > 0),
+	)
+	defer span.End()
+
+	var err error
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
+	}()
+
 	if port <= 0 {
 		port = 25
 	}

--- a/internal/queue/factory.go
+++ b/internal/queue/factory.go
@@ -10,9 +10,17 @@ import (
 func NewBackend(cfg config.Config) (Backend, error) {
 	switch strings.ToLower(strings.TrimSpace(cfg.QueueBackend)) {
 	case "", "local":
-		return New(cfg.QueueDir)
+		b, err := New(cfg.QueueDir)
+		if err != nil {
+			return nil, err
+		}
+		return wrapObservedBackend("local", b), nil
 	case "kafka":
-		return NewKafka(cfg)
+		b, err := NewKafka(cfg)
+		if err != nil {
+			return nil, err
+		}
+		return wrapObservedBackend("kafka", b), nil
 	default:
 		return nil, errors.New("unknown queue backend: " + cfg.QueueBackend)
 	}

--- a/internal/queue/factory_test.go
+++ b/internal/queue/factory_test.go
@@ -12,8 +12,12 @@ func TestNewBackendLocal(t *testing.T) {
 		t.Fatalf("NewBackend(local): %v", err)
 	}
 	defer b.Close()
-	if _, ok := b.(*Store); !ok {
-		t.Fatalf("expected *Store backend, got %T", b)
+	observed, ok := b.(*observedBackend)
+	if !ok {
+		t.Fatalf("expected observed backend wrapper, got %T", b)
+	}
+	if _, ok := observed.next.(*Store); !ok {
+		t.Fatalf("expected wrapped *Store backend, got %T", observed.next)
 	}
 }
 

--- a/internal/queue/otel.go
+++ b/internal/queue/otel.go
@@ -1,0 +1,117 @@
+package queue
+
+import (
+	"context"
+	"time"
+
+	"github.com/tamago0224/kuroshio-mta/internal/model"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+var queueTracer = otel.Tracer("github.com/tamago0224/kuroshio-mta/internal/queue")
+
+type observedBackend struct {
+	name string
+	next Backend
+}
+
+func wrapObservedBackend(name string, next Backend) Backend {
+	if next == nil {
+		return nil
+	}
+	return &observedBackend{name: name, next: next}
+}
+
+func (b *observedBackend) Enqueue(msg *model.Message) error {
+	_, span := b.startSpan(context.Background(), "queue.enqueue", msg)
+	defer span.End()
+
+	err := b.next.Enqueue(msg)
+	recordSpanError(span, err)
+	return err
+}
+
+func (b *observedBackend) Due(limit int) ([]*model.Message, error) {
+	_, span := queueTracer.Start(
+		context.Background(),
+		"queue.due",
+		trace.WithAttributes(
+			attribute.String("queue.backend", b.name),
+			attribute.Int("queue.limit", limit),
+		),
+	)
+	defer span.End()
+
+	msgs, err := b.next.Due(limit)
+	if err == nil {
+		span.SetAttributes(attribute.Int("queue.message_count", len(msgs)))
+	}
+	recordSpanError(span, err)
+	return msgs, err
+}
+
+func (b *observedBackend) AckSent(id string, msg *model.Message) error {
+	_, span := b.startSpan(context.Background(), "queue.ack_sent", msg)
+	defer span.End()
+
+	err := b.next.AckSent(id, msg)
+	recordSpanError(span, err)
+	return err
+}
+
+func (b *observedBackend) Retry(msg *model.Message, delay time.Duration, reason string) error {
+	_, span := b.startSpan(context.Background(), "queue.retry", msg)
+	span.SetAttributes(attribute.String("queue.retry_delay", delay.String()))
+	defer span.End()
+
+	err := b.next.Retry(msg, delay, reason)
+	recordSpanError(span, err)
+	return err
+}
+
+func (b *observedBackend) Fail(msg *model.Message, reason string) error {
+	_, span := b.startSpan(context.Background(), "queue.fail", msg)
+	defer span.End()
+
+	err := b.next.Fail(msg, reason)
+	recordSpanError(span, err)
+	return err
+}
+
+func (b *observedBackend) Close() error {
+	_, span := queueTracer.Start(
+		context.Background(),
+		"queue.close",
+		trace.WithAttributes(attribute.String("queue.backend", b.name)),
+	)
+	defer span.End()
+
+	err := b.next.Close()
+	recordSpanError(span, err)
+	return err
+}
+
+func (b *observedBackend) startSpan(ctx context.Context, name string, msg *model.Message) (context.Context, trace.Span) {
+	attrs := []attribute.KeyValue{
+		attribute.String("queue.backend", b.name),
+	}
+	if msg != nil {
+		attrs = append(attrs,
+			attribute.String("mail.message_id", msg.ID),
+			attribute.Int("mail.attempt", msg.Attempts),
+			attribute.Int("mail.rcpt_count", len(msg.RcptTo)),
+		)
+	}
+	return queueTracer.Start(ctx, name, trace.WithAttributes(attrs...))
+}
+
+func recordSpanError(span trace.Span, err error) {
+	if err == nil {
+		return
+	}
+	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
+}


### PR DESCRIPTION
## 概要
- queue backend に OTEL span を追加し、enqueue / due / ack / retry / fail を計装
- delivery 経路に OTEL span を追加し、MX lookup、MTA-STS lookup、DANE lookup、配送先ホストごとの SMTP 試行を計装
- observability ドキュメントを更新して現在の trace 対象を反映

## 関連 Issue
- Closes #207

## 確認内容
- [x] go test ./...
- [x] git diff --check

## 補足
- .codex は未追跡のローカルファイルのため含めていません
