### PR TITLE
feat: OTEL の trace と log を相関

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -49,6 +49,8 @@ reputation tracker を有効にしている場合だけ値が返ります。
 アプリケーションログは `slog` ベースの JSON です。
 `log_level` で `debug` / `info` / `warn` / `error` を切り替えます。
 
+OpenTelemetry tracing を有効にしていて、かつ `InfoContext` / `WarnContext` / `ErrorContext` 経由で出力されたログには、`trace_id` と `span_id` も付与されます。
+
 ## 現在の OTEL 対応状況
 
 現時点の `kuroshio-mta` では、OpenTelemetry SDK を使った trace export を有効化できます。

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -12,7 +12,7 @@ func New(level string, w io.Writer) *slog.Logger {
 		w = os.Stdout
 	}
 	lvl := parseLevel(level)
-	h := slog.NewJSONHandler(w, &slog.HandlerOptions{Level: lvl})
+	h := newOTELHandler(slog.NewJSONHandler(w, &slog.HandlerOptions{Level: lvl}))
 	return slog.New(h)
 }
 

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -2,9 +2,13 @@ package logging
 
 import (
 	"bytes"
+	"context"
 	"log/slog"
 	"strings"
 	"testing"
+
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
 func TestNewJSONLoggerOutputsStructuredRecord(t *testing.T) {
@@ -29,5 +33,30 @@ func TestNewLoggerRespectsLevel(t *testing.T) {
 	l.Info("info should be filtered")
 	if got := strings.TrimSpace(buf.String()); got != "" {
 		t.Fatalf("unexpected output at warn level: %q", got)
+	}
+}
+
+func TestNewLoggerIncludesTraceCorrelationForContextLogs(t *testing.T) {
+	var buf bytes.Buffer
+	l := New("info", &buf)
+
+	tp := sdktrace.NewTracerProvider()
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	defer func() {
+		otel.SetTracerProvider(prev)
+		_ = tp.Shutdown(context.Background())
+	}()
+
+	ctx, span := otel.Tracer("test").Start(context.Background(), "op")
+	defer span.End()
+
+	l.InfoContext(ctx, "context aware log")
+	out := buf.String()
+	if !strings.Contains(out, `"trace_id":"`) {
+		t.Fatalf("missing trace_id field: %q", out)
+	}
+	if !strings.Contains(out, `"span_id":"`) {
+		t.Fatalf("missing span_id field: %q", out)
 	}
 }

--- a/internal/logging/otel_handler.go
+++ b/internal/logging/otel_handler.go
@@ -1,0 +1,39 @@
+package logging
+
+import (
+	"context"
+	"log/slog"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+type otelHandler struct {
+	next slog.Handler
+}
+
+func newOTELHandler(next slog.Handler) slog.Handler {
+	return &otelHandler{next: next}
+}
+
+func (h *otelHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.next.Enabled(ctx, level)
+}
+
+func (h *otelHandler) Handle(ctx context.Context, r slog.Record) error {
+	spanCtx := trace.SpanContextFromContext(ctx)
+	if spanCtx.IsValid() {
+		r.AddAttrs(
+			slog.String("trace_id", spanCtx.TraceID().String()),
+			slog.String("span_id", spanCtx.SpanID().String()),
+		)
+	}
+	return h.next.Handle(ctx, r)
+}
+
+func (h *otelHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &otelHandler{next: h.next.WithAttrs(attrs)}
+}
+
+func (h *otelHandler) WithGroup(name string) slog.Handler {
+	return &otelHandler{next: h.next.WithGroup(name)}
+}

--- a/internal/smtp/server.go
+++ b/internal/smtp/server.go
@@ -212,11 +212,11 @@ func (s *Server) handleConnWithContext(ctx context.Context, conn net.Conn) {
 		if s.limiter != nil {
 			allowed, err := s.limiter.Allow(remoteStr, now)
 			if err != nil {
-				slog.Warn("rate limit store error", "component", "smtp", "error", err, "remote_ip", remoteStr)
+				slog.WarnContext(ctx, "rate limit store error", "component", "smtp", "error", err, "remote_ip", remoteStr)
 			} else if !allowed {
 				rejectReason = "rate_limit"
 				s.metricInc("smtp_reject_rate_limit")
-				slog.Warn("ingress rejected", "component", "smtp", "reason", "rate_limit", "remote_ip", remoteStr)
+				slog.WarnContext(ctx, "ingress rejected", "component", "smtp", "reason", "rate_limit", "remote_ip", remoteStr)
 				writeResp(w, 421, "rate limit exceeded, try again later")
 				return
 			}
@@ -224,11 +224,11 @@ func (s *Server) handleConnWithContext(ctx context.Context, conn net.Conn) {
 		if s.flexLimiter != nil {
 			allowed, err := s.flexLimiter.Allow("connect", remoteStr, "", "", now)
 			if err != nil {
-				slog.Warn("rate limit store error", "component", "smtp", "error", err, "remote_ip", remoteStr, "event", "connect")
+				slog.WarnContext(ctx, "rate limit store error", "component", "smtp", "error", err, "remote_ip", remoteStr, "event", "connect")
 			} else if !allowed {
 				rejectReason = "rate_rule_connect"
 				s.metricInc("smtp_reject_rate_limit")
-				slog.Warn("ingress rejected", "component", "smtp", "reason", "rate_rule_connect", "remote_ip", remoteStr)
+				slog.WarnContext(ctx, "ingress rejected", "component", "smtp", "reason", "rate_rule_connect", "remote_ip", remoteStr)
 				writeResp(w, 421, "rate limit exceeded, try again later")
 				return
 			}
@@ -237,7 +237,7 @@ func (s *Server) handleConnWithContext(ctx context.Context, conn net.Conn) {
 			if listed, zone := s.dnsbl.IsListed(remoteStr); listed {
 				rejectReason = "dnsbl:" + zone
 				s.metricInc("smtp_reject_dnsbl")
-				slog.Warn("ingress rejected", "component", "smtp", "reason", "dnsbl", "zone", zone, "remote_ip", remoteStr)
+				slog.WarnContext(ctx, "ingress rejected", "component", "smtp", "reason", "dnsbl", "zone", zone, "remote_ip", remoteStr)
 				writeResp(w, 554, "connection rejected (dnsbl: "+zone+")")
 				return
 			}
@@ -272,10 +272,10 @@ func (s *Server) handleConnWithContext(ctx context.Context, conn net.Conn) {
 			if remoteIP != nil && s.flexLimiter != nil {
 				allowed, err := s.flexLimiter.Allow("helo", remoteIP.String(), ss.helo, "", time.Now().UTC())
 				if err != nil {
-					slog.Warn("rate limit store error", "component", "smtp", "error", err, "remote_ip", remoteIP.String(), "event", "helo", "helo", ss.helo)
+					slog.WarnContext(ctx, "rate limit store error", "component", "smtp", "error", err, "remote_ip", remoteIP.String(), "event", "helo", "helo", ss.helo)
 				} else if !allowed {
 					s.metricInc("smtp_reject_rate_limit")
-					slog.Warn("ingress rejected", "component", "smtp", "reason", "rate_rule_helo", "remote_ip", remoteIP.String(), "helo", ss.helo)
+					slog.WarnContext(ctx, "ingress rejected", "component", "smtp", "reason", "rate_rule_helo", "remote_ip", remoteIP.String(), "helo", ss.helo)
 					writeResp(w, 421, "rate limit exceeded, try again later")
 					return
 				}
@@ -341,10 +341,10 @@ func (s *Server) handleConnWithContext(ctx context.Context, conn net.Conn) {
 			if remoteIP != nil && s.flexLimiter != nil {
 				allowed, err := s.flexLimiter.Allow("mailfrom", remoteIP.String(), ss.helo, mailArgs.Address, time.Now().UTC())
 				if err != nil {
-					slog.Warn("rate limit store error", "component", "smtp", "error", err, "remote_ip", remoteIP.String(), "event", "mailfrom", "helo", ss.helo, "mail_from", logging.MaskEmail(mailArgs.Address))
+					slog.WarnContext(ctx, "rate limit store error", "component", "smtp", "error", err, "remote_ip", remoteIP.String(), "event", "mailfrom", "helo", ss.helo, "mail_from", logging.MaskEmail(mailArgs.Address))
 				} else if !allowed {
 					s.metricInc("smtp_reject_rate_limit")
-					slog.Warn("ingress rejected", "component", "smtp", "reason", "rate_rule_mailfrom", "remote_ip", remoteIP.String(), "helo", ss.helo, "mail_from", logging.MaskEmail(mailArgs.Address))
+					slog.WarnContext(ctx, "ingress rejected", "component", "smtp", "reason", "rate_rule_mailfrom", "remote_ip", remoteIP.String(), "helo", ss.helo, "mail_from", logging.MaskEmail(mailArgs.Address))
 					writeResp(w, 421, "rate limit exceeded, try again later")
 					return
 				}

--- a/internal/worker/dispatcher.go
+++ b/internal/worker/dispatcher.go
@@ -143,7 +143,7 @@ func (d *Dispatcher) handleMessage(ctx context.Context, msg *model.Message) {
 					d.metricInc("worker_permanent_bounce")
 					if d.sup != nil {
 						if sErr := d.sup.Add(rcpt, smtpErr.Line); sErr != nil {
-							slog.Error("suppression add failed", "component", "worker", "rcpt", logging.MaskEmail(rcpt), "msg_id", msg.ID, "error", sErr)
+							slog.ErrorContext(ctx, "suppression add failed", "component", "worker", "rcpt", logging.MaskEmail(rcpt), "msg_id", msg.ID, "error", sErr)
 						}
 					}
 					return
@@ -172,7 +172,7 @@ func (d *Dispatcher) handleMessage(ctx context.Context, msg *model.Message) {
 	if len(errs) == 0 {
 		span.SetAttributes(attribute.String("worker.result", "sent"))
 		if err := d.queue.AckSent(msg.ID, msg); err != nil {
-			slog.Error("ack sent failed", "component", "worker", "msg_id", msg.ID, "error", err)
+			slog.ErrorContext(ctx, "ack sent failed", "component", "worker", "msg_id", msg.ID, "error", err)
 		}
 		d.metricInc("worker_ack_sent")
 		return
@@ -186,7 +186,7 @@ func (d *Dispatcher) handleMessage(ctx context.Context, msg *model.Message) {
 		span.SetAttributes(attribute.String("worker.result", "failed"))
 		span.SetStatus(codes.Error, reason)
 		if err := d.queue.Fail(msg, reason); err != nil {
-			slog.Error("mark failed failed", "component", "worker", "msg_id", msg.ID, "error", err)
+			slog.ErrorContext(ctx, "mark failed failed", "component", "worker", "msg_id", msg.ID, "error", err)
 		}
 		d.metricInc("worker_mark_failed")
 		return
@@ -201,7 +201,7 @@ func (d *Dispatcher) handleMessage(ctx context.Context, msg *model.Message) {
 	)
 	span.SetStatus(codes.Error, reason)
 	if err := d.queue.Retry(msg, delay, reason); err != nil {
-		slog.Error("retry schedule failed", "component", "worker", "msg_id", msg.ID, "error", err)
+		slog.ErrorContext(ctx, "retry schedule failed", "component", "worker", "msg_id", msg.ID, "error", err)
 	}
 	d.metricInc("worker_retry_scheduled")
 }
@@ -215,7 +215,7 @@ func (d *Dispatcher) emitHardBounceDSN(ctx context.Context, msg *model.Message, 
 		return
 	}
 	if err := d.queue.Enqueue(dsnMsg); err != nil {
-		slog.Error("enqueue hard dsn failed", "component", "worker", "msg_id", msg.ID, "rcpt", logging.MaskEmail(rcpt), "error", err)
+		slog.ErrorContext(ctx, "enqueue hard dsn failed", "component", "worker", "msg_id", msg.ID, "rcpt", logging.MaskEmail(rcpt), "error", err)
 	}
 }
 
@@ -232,7 +232,7 @@ func (d *Dispatcher) emitSoftBounceDSN(ctx context.Context, msg *model.Message, 
 		return
 	}
 	if err := d.queue.Enqueue(dsnMsg); err != nil {
-		slog.Error("enqueue soft dsn failed", "component", "worker", "msg_id", msg.ID, "rcpt", logging.MaskEmail(rcpt), "error", err)
+		slog.ErrorContext(ctx, "enqueue soft dsn failed", "component", "worker", "msg_id", msg.ID, "rcpt", logging.MaskEmail(rcpt), "error", err)
 	}
 }
 


### PR DESCRIPTION
## 概要
- slog handler に trace_id / span_id の自動付与を追加
- SMTP / worker の文脈付きログを WarnContext / ErrorContext ベースに更新
- observability ドキュメントに log 相関の説明を追記

## 関連 Issue
- Closes #207

## 確認内容
- [x] go test ./...
- [x] git diff --check

## 補足
- .codex は未追跡のローカルファイルのため含めていません
