### PR TITLE
docs: OTEL tutorial を Grafana と Tempo に切り替え

### DIFF
--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -9,7 +9,7 @@
 | Tutorial | 何を確認するか | 主な環境 |
 | --- | --- | --- |
 | [最小メールフローを試す](/tutorials/basic-mail-flow) | SMTP で 1 通受信し、local queue に入るところ | `kuroshio` + `smtp-client` |
-| [OTEL Tracing を試す](/tutorials/otel-tracing) | OTLP/HTTP で Collector に trace を送り、Jaeger で見る | `kuroshio` + `otel-collector` + `jaeger` |
+| [OTEL Tracing を試す](/tutorials/otel-tracing) | OTLP/HTTP で Collector に trace を送り、Grafana で見る | `kuroshio` + `otel-collector` + `tempo` + `grafana` |
 | [Rate Limit を試す](/tutorials/rate-limit) | 接続元 IP や `MAIL FROM` 単位の制限 | `kuroshio` + `smtp-client` |
 | [Admin API を試す](/tutorials/admin-operations) | queue 操作と Admin API / CLI | `kuroshio` + `smtp-client` |
 | [メール認証を試す](/tutorials/mail-auth) | SPF / DMARC 評価、DKIM / ARC 署名 | `CoreDNS` + `policy` + `tester` |

--- a/docs/tutorials/otel-tracing.md
+++ b/docs/tutorials/otel-tracing.md
@@ -1,13 +1,13 @@
 # OTEL Tracing を試す
 
-`kuroshio-mta` の OpenTelemetry tracing を、`OTLP/HTTP -> OpenTelemetry Collector -> Jaeger` の最小構成で確認する tutorial です。
+`kuroshio-mta` の OpenTelemetry tracing を、`OTLP/HTTP -> OpenTelemetry Collector -> Tempo -> Grafana` の最小構成で確認する tutorial です。
 
-この tutorial では、SMTP で 1 通受けたときの trace を Collector 経由で Jaeger に送り、UI と API の両方から確認します。
+この tutorial では、SMTP で 1 通受けたときの trace を Collector 経由で Tempo に送り、Grafana から確認します。
 
 ## 前提
 
 - Docker と `docker compose` が使えること
-- ローカルで `:2525`、`:9090`、`:16686`、`:4318` を使えること
+- ローカルで `:2525`、`:9090`、`:3000`、`:3200`、`:4318` を使えること
 
 使う compose 一式は [examples/tutorials/otel-tracing](https://github.com/tamago0224/kuroshio-mta/tree/main/examples/tutorials/otel-tracing) にあります。
 
@@ -15,8 +15,9 @@
 
 - `kuroshio`: tutorial 用の MTA 本体
 - `smtp-client`: SMTP セッション投入用の補助コンテナ
-- `otel-collector`: OTLP/HTTP receiver と Jaeger 向け exporter
-- `jaeger`: trace 可視化用 UI
+- `otel-collector`: OTLP/HTTP receiver と Tempo 向け exporter
+- `tempo`: trace 保存先
+- `grafana`: trace 可視化用 UI
 
 ## 1. compose を起動する
 
@@ -52,16 +53,16 @@ EOF
 
 `delivery_mode: local_spool` にしているので、外部配送先は不要です。
 
-## 3. Jaeger UI で trace を見る
+## 3. Grafana で trace を見る
 
-ブラウザで `http://127.0.0.1:16686` を開き、`Service` に `kuroshio-mta` を選びます。
+ブラウザで `http://127.0.0.1:3000` を開き、左メニューから `Explore` を開きます。
 
-最新 trace がまだ見えないときは、`Lookback` を広げて `Find Traces` を押してください。
+datasource は provisioning 済みなので、最初から `Tempo` が使えます。`Search` タブで `Service Name` に `kuroshio-mta` を指定し、最新 trace を探してください。
 
-CLI から確認するなら次でも service 一覧を見られます。
+Tempo の到達性だけ先に確認するなら次を使います。
 
 ```bash
-curl http://127.0.0.1:16686/api/services
+curl http://127.0.0.1:3200/ready
 ```
 
 ## 4. Collector 側で受信も確認する

--- a/examples/tutorials/otel-tracing/collector-config.yaml
+++ b/examples/tutorials/otel-tracing/collector-config.yaml
@@ -9,12 +9,14 @@ processors:
 
 exporters:
   debug: {}
-  otlphttp/jaeger:
-    endpoint: http://jaeger:4318
+  otlphttp/tempo:
+    endpoint: http://tempo:4318
+    tls:
+      insecure: true
 
 service:
   pipelines:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [debug, otlphttp/jaeger]
+      exporters: [debug, otlphttp/tempo]

--- a/examples/tutorials/otel-tracing/compose.yaml
+++ b/examples/tutorials/otel-tracing/compose.yaml
@@ -23,11 +23,28 @@ services:
     ports:
       - "4318:4318"
     volumes:
-      - ./otel-collector-config.yaml:/etc/otelcol/config.yaml:ro
+      - ./collector-config.yaml:/etc/otelcol/config.yaml:ro
     depends_on:
-      - jaeger
+      - tempo
 
-  jaeger:
-    image: cr.jaegertracing.io/jaegertracing/jaeger:2.17.0
+  tempo:
+    image: grafana/tempo:latest
+    command: ["-config.file=/etc/tempo.yaml"]
+    volumes:
+      - ./tempo.yaml:/etc/tempo.yaml:ro
     ports:
-      - "16686:16686"
+      - "3200:3200"
+      - "4319:4318"
+
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    environment:
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
+      GF_AUTH_DISABLE_LOGIN_FORM: "true"
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+    depends_on:
+      - tempo

--- a/examples/tutorials/otel-tracing/grafana/provisioning/datasources/datasources.yaml
+++ b/examples/tutorials/otel-tracing/grafana/provisioning/datasources/datasources.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:3200
+    isDefault: true
+    editable: false

--- a/examples/tutorials/otel-tracing/tempo.yaml
+++ b/examples/tutorials/otel-tracing/tempo.yaml
@@ -1,0 +1,29 @@
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        http:
+          endpoint: 0.0.0.0:4318
+
+ingester:
+  max_block_duration: 5m
+
+compactor:
+  compaction:
+    block_retention: 24h
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /tmp/tempo/blocks
+    wal:
+      path: /tmp/tempo/wal
+
+overrides:
+  defaults:
+    metrics_generator:
+      processors: []


### PR DESCRIPTION
## 概要
- OTEL tracing tutorial の可視化先を Jaeger から Grafana + Tempo に変更
- Collector の export 先と tutorial 文面を Grafana stack 前提に更新
- tutorial 一覧の説明も Grafana / Tempo 構成に合わせて更新

## 確認内容
- npm run docs:build
- docker compose -f examples/tutorials/otel-tracing/compose.yaml config
- git diff --check

## 補足
- 今回は trace 可視化を Grafana stack に寄せる変更で、Prometheus や Loki の追加までは行っていません
