### PR TITLE
docs: Grafana Loki で trace と log の相関 tutorial を追加

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -46,6 +46,7 @@ export default defineConfig({
           { text: "Tutorials Home", link: "/tutorials/" },
           { text: "Basic Mail Flow", link: "/tutorials/basic-mail-flow" },
           { text: "OTEL Tracing", link: "/tutorials/otel-tracing" },
+          { text: "Trace / Log Correlation", link: "/tutorials/otel-logs-loki" },
           { text: "Mail Authentication", link: "/tutorials/mail-auth" },
           { text: "TLS Delivery Policies", link: "/tutorials/tls-policy" },
           { text: "Rate Limit Tutorial", link: "/tutorials/rate-limit" },

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -10,6 +10,7 @@
 | --- | --- | --- |
 | [最小メールフローを試す](/tutorials/basic-mail-flow) | SMTP で 1 通受信し、local queue に入るところ | `kuroshio` + `smtp-client` |
 | [OTEL Tracing を試す](/tutorials/otel-tracing) | OTLP/HTTP で Collector に trace を送り、Grafana で見る | `kuroshio` + `otel-collector` + `tempo` + `grafana` |
+| [Grafana で trace と log を紐づける](/tutorials/otel-logs-loki) | `trace_id` / `span_id` を使って Tempo と Loki を往復する | `kuroshio` + `tempo` + `loki` + `promtail` + `grafana` |
 | [Rate Limit を試す](/tutorials/rate-limit) | 接続元 IP や `MAIL FROM` 単位の制限 | `kuroshio` + `smtp-client` |
 | [Admin API を試す](/tutorials/admin-operations) | queue 操作と Admin API / CLI | `kuroshio` + `smtp-client` |
 | [メール認証を試す](/tutorials/mail-auth) | SPF / DMARC 評価、DKIM / ARC 署名 | `CoreDNS` + `policy` + `tester` |
@@ -28,5 +29,6 @@
 1. [Getting Started](/getting-started) で最初の起動方法を確認する
 2. [最小メールフローを試す](/tutorials/basic-mail-flow) で 1 通受ける
 3. [OTEL Tracing を試す](/tutorials/otel-tracing) で trace の見え方を確認する
-4. [Rate Limit を試す](/tutorials/rate-limit) と [Admin API を試す](/tutorials/admin-operations) で運用系を見る
-5. [メール認証を試す](/tutorials/mail-auth) と [TLS 配送ポリシーを試す](/tutorials/tls-policy) で DNS / policy 系を確認する
+4. [Grafana で trace と log を紐づける](/tutorials/otel-logs-loki) で trace とログの相関を見る
+5. [Rate Limit を試す](/tutorials/rate-limit) と [Admin API を試す](/tutorials/admin-operations) で運用系を見る
+6. [メール認証を試す](/tutorials/mail-auth) と [TLS 配送ポリシーを試す](/tutorials/tls-policy) で DNS / policy 系を確認する

--- a/docs/tutorials/otel-logs-loki.md
+++ b/docs/tutorials/otel-logs-loki.md
@@ -1,0 +1,118 @@
+# Grafana で trace と log を紐づける
+
+`kuroshio-mta` の JSON ログには、OpenTelemetry tracing を有効にすると `trace_id` と `span_id` が入ります。
+
+この tutorial では、[OTEL Tracing を試す](/tutorials/otel-tracing) と同じ compose 環境に `Loki` と `Promtail` を追加し、Grafana 上で trace と log を相互に辿れるようにします。
+
+## 前提
+
+- Docker と `docker compose` が使えること
+- ローカルで `:3000`、`:3100`、`:3200`、`:4318` を使えること
+- 先に [OTEL Tracing を試す](/tutorials/otel-tracing) を一度読んでおくと流れを追いやすいです
+
+使う compose 一式は [examples/tutorials/otel-tracing](https://github.com/tamago0224/kuroshio-mta/tree/main/examples/tutorials/otel-tracing) にあります。
+
+## 起動するもの
+
+- `kuroshio`: JSON ログと trace を出す MTA 本体
+- `otel-collector`: trace を Tempo に送る Collector
+- `tempo`: trace 保存先
+- `loki`: log 保存先
+- `promtail`: Docker logs を Loki に送る agent
+- `grafana`: trace / log の UI
+
+## 1. compose を起動する
+
+```bash
+docker compose -f examples/tutorials/otel-tracing/compose.yaml up --build -d
+```
+
+この compose では Grafana datasource を provisioning 済みです。
+
+- `Tempo`: trace 用
+- `Loki`: log 用
+
+加えて、次の相関設定も入っています。
+
+- `Tempo -> Loki`: trace から同じ `trace_id` のログを検索
+- `Loki -> Tempo`: ログ中の `trace_id` から trace を開く
+
+## 2. trace と log を発生させる
+
+```bash
+docker compose -f examples/tutorials/otel-tracing/compose.yaml exec smtp-client sh -lc '
+cat <<EOF | nc kuroshio 2525
+EHLO tutorial.local
+MAIL FROM:<sender@example.com>
+RCPT TO:<recipient@example.net>
+DATA
+Subject: trace-log tutorial
+
+link trace and logs
+.
+QUIT
+EOF
+'
+```
+
+## 3. Loki にログが入っているか確認する
+
+まず Loki の readiness を確認します。
+
+```bash
+curl http://127.0.0.1:3100/ready
+```
+
+Promtail が `kuroshio` コンテナを拾えているかは次で見られます。
+
+```bash
+docker compose -f examples/tutorials/otel-tracing/compose.yaml logs promtail
+```
+
+## 4. Grafana Explore でログを見る
+
+ブラウザで `http://127.0.0.1:3000` を開き、`Explore` で datasource に `Loki` を選びます。
+
+次のような query で `kuroshio` のログを絞れます。
+
+```text
+{compose_service="kuroshio"}
+```
+
+ログ詳細を見ると、JSON フィールドとして `trace_id` と `span_id` が含まれます。
+
+## 5. log から trace を開く
+
+Loki datasource には derived field を設定してあるので、`trace_id` を含むログ行から `Tempo` の trace へ直接移動できます。
+
+Grafana のログ詳細で `TraceID` リンクが見えたら、それを開いて trace を確認してください。
+
+## 6. trace から対応ログを開く
+
+今度は datasource を `Tempo` に切り替えて、`Service Name = kuroshio-mta` で trace を検索します。
+
+trace 詳細画面では `Logs for this span` 相当のリンクから、同じ `trace_id` を持つ Loki ログへ移動できます。
+
+## 7. 何が紐づいているのか
+
+この tutorial の相関は、アプリ側で埋め込まれた `trace_id` / `span_id` に依存しています。
+
+実装上は [internal/logging/otel_handler.go](https://github.com/tamago0224/kuroshio-mta/blob/main/internal/logging/otel_handler.go) で、`InfoContext` / `WarnContext` / `ErrorContext` 経由の JSON ログに `trace_id` と `span_id` を追加しています。
+
+## 8. 後片付け
+
+```bash
+docker compose -f examples/tutorials/otel-tracing/compose.yaml down
+```
+
+生成された queue / spool を消したい場合だけ次を実行します。
+
+```bash
+rm -rf examples/tutorials/otel-tracing/var
+```
+
+## 関連
+
+- [OTEL Tracing を試す](/tutorials/otel-tracing)
+- [Observability](/observability)
+- [Tutorials Home](/tutorials/)

--- a/examples/tutorials/otel-tracing/compose.yaml
+++ b/examples/tutorials/otel-tracing/compose.yaml
@@ -36,6 +36,23 @@ services:
       - "3200:3200"
       - "4319:4318"
 
+  loki:
+    image: grafana/loki:latest
+    command: ["-config.file=/etc/loki/local-config.yaml"]
+    volumes:
+      - ./loki.yaml:/etc/loki/local-config.yaml:ro
+    ports:
+      - "3100:3100"
+
+  promtail:
+    image: grafana/promtail:latest
+    command: ["-config.file=/etc/promtail/config.yml"]
+    volumes:
+      - ./promtail.yaml:/etc/promtail/config.yml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    depends_on:
+      - loki
+
   grafana:
     image: grafana/grafana:latest
     ports:
@@ -48,3 +65,4 @@ services:
       - ./grafana/provisioning:/etc/grafana/provisioning:ro
     depends_on:
       - tempo
+      - loki

--- a/examples/tutorials/otel-tracing/grafana/provisioning/datasources/datasources.yaml
+++ b/examples/tutorials/otel-tracing/grafana/provisioning/datasources/datasources.yaml
@@ -2,8 +2,28 @@ apiVersion: 1
 
 datasources:
   - name: Tempo
+    uid: tempo
     type: tempo
     access: proxy
     url: http://tempo:3200
     isDefault: true
     editable: false
+    jsonData:
+      tracesToLogsV2:
+        datasourceUid: loki
+        filterByTraceID: true
+        spanStartTimeShift: "-5m"
+        spanEndTimeShift: "5m"
+
+  - name: Loki
+    uid: loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: false
+    jsonData:
+      derivedFields:
+        - name: TraceID
+          matcherRegex: '"trace_id":"([a-f0-9]{32})"'
+          datasourceUid: tempo
+          url: "$${__value.raw}"

--- a/examples/tutorials/otel-tracing/loki.yaml
+++ b/examples/tutorials/otel-tracing/loki.yaml
@@ -1,0 +1,28 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /tmp/loki
+  storage:
+    filesystem:
+      chunks_directory: /tmp/loki/chunks
+      rules_directory: /tmp/loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  allow_structured_metadata: false

--- a/examples/tutorials/otel-tracing/promtail.yaml
+++ b/examples/tutorials/otel-tracing/promtail.yaml
@@ -1,0 +1,34 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    relabel_configs:
+      - source_labels: ["__meta_docker_container_label_com_docker_compose_service"]
+        regex: kuroshio
+        action: keep
+      - source_labels: ["__meta_docker_container_name"]
+        target_label: container
+      - source_labels: ["__meta_docker_container_label_com_docker_compose_project"]
+        target_label: compose_project
+      - source_labels: ["__meta_docker_container_label_com_docker_compose_service"]
+        target_label: compose_service
+      - source_labels: ["__meta_docker_container_log_stream"]
+        target_label: stream
+    pipeline_stages:
+      - docker: {}
+      - json:
+          expressions:
+            level: level
+            trace_id: trace_id
+            span_id: span_id


### PR DESCRIPTION
## 概要
- Grafana / Tempo / Loki / Promtail を使って trace と log を相互に辿る tutorial を追加
- OTEL tutorial 用 compose に Loki と Promtail を追加
- Grafana datasource provisioning に Tempo / Loki 相関設定を追加

## 確認内容
- npm run docs:build
- docker compose -f examples/tutorials/otel-tracing/compose.yaml config
- git diff --check

## 補足
- この環境では compose の構文確認までで、実際のコンテナ起動までは未実施
