### PR TITLE
feat: SMTP コマンド単位の OTEL span を追加

### DIFF
--- a/internal/smtp/server.go
+++ b/internal/smtp/server.go
@@ -176,7 +176,7 @@ func (s *Server) handleConnWithContext(ctx context.Context, conn net.Conn) {
 	if remoteIP != nil {
 		spanAttrs = append(spanAttrs, attribute.String("smtp.remote_ip", remoteIP.String()))
 	}
-	_, span := smtpTracer.Start(ctx, "smtp.session", trace.WithAttributes(spanAttrs...))
+	sessionCtx, span := smtpTracer.Start(ctx, "smtp.session", trace.WithAttributes(spanAttrs...))
 	defer span.End()
 
 	var (
@@ -301,48 +301,79 @@ func (s *Server) handleConnWithContext(ctx context.Context, conn net.Conn) {
 			ss.data = nil
 			writeResp(w, 250, s.cfg.Hostname)
 		case "MAIL":
+			_, cmdSpan := startSMTPCommandSpan(sessionCtx, "smtp.mail")
 			if !ss.seenHelo {
+				cmdSpan.setResponse(503, "send EHLO/HELO first")
+				cmdSpan.end()
 				writeResp(w, 503, "send EHLO/HELO first")
 				continue
 			}
 			if s.submission && s.cfg.SubmissionAuth && !ss.authOK {
+				cmdSpan.reject("auth_required", 530, "authentication required")
+				cmdSpan.end()
 				writeResp(w, 530, "authentication required")
 				continue
 			}
 			mailArgs, err := parseMailFrom(arg)
 			if err != nil {
+				cmdSpan.recordError(err)
 				if errors.Is(err, errSMTPUTF8Address) {
+					cmdSpan.reject("smtputf8_address", 553, err.Error())
+					cmdSpan.end()
 					writeResp(w, 553, err.Error())
 					continue
 				}
 				if errors.Is(err, errSMTPUTF8Param) {
+					cmdSpan.reject("smtputf8_parameter", 555, err.Error())
+					cmdSpan.end()
 					writeResp(w, 555, err.Error())
 					continue
 				}
 				if errors.Is(err, errMailParamUnsupported) {
+					cmdSpan.reject("unsupported_parameter", 555, err.Error())
+					cmdSpan.end()
 					writeResp(w, 555, err.Error())
 					continue
 				}
+				cmdSpan.setResponse(501, err.Error())
+				cmdSpan.end()
 				writeResp(w, 501, err.Error())
 				continue
 			}
+			cmdSpan.SetAttributes(
+				attribute.String("smtp.mail_from", logging.MaskEmail(mailArgs.Address)),
+				attribute.Bool("smtp.mail.has_size", mailArgs.HasSize),
+				attribute.String("smtp.mail.body_mode", mailArgs.Body),
+			)
+			if mailArgs.HasSize {
+				cmdSpan.SetAttributes(attribute.Int64("smtp.mail.size", mailArgs.Size))
+			}
 			if !ss.extended && (mailArgs.HasSize || mailArgs.Body != "") {
+				cmdSpan.reject("mail_params_require_ehlo", 555, "MAIL parameters require EHLO")
+				cmdSpan.end()
 				writeResp(w, 555, "MAIL parameters require EHLO")
 				continue
 			}
 			if mailArgs.HasSize && mailArgs.Size > s.cfg.MaxMessageBytes {
+				cmdSpan.reject("message_too_large", 552, "message size exceeds fixed maximum message size")
+				cmdSpan.end()
 				writeResp(w, 552, "message size exceeds fixed maximum message size")
 				continue
 			}
 			if s.submission && s.cfg.SubmissionSenderID && ss.authOK && !senderAllowedForAuth(ss.authUser, mailArgs.Address) {
+				cmdSpan.reject("sender_not_allowed_for_auth", 553, "sender address rejected for authenticated identity")
+				cmdSpan.end()
 				writeResp(w, 553, "sender address rejected for authenticated identity")
 				continue
 			}
 			if remoteIP != nil && s.flexLimiter != nil {
 				allowed, err := s.flexLimiter.Allow("mailfrom", remoteIP.String(), ss.helo, mailArgs.Address, time.Now().UTC())
 				if err != nil {
+					cmdSpan.recordError(err)
 					slog.WarnContext(ctx, "rate limit store error", "component", "smtp", "error", err, "remote_ip", remoteIP.String(), "event", "mailfrom", "helo", ss.helo, "mail_from", logging.MaskEmail(mailArgs.Address))
 				} else if !allowed {
+					cmdSpan.reject("rate_rule_mailfrom", 421, "rate limit exceeded, try again later")
+					cmdSpan.end()
 					s.metricInc("smtp_reject_rate_limit")
 					slog.WarnContext(ctx, "ingress rejected", "component", "smtp", "reason", "rate_rule_mailfrom", "remote_ip", remoteIP.String(), "helo", ss.helo, "mail_from", logging.MaskEmail(mailArgs.Address))
 					writeResp(w, 421, "rate limit exceeded, try again later")
@@ -356,46 +387,81 @@ func (s *Server) handleConnWithContext(ctx context.Context, conn net.Conn) {
 			}
 			ss.rcptTo = nil
 			ss.data = nil
+			cmdSpan.setResponse(250, "sender ok")
+			cmdSpan.end()
 			writeResp(w, 250, "sender ok")
 		case "RCPT":
+			_, cmdSpan := startSMTPCommandSpan(sessionCtx, "smtp.rcpt")
 			if ss.mailFrom == "" {
+				cmdSpan.setResponse(503, "send MAIL FROM first")
+				cmdSpan.end()
 				writeResp(w, 503, "send MAIL FROM first")
 				continue
 			}
 			addr, err := parseRcptTo(arg, s.cfg.Hostname)
 			if err != nil {
+				cmdSpan.recordError(err)
 				if errors.Is(err, errSMTPUTF8Address) {
+					cmdSpan.reject("smtputf8_address", 553, err.Error())
+					cmdSpan.end()
 					writeResp(w, 553, err.Error())
 					continue
 				}
 				if strings.Contains(strings.ToLower(err.Error()), "parameters") {
+					cmdSpan.reject("unsupported_parameters", 555, err.Error())
+					cmdSpan.end()
 					writeResp(w, 555, err.Error())
 				} else {
+					cmdSpan.setResponse(501, err.Error())
+					cmdSpan.end()
 					writeResp(w, 501, err.Error())
 				}
 				continue
 			}
+			cmdSpan.SetAttributes(attribute.String("smtp.rcpt_to", logging.MaskEmail(addr)))
 			ss.rcptTo = append(ss.rcptTo, addr)
+			cmdSpan.setResponse(250, "recipient ok")
+			cmdSpan.end()
 			writeResp(w, 250, "recipient ok")
 		case "DATA":
+			_, cmdSpan := startSMTPCommandSpan(
+				sessionCtx,
+				"smtp.data",
+				attribute.Int("smtp.rcpt_count", len(ss.rcptTo)),
+				attribute.String("smtp.body_mode", ss.bodyMode),
+				attribute.String("smtp.mail_from", logging.MaskEmail(ss.mailFrom)),
+			)
 			if len(ss.rcptTo) == 0 {
+				cmdSpan.setResponse(503, "need RCPT TO before DATA")
+				cmdSpan.end()
 				writeResp(w, 503, "need RCPT TO before DATA")
 				continue
 			}
+			cmdSpan.addEvent("smtp.data.ready")
 			writeResp(w, 354, "end with <CRLF>.<CRLF>")
 			data, err := readData(r, s.cfg.MaxMessageBytes)
 			if err != nil {
+				cmdSpan.recordError(err)
 				switch {
 				case errors.Is(err, errDataLineTooLong):
+					cmdSpan.reject("data_line_too_long", 500, "line too long")
+					cmdSpan.end()
 					writeResp(w, 500, "line too long")
 				case errors.Is(err, errMessageTooLarge):
+					cmdSpan.reject("message_too_large", 552, "message size exceeds fixed maximum message size")
+					cmdSpan.end()
 					writeResp(w, 552, "message size exceeds fixed maximum message size")
 				default:
+					cmdSpan.setResponse(451, "temporary local problem")
+					cmdSpan.end()
 					writeResp(w, 451, "temporary local problem")
 				}
 				continue
 			}
+			cmdSpan.SetAttributes(attribute.Int("smtp.data.bytes", len(data)))
 			if !strings.EqualFold(ss.bodyMode, "8BITMIME") && contains8Bit(data) {
+				cmdSpan.reject("body_requires_8bitmime", 554, "8-bit data is not permitted without BODY=8BITMIME")
+				cmdSpan.end()
 				writeResp(w, 554, "8-bit data is not permitted without BODY=8BITMIME")
 				ss.mailFrom = ""
 				ss.rcptTo = nil
@@ -413,8 +479,15 @@ func (s *Server) handleConnWithContext(ctx context.Context, conn net.Conn) {
 				ARCFailureMode: s.cfg.ARCFailurePolicy,
 			})
 			s.metricAuthResult(authRes)
+			cmdSpan.SetAttributes(
+				attribute.String("smtp.auth.action", string(authRes.Action)),
+				attribute.String("smtp.auth.dmarc.result", authRes.DMARC.Result),
+				attribute.String("smtp.auth.dmarc.policy", authRes.DMARC.Policy),
+			)
 			switch authRes.Action {
 			case mailauth.ActionReject:
+				cmdSpan.reject("auth_policy_reject", 550, "message rejected by auth policy")
+				cmdSpan.end()
 				writeResp(w, 550, "message rejected by auth policy")
 				ss.mailFrom = ""
 				ss.rcptTo = nil
@@ -429,6 +502,9 @@ func (s *Server) handleConnWithContext(ctx context.Context, conn net.Conn) {
 			}
 			id, err := newID()
 			if err != nil {
+				cmdSpan.recordError(err)
+				cmdSpan.setResponse(451, "temporary local problem")
+				cmdSpan.end()
 				writeResp(w, 451, "temporary local problem")
 				continue
 			}
@@ -436,6 +512,10 @@ func (s *Server) handleConnWithContext(ctx context.Context, conn net.Conn) {
 			ss.data = mailauth.InjectHeaders(ss.data, []string{received})
 
 			if err := s.enqueue(ss, id); err != nil {
+				cmdSpan.recordError(err)
+				cmdSpan.SetAttributes(attribute.String("smtp.message_id", id))
+				cmdSpan.setResponse(451, "temporary local problem")
+				cmdSpan.end()
 				slog.Error("enqueue failed", "component", "smtp", "error", err, "msg_id", id, "remote_ip", ipString(msgRemoteIP))
 				s.metricInc("smtp_enqueue_fail")
 				writeResp(w, 451, "temporary local problem")
@@ -443,6 +523,9 @@ func (s *Server) handleConnWithContext(ctx context.Context, conn net.Conn) {
 			}
 			s.enqueueDMARCReports(authRes, ss.mailFrom, id, time.Now().UTC())
 			s.metricInc("smtp_queued_messages")
+			cmdSpan.SetAttributes(attribute.String("smtp.message_id", id))
+			cmdSpan.setResponse(250, "queued")
+			cmdSpan.end()
 			writeResp(w, 250, "queued")
 			ss.mailFrom = ""
 			ss.rcptTo = nil
@@ -454,29 +537,49 @@ func (s *Server) handleConnWithContext(ctx context.Context, conn net.Conn) {
 			ss.data = nil
 			writeResp(w, 250, "reset state")
 		case "AUTH":
+			mech, _ := authMechanism(arg)
+			_, cmdSpan := startSMTPCommandSpan(sessionCtx, "smtp.auth", attribute.String("smtp.auth.mechanism", mech))
 			if !s.submission {
+				cmdSpan.setResponse(502, "AUTH is not supported")
+				cmdSpan.end()
 				writeResp(w, 502, "AUTH is not supported")
 				continue
 			}
 			if !ss.extended {
+				cmdSpan.setResponse(503, "send EHLO first")
+				cmdSpan.end()
 				writeResp(w, 503, "send EHLO first")
 				continue
 			}
 			if s.authBackend == nil {
+				cmdSpan.setResponse(454, "authentication backend unavailable")
+				cmdSpan.end()
 				writeResp(w, 454, "authentication backend unavailable")
 				continue
 			}
 			user, ok, err := s.handleAuth(r, w, arg)
 			if err != nil {
+				cmdSpan.recordError(err)
+				cmdSpan.setResponse(501, err.Error())
+				cmdSpan.end()
 				writeResp(w, 501, err.Error())
 				continue
 			}
 			if !ok {
+				cmdSpan.SetAttributes(attribute.Bool("smtp.auth.success", false))
+				cmdSpan.reject("invalid_credentials", 535, "authentication credentials invalid")
+				cmdSpan.end()
 				writeResp(w, 535, "authentication credentials invalid")
 				continue
 			}
 			ss.authUser = user
 			ss.authOK = true
+			cmdSpan.SetAttributes(
+				attribute.Bool("smtp.auth.success", true),
+				attribute.String("smtp.auth.user", logging.MaskEmail(user)),
+			)
+			cmdSpan.setResponse(235, "authentication successful")
+			cmdSpan.end()
 			writeResp(w, 235, "authentication successful")
 		case "NOOP":
 			writeResp(w, 250, "ok")
@@ -494,17 +597,24 @@ func (s *Server) handleConnWithContext(ctx context.Context, conn net.Conn) {
 			writeResp(w, 221, "bye")
 			return
 		case "STARTTLS":
+			_, cmdSpan := startSMTPCommandSpan(sessionCtx, "smtp.starttls")
 			if ss.tls {
+				cmdSpan.setResponse(503, "already using TLS")
+				cmdSpan.end()
 				writeResp(w, 503, "already using TLS")
 				continue
 			}
 			if s.tlsConfig == nil {
+				cmdSpan.setResponse(454, "TLS not available due to temporary reason")
+				cmdSpan.end()
 				writeResp(w, 454, "TLS not available due to temporary reason")
 				continue
 			}
 			writeResp(w, 220, "Ready to start TLS")
 			tlsConn := tls.Server(conn, s.tlsConfig)
 			if err := tlsConn.Handshake(); err != nil {
+				cmdSpan.recordError(err)
+				cmdSpan.end()
 				return
 			}
 			conn = tlsConn
@@ -520,6 +630,9 @@ func (s *Server) handleConnWithContext(ctx context.Context, conn net.Conn) {
 			ss.data = nil
 			ss.authUser = ""
 			ss.authOK = false
+			cmdSpan.SetAttributes(attribute.Bool("smtp.tls", true))
+			cmdSpan.setResponse(220, "Ready to start TLS")
+			cmdSpan.end()
 		default:
 			writeResp(w, 500, "unsupported command")
 		}
@@ -536,6 +649,45 @@ func (s *Server) metricAuthResult(res mailauth.Result) {
 	s.metricInc("smtp_auth_action_" + sanitizeMetricToken(string(res.Action)))
 	s.metricInc("smtp_auth_dmarc_result_" + sanitizeMetricToken(res.DMARC.Result))
 	s.metricInc("smtp_auth_dmarc_policy_" + sanitizeMetricToken(res.DMARC.Policy))
+}
+
+type smtpCommandSpan struct {
+	trace.Span
+}
+
+func startSMTPCommandSpan(ctx context.Context, name string, attrs ...attribute.KeyValue) (context.Context, *smtpCommandSpan) {
+	cmdCtx, span := smtpTracer.Start(ctx, name, trace.WithAttributes(attrs...))
+	return cmdCtx, &smtpCommandSpan{Span: span}
+}
+
+func (s *smtpCommandSpan) setResponse(code int, message string) {
+	s.SetAttributes(attribute.Int("smtp.response.code", code))
+	if code >= 400 {
+		s.SetStatus(codes.Error, message)
+		return
+	}
+	s.SetStatus(codes.Ok, message)
+}
+
+func (s *smtpCommandSpan) reject(reason string, code int, message string) {
+	s.SetAttributes(attribute.String("smtp.reject_reason", reason))
+	s.AddEvent("smtp.reject", trace.WithAttributes(attribute.String("smtp.reject_reason", reason)))
+	s.setResponse(code, message)
+}
+
+func (s *smtpCommandSpan) recordError(err error) {
+	if err == nil {
+		return
+	}
+	s.RecordError(err)
+}
+
+func (s *smtpCommandSpan) addEvent(name string, attrs ...attribute.KeyValue) {
+	s.AddEvent(name, trace.WithAttributes(attrs...))
+}
+
+func (s *smtpCommandSpan) end() {
+	s.End()
 }
 
 func (s *Server) enqueue(ss *session, id string) error {
@@ -943,6 +1095,14 @@ func decodeAuthPlain(payload string) (string, string, error) {
 
 func decodeBase64Line(v string) ([]byte, error) {
 	return base64.StdEncoding.DecodeString(strings.TrimSpace(v))
+}
+
+func authMechanism(arg string) (string, bool) {
+	parts := strings.Fields(strings.TrimSpace(arg))
+	if len(parts) == 0 {
+		return "", false
+	}
+	return strings.ToUpper(parts[0]), true
 }
 
 func senderAllowedForAuth(authUser, mailFrom string) bool {

--- a/internal/smtp/server_trace_test.go
+++ b/internal/smtp/server_trace_test.go
@@ -1,0 +1,306 @@
+package smtp
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/tamago0224/kuroshio-mta/internal/config"
+	"github.com/tamago0224/kuroshio-mta/internal/mailauth"
+	"github.com/tamago0224/kuroshio-mta/internal/userauth"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestSMTPTracingCapturesMailRcptAndDataSpans(t *testing.T) {
+	origEval := evaluateAuthWithPolicy
+	evaluateAuthWithPolicy = func(_ net.IP, _, _ string, _ []byte, _ mailauth.SPFPolicy) mailauth.Result {
+		return mailauth.Result{Action: mailauth.ActionAccept}
+	}
+	defer func() {
+		evaluateAuthWithPolicy = origEval
+	}()
+
+	exp := setupSMTPTraceExporter(t)
+	q := &recordingQueue{}
+	s := &Server{cfg: config.Config{Hostname: "mx.example.test", MaxMessageBytes: 1024 * 1024}, queue: q}
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	go s.handleConn(server)
+
+	r := bufio.NewReader(client)
+	w := bufio.NewWriter(client)
+	_, _ = readSMTPResponse(t, r)
+
+	mustWriteSMTPLine(t, w, "EHLO client.example")
+	_, _ = readSMTPResponse(t, r)
+	mustWriteSMTPLine(t, w, "MAIL FROM:<alice@example.com> BODY=8BITMIME")
+	_, mailCode := readSMTPResponse(t, r)
+	if mailCode != 250 {
+		t.Fatalf("mail code=%d want=250", mailCode)
+	}
+	mustWriteSMTPLine(t, w, "RCPT TO:<bob@example.net>")
+	_, rcptCode := readSMTPResponse(t, r)
+	if rcptCode != 250 {
+		t.Fatalf("rcpt code=%d want=250", rcptCode)
+	}
+	mustWriteSMTPLine(t, w, "DATA")
+	_, dataCode := readSMTPResponse(t, r)
+	if dataCode != 354 {
+		t.Fatalf("data prompt code=%d want=354", dataCode)
+	}
+	if _, err := w.WriteString("Subject: trace\r\n\r\nhello\r\n.\r\n"); err != nil {
+		t.Fatalf("write data: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("flush data: %v", err)
+	}
+	_, queuedCode := readSMTPResponse(t, r)
+	if queuedCode != 250 {
+		t.Fatalf("queued code=%d want=250", queuedCode)
+	}
+	mustWriteSMTPLine(t, w, "QUIT")
+	_, quitCode := readSMTPResponse(t, r)
+	if quitCode != 221 {
+		t.Fatalf("quit code=%d want=221", quitCode)
+	}
+
+	spans := waitForSpans(t, exp, "smtp.session", "smtp.mail", "smtp.rcpt", "smtp.data")
+	session := requireSpan(t, spans, "smtp.session")
+	mail := requireSpan(t, spans, "smtp.mail")
+	rcpt := requireSpan(t, spans, "smtp.rcpt")
+	data := requireSpan(t, spans, "smtp.data")
+
+	if mail.Parent.SpanID() != session.SpanContext.SpanID() {
+		t.Fatalf("mail parent=%s want session=%s", mail.Parent.SpanID(), session.SpanContext.SpanID())
+	}
+	if rcpt.Parent.SpanID() != session.SpanContext.SpanID() {
+		t.Fatalf("rcpt parent=%s want session=%s", rcpt.Parent.SpanID(), session.SpanContext.SpanID())
+	}
+	if data.Parent.SpanID() != session.SpanContext.SpanID() {
+		t.Fatalf("data parent=%s want session=%s", data.Parent.SpanID(), session.SpanContext.SpanID())
+	}
+	if got := attrString(t, mail.Attributes, "smtp.mail_from"); got == "" {
+		t.Fatal("smtp.mail_from should be recorded on smtp.mail span")
+	}
+	if got := attrString(t, rcpt.Attributes, "smtp.rcpt_to"); got == "" {
+		t.Fatal("smtp.rcpt_to should be recorded on smtp.rcpt span")
+	}
+	if got := attrInt64(t, data.Attributes, "smtp.response.code"); got != 250 {
+		t.Fatalf("smtp.data response code=%d want=250", got)
+	}
+	if got := attrInt64(t, data.Attributes, "smtp.data.bytes"); got <= 0 {
+		t.Fatalf("smtp.data bytes=%d want > 0", got)
+	}
+	if got := attrString(t, data.Attributes, "smtp.auth.action"); got != string(mailauth.ActionAccept) {
+		t.Fatalf("smtp.auth.action=%q want=%q", got, mailauth.ActionAccept)
+	}
+}
+
+func TestSMTPTracingCapturesAuthSpan(t *testing.T) {
+	exp := setupSMTPTraceExporter(t)
+	authBackend, err := userauth.NewStatic("alice@example.com:s3cr3t")
+	if err != nil {
+		t.Fatalf("NewStatic: %v", err)
+	}
+	s := NewSubmissionServer(
+		config.Config{
+			Hostname:           "mx.example.test",
+			SubmissionAddr:     "127.0.0.1:587",
+			SubmissionAuth:     true,
+			SubmissionSenderID: true,
+		},
+		&recordingQueue{},
+		nil,
+		authBackend,
+	)
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	go s.handleConn(server)
+
+	r := bufio.NewReader(client)
+	w := bufio.NewWriter(client)
+	_, _ = readSMTPResponse(t, r)
+
+	mustWriteSMTPLine(t, w, "EHLO client.example")
+	_, _ = readSMTPResponse(t, r)
+	mustWriteSMTPLine(t, w, "AUTH PLAIN AGFsaWNlQGV4YW1wbGUuY29tAHMzY3IzdA==")
+	_, code := readSMTPResponse(t, r)
+	if code != 235 {
+		t.Fatalf("auth code=%d want=235", code)
+	}
+	mustWriteSMTPLine(t, w, "QUIT")
+	_, quitCode := readSMTPResponse(t, r)
+	if quitCode != 221 {
+		t.Fatalf("quit code=%d want=221", quitCode)
+	}
+
+	auth := requireSpan(t, waitForSpans(t, exp, "smtp.auth"), "smtp.auth")
+	if got := attrString(t, auth.Attributes, "smtp.auth.mechanism"); got != "PLAIN" {
+		t.Fatalf("mechanism=%q want=PLAIN", got)
+	}
+	if got := attrString(t, auth.Attributes, "smtp.auth.user"); got == "" {
+		t.Fatal("smtp.auth.user should be recorded on smtp.auth span")
+	}
+	if got := attrBool(t, auth.Attributes, "smtp.auth.success"); !got {
+		t.Fatal("smtp.auth.success should be true")
+	}
+	if got := attrInt64(t, auth.Attributes, "smtp.response.code"); got != 235 {
+		t.Fatalf("smtp.auth response code=%d want=235", got)
+	}
+}
+
+func TestSMTPTracingCapturesStartTLSSpan(t *testing.T) {
+	exp := setupSMTPTraceExporter(t)
+	cert, err := selfSignedCert()
+	if err != nil {
+		t.Fatalf("selfSignedCert: %v", err)
+	}
+	s := &Server{
+		cfg:       config.Config{Hostname: "mx.example.test"},
+		tlsConfig: &tls.Config{Certificates: []tls.Certificate{cert}},
+	}
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	go s.handleConn(server)
+
+	r := bufio.NewReader(client)
+	w := bufio.NewWriter(client)
+	_, _ = readSMTPResponse(t, r)
+
+	mustWriteSMTPLine(t, w, "EHLO client.example")
+	resp, code := readSMTPResponse(t, r)
+	if code != 250 {
+		t.Fatalf("ehlo code=%d want=250", code)
+	}
+	if resp == "" {
+		t.Fatal("ehlo response should not be empty")
+	}
+	mustWriteSMTPLine(t, w, "STARTTLS")
+	_, starttlsCode := readSMTPResponse(t, r)
+	if starttlsCode != 220 {
+		t.Fatalf("starttls code=%d want=220", starttlsCode)
+	}
+
+	tlsClient := tls.Client(client, &tls.Config{InsecureSkipVerify: true})
+	if err := tlsClient.Handshake(); err != nil {
+		t.Fatalf("tls handshake: %v", err)
+	}
+	rt := bufio.NewReader(tlsClient)
+	wt := bufio.NewWriter(tlsClient)
+	mustWriteSMTPLine(t, wt, "QUIT")
+	_, quitCode := readSMTPResponse(t, rt)
+	if quitCode != 221 {
+		t.Fatalf("quit code=%d want=221", quitCode)
+	}
+	_ = tlsClient.Close()
+
+	starttls := requireSpan(t, waitForSpans(t, exp, "smtp.starttls"), "smtp.starttls")
+	if got := attrBool(t, starttls.Attributes, "smtp.tls"); !got {
+		t.Fatal("smtp.tls should be true after STARTTLS")
+	}
+	if got := attrInt64(t, starttls.Attributes, "smtp.response.code"); got != 220 {
+		t.Fatalf("smtp.starttls response code=%d want=220", got)
+	}
+}
+
+func setupSMTPTraceExporter(t *testing.T) *tracetest.InMemoryExporter {
+	t.Helper()
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	prev := otel.GetTracerProvider()
+	prevTracer := smtpTracer
+	otel.SetTracerProvider(tp)
+	smtpTracer = tp.Tracer("github.com/tamago0224/kuroshio-mta/internal/smtp")
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+		otel.SetTracerProvider(prev)
+		smtpTracer = prevTracer
+	})
+	return exp
+}
+
+func requireSpan(t *testing.T, spans tracetest.SpanStubs, name string) tracetest.SpanStub {
+	t.Helper()
+	var names []string
+	for _, span := range spans {
+		names = append(names, span.Name)
+		if span.Name == name {
+			return span
+		}
+	}
+	t.Fatalf("span %q not found; got=%v", name, names)
+	return tracetest.SpanStub{}
+}
+
+func waitForSpans(t *testing.T, exp *tracetest.InMemoryExporter, names ...string) tracetest.SpanStubs {
+	t.Helper()
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for {
+		spans := exp.GetSpans()
+		if hasSpanNames(spans, names...) {
+			return spans
+		}
+		if time.Now().After(deadline) {
+			return spans
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func hasSpanNames(spans tracetest.SpanStubs, names ...string) bool {
+	for _, name := range names {
+		found := false
+		for _, span := range spans {
+			if span.Name == name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func attrString(t *testing.T, attrs []attribute.KeyValue, key string) string {
+	t.Helper()
+	for _, attr := range attrs {
+		if string(attr.Key) == key {
+			return attr.Value.AsString()
+		}
+	}
+	t.Fatalf("attribute %q not found", key)
+	return ""
+}
+
+func attrInt64(t *testing.T, attrs []attribute.KeyValue, key string) int64 {
+	t.Helper()
+	for _, attr := range attrs {
+		if string(attr.Key) == key {
+			return attr.Value.AsInt64()
+		}
+	}
+	t.Fatalf("attribute %q not found", key)
+	return 0
+}
+
+func attrBool(t *testing.T, attrs []attribute.KeyValue, key string) bool {
+	t.Helper()
+	for _, attr := range attrs {
+		if string(attr.Key) == key {
+			return attr.Value.AsBool()
+		}
+	}
+	t.Fatalf("attribute %q not found", key)
+	return false
+}


### PR DESCRIPTION
## Summary
- `smtp.session` の子として `MAIL` / `RCPT` / `DATA` / `AUTH` / `STARTTLS` の command span を追加
- response code、reject reason、主要属性を span に載せて、SMTP セッション内部の流れを追いやすくした
- SMTP セッションを流しながら trace を検証するテストを追加

## Related Issue
- Closes #218

## Validation
- [x] `go test ./internal/smtp`
- [x] `go test ./...`
- [x] `git diff --check`

## TDD Checklist
- [ ] Red: failing test was added first
- [x] Green: SMTP trace 用テストを追加し、最小実装で通した
- [x] Refactor: span 補助を小さくまとめて既存 session span を維持した