### PR TITLE
feat: queue から delivery までの trace 伝播を改善

### DIFF
--- a/internal/model/message.go
+++ b/internal/model/message.go
@@ -11,6 +11,8 @@ type Message struct {
 	MailFrom    string    `json:"mail_from"`
 	RcptTo      []string  `json:"rcpt_to"`
 	Data        []byte    `json:"data"`
+	TraceParent string    `json:"trace_parent,omitempty"`
+	TraceState  string    `json:"trace_state,omitempty"`
 	Attempts    int       `json:"attempts"`
 	NextAttempt time.Time `json:"next_attempt"`
 	LastError   string    `json:"last_error"`

--- a/internal/observability/trace_message.go
+++ b/internal/observability/trace_message.go
@@ -1,0 +1,62 @@
+package observability
+
+import (
+	"context"
+
+	"github.com/tamago0224/kuroshio-mta/internal/model"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+func InjectTraceContext(ctx context.Context, msg *model.Message) {
+	if msg == nil {
+		return
+	}
+	carrier := messageCarrier{msg: msg}
+	otel.GetTextMapPropagator().Inject(ctx, carrier)
+}
+
+func ExtractTraceContext(ctx context.Context, msg *model.Message) context.Context {
+	if msg == nil {
+		return ctx
+	}
+	carrier := messageCarrier{msg: msg}
+	return otel.GetTextMapPropagator().Extract(ctx, carrier)
+}
+
+type messageCarrier struct {
+	msg *model.Message
+}
+
+func (c messageCarrier) Get(key string) string {
+	switch key {
+	case "traceparent":
+		return c.msg.TraceParent
+	case "tracestate":
+		return c.msg.TraceState
+	default:
+		return ""
+	}
+}
+
+func (c messageCarrier) Set(key, value string) {
+	switch key {
+	case "traceparent":
+		c.msg.TraceParent = value
+	case "tracestate":
+		c.msg.TraceState = value
+	}
+}
+
+func (c messageCarrier) Keys() []string {
+	keys := make([]string, 0, 2)
+	if c.msg.TraceParent != "" {
+		keys = append(keys, "traceparent")
+	}
+	if c.msg.TraceState != "" {
+		keys = append(keys, "tracestate")
+	}
+	return keys
+}
+
+var _ propagation.TextMapCarrier = messageCarrier{}

--- a/internal/queue/otel.go
+++ b/internal/queue/otel.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/tamago0224/kuroshio-mta/internal/model"
+	"github.com/tamago0224/kuroshio-mta/internal/observability"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -64,7 +65,14 @@ func (b *observedBackend) AckSent(id string, msg *model.Message) error {
 
 func (b *observedBackend) Retry(msg *model.Message, delay time.Duration, reason string) error {
 	_, span := b.startSpan(context.Background(), "queue.retry", msg)
-	span.SetAttributes(attribute.String("queue.retry_delay", delay.String()))
+	span.SetAttributes(
+		attribute.String("queue.retry_delay", delay.String()),
+		attribute.String("queue.reason", reason),
+	)
+	span.AddEvent("queue.retry_scheduled", trace.WithAttributes(
+		attribute.String("queue.reason", reason),
+		attribute.String("queue.retry_delay", delay.String()),
+	))
 	defer span.End()
 
 	err := b.next.Retry(msg, delay, reason)
@@ -74,6 +82,8 @@ func (b *observedBackend) Retry(msg *model.Message, delay time.Duration, reason 
 
 func (b *observedBackend) Fail(msg *model.Message, reason string) error {
 	_, span := b.startSpan(context.Background(), "queue.fail", msg)
+	span.SetAttributes(attribute.String("queue.reason", reason))
+	span.AddEvent("queue.failed", trace.WithAttributes(attribute.String("queue.reason", reason)))
 	defer span.End()
 
 	err := b.next.Fail(msg, reason)
@@ -95,6 +105,7 @@ func (b *observedBackend) Close() error {
 }
 
 func (b *observedBackend) startSpan(ctx context.Context, name string, msg *model.Message) (context.Context, trace.Span) {
+	ctx = observability.ExtractTraceContext(ctx, msg)
 	attrs := []attribute.KeyValue{
 		attribute.String("queue.backend", b.name),
 	}
@@ -104,6 +115,9 @@ func (b *observedBackend) startSpan(ctx context.Context, name string, msg *model
 			attribute.Int("mail.attempt", msg.Attempts),
 			attribute.Int("mail.rcpt_count", len(msg.RcptTo)),
 		)
+		if msg.LastError != "" {
+			attrs = append(attrs, attribute.String("queue.last_error", msg.LastError))
+		}
 	}
 	return queueTracer.Start(ctx, name, trace.WithAttributes(attrs...))
 }

--- a/internal/queue/otel_trace_test.go
+++ b/internal/queue/otel_trace_test.go
@@ -1,0 +1,123 @@
+package queue
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tamago0224/kuroshio-mta/internal/model"
+	"github.com/tamago0224/kuroshio-mta/internal/observability"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestObservedBackendRetryUsesMessageTraceContext(t *testing.T) {
+	exp, tp, restore := setupQueueTraceExporter(t)
+	defer restore()
+
+	rootCtx, rootSpan := tp.Tracer("test").Start(context.Background(), "root")
+	msg := &model.Message{
+		ID:       "msg-1",
+		RcptTo:   []string{"bob@example.net"},
+		Attempts: 1,
+	}
+	observability.InjectTraceContext(rootCtx, msg)
+	rootSpan.End()
+
+	b := wrapObservedBackend("test", &recordingBackend{})
+	if err := b.Retry(msg, 5*time.Minute, "temporary failure"); err != nil {
+		t.Fatalf("Retry: %v", err)
+	}
+
+	spans := waitForQueueSpans(t, exp, "queue.retry")
+	retry := requireQueueSpan(t, spans, "queue.retry")
+	if retry.Parent.SpanID() != rootSpan.SpanContext().SpanID() {
+		t.Fatalf("queue.retry parent=%s want root=%s", retry.Parent.SpanID(), rootSpan.SpanContext().SpanID())
+	}
+	if got := queueAttrString(t, retry.Attributes, "queue.reason"); got != "temporary failure" {
+		t.Fatalf("queue.reason=%q want=%q", got, "temporary failure")
+	}
+}
+
+type recordingBackend struct{}
+
+func (recordingBackend) Enqueue(*model.Message) error                      { return nil }
+func (recordingBackend) Due(int) ([]*model.Message, error)                 { return nil, nil }
+func (recordingBackend) AckSent(string, *model.Message) error              { return nil }
+func (recordingBackend) Retry(*model.Message, time.Duration, string) error { return nil }
+func (recordingBackend) Fail(*model.Message, string) error                 { return nil }
+func (recordingBackend) Close() error                                      { return nil }
+
+func setupQueueTraceExporter(t *testing.T) (*tracetest.InMemoryExporter, *sdktrace.TracerProvider, func()) {
+	t.Helper()
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	prevProvider := otel.GetTracerProvider()
+	prevPropagator := otel.GetTextMapPropagator()
+	prevQueueTracer := queueTracer
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	queueTracer = tp.Tracer("github.com/tamago0224/kuroshio-mta/internal/queue")
+	return exp, tp, func() {
+		_ = tp.Shutdown(context.Background())
+		otel.SetTracerProvider(prevProvider)
+		otel.SetTextMapPropagator(prevPropagator)
+		queueTracer = prevQueueTracer
+	}
+}
+
+func waitForQueueSpans(t *testing.T, exp *tracetest.InMemoryExporter, names ...string) tracetest.SpanStubs {
+	t.Helper()
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for {
+		spans := exp.GetSpans()
+		if hasQueueSpanNames(spans, names...) {
+			return spans
+		}
+		if time.Now().After(deadline) {
+			return spans
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func hasQueueSpanNames(spans tracetest.SpanStubs, names ...string) bool {
+	for _, name := range names {
+		found := false
+		for _, span := range spans {
+			if span.Name == name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func requireQueueSpan(t *testing.T, spans tracetest.SpanStubs, name string) tracetest.SpanStub {
+	t.Helper()
+	for _, span := range spans {
+		if span.Name == name {
+			return span
+		}
+	}
+	t.Fatalf("span %q not found", name)
+	return tracetest.SpanStub{}
+}
+
+func queueAttrString(t *testing.T, attrs []attribute.KeyValue, key string) string {
+	t.Helper()
+	for _, attr := range attrs {
+		if string(attr.Key) == key {
+			return attr.Value.AsString()
+		}
+	}
+	t.Fatalf("attribute %q not found", key)
+	return ""
+}

--- a/internal/smtp/server.go
+++ b/internal/smtp/server.go
@@ -511,7 +511,7 @@ func (s *Server) handleConnWithContext(ctx context.Context, conn net.Conn) {
 			received := buildReceivedHeader(s.cfg.Hostname, ss.helo, ss.remote, id, time.Now().UTC(), ss.extended, ss.tls)
 			ss.data = mailauth.InjectHeaders(ss.data, []string{received})
 
-			if err := s.enqueue(ss, id); err != nil {
+			if err := s.enqueue(ctx, ss, id); err != nil {
 				cmdSpan.recordError(err)
 				cmdSpan.SetAttributes(attribute.String("smtp.message_id", id))
 				cmdSpan.setResponse(451, "temporary local problem")
@@ -521,7 +521,7 @@ func (s *Server) handleConnWithContext(ctx context.Context, conn net.Conn) {
 				writeResp(w, 451, "temporary local problem")
 				continue
 			}
-			s.enqueueDMARCReports(authRes, ss.mailFrom, id, time.Now().UTC())
+			s.enqueueDMARCReports(ctx, authRes, ss.mailFrom, id, time.Now().UTC())
 			s.metricInc("smtp_queued_messages")
 			cmdSpan.SetAttributes(attribute.String("smtp.message_id", id))
 			cmdSpan.setResponse(250, "queued")
@@ -690,7 +690,7 @@ func (s *smtpCommandSpan) end() {
 	s.End()
 }
 
-func (s *Server) enqueue(ss *session, id string) error {
+func (s *Server) enqueue(ctx context.Context, ss *session, id string) error {
 	msg := &model.Message{
 		ID:         id,
 		RemoteAddr: ss.remote,
@@ -699,10 +699,11 @@ func (s *Server) enqueue(ss *session, id string) error {
 		RcptTo:     append([]string(nil), ss.rcptTo...),
 		Data:       append([]byte(nil), ss.data...),
 	}
+	observability.InjectTraceContext(ctx, msg)
 	return s.queue.Enqueue(msg)
 }
 
-func (s *Server) enqueueDMARCReports(authRes mailauth.Result, mailFrom, msgID string, now time.Time) {
+func (s *Server) enqueueDMARCReports(ctx context.Context, authRes mailauth.Result, mailFrom, msgID string, now time.Time) {
 	if s.submission || s.queue == nil {
 		return
 	}
@@ -729,6 +730,7 @@ func (s *Server) enqueueDMARCReports(authRes mailauth.Result, mailFrom, msgID st
 			RcptTo:     []string{rep.To},
 			Data:       buildReportMessage(reportFrom, rep.To, rep.Subject, rep.Body, id, now),
 		}
+		observability.InjectTraceContext(ctx, msg)
 		if err := s.queue.Enqueue(msg); err != nil {
 			slog.Warn("enqueue dmarc report failed", "component", "smtp", "error", err, "parent_msg_id", msgID, "rcpt", logging.MaskEmail(rep.To))
 			continue

--- a/internal/worker/dispatcher.go
+++ b/internal/worker/dispatcher.go
@@ -20,6 +20,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
 
 type Dispatcher struct {
@@ -88,6 +89,7 @@ func (d *Dispatcher) processBatch(ctx context.Context) error {
 }
 
 func (d *Dispatcher) handleMessage(ctx context.Context, msg *model.Message) {
+	ctx = observability.ExtractTraceContext(ctx, msg)
 	ctx, span := workerTracer.Start(ctx, "worker.handle_message")
 	span.SetAttributes(
 		attribute.String("mail.message_id", msg.ID),
@@ -95,6 +97,7 @@ func (d *Dispatcher) handleMessage(ctx context.Context, msg *model.Message) {
 		attribute.Int("mail.rcpt_count", len(msg.RcptTo)),
 	)
 	defer span.End()
+	observability.InjectTraceContext(ctx, msg)
 
 	var (
 		errs    []error
@@ -171,6 +174,7 @@ func (d *Dispatcher) handleMessage(ctx context.Context, msg *model.Message) {
 
 	if len(errs) == 0 {
 		span.SetAttributes(attribute.String("worker.result", "sent"))
+		span.AddEvent("worker.ack_sent")
 		if err := d.queue.AckSent(msg.ID, msg); err != nil {
 			slog.ErrorContext(ctx, "ack sent failed", "component", "worker", "msg_id", msg.ID, "error", err)
 		}
@@ -184,6 +188,7 @@ func (d *Dispatcher) handleMessage(ctx context.Context, msg *model.Message) {
 			span.RecordError(joined)
 		}
 		span.SetAttributes(attribute.String("worker.result", "failed"))
+		span.AddEvent("worker.failed", trace.WithAttributes(attribute.String("worker.reason", reason)))
 		span.SetStatus(codes.Error, reason)
 		if err := d.queue.Fail(msg, reason); err != nil {
 			slog.ErrorContext(ctx, "mark failed failed", "component", "worker", "msg_id", msg.ID, "error", err)
@@ -199,6 +204,10 @@ func (d *Dispatcher) handleMessage(ctx context.Context, msg *model.Message) {
 		attribute.String("worker.result", "retry"),
 		attribute.String("worker.retry_delay", delay.String()),
 	)
+	span.AddEvent("worker.retry_scheduled", trace.WithAttributes(
+		attribute.String("worker.reason", reason),
+		attribute.String("worker.retry_delay", delay.String()),
+	))
 	span.SetStatus(codes.Error, reason)
 	if err := d.queue.Retry(msg, delay, reason); err != nil {
 		slog.ErrorContext(ctx, "retry schedule failed", "component", "worker", "msg_id", msg.ID, "error", err)
@@ -214,6 +223,7 @@ func (d *Dispatcher) emitHardBounceDSN(ctx context.Context, msg *model.Message, 
 	if err != nil {
 		return
 	}
+	observability.InjectTraceContext(ctx, dsnMsg)
 	if err := d.queue.Enqueue(dsnMsg); err != nil {
 		slog.ErrorContext(ctx, "enqueue hard dsn failed", "component", "worker", "msg_id", msg.ID, "rcpt", logging.MaskEmail(rcpt), "error", err)
 	}
@@ -231,6 +241,7 @@ func (d *Dispatcher) emitSoftBounceDSN(ctx context.Context, msg *model.Message, 
 	if err != nil {
 		return
 	}
+	observability.InjectTraceContext(ctx, dsnMsg)
 	if err := d.queue.Enqueue(dsnMsg); err != nil {
 		slog.ErrorContext(ctx, "enqueue soft dsn failed", "component", "worker", "msg_id", msg.ID, "rcpt", logging.MaskEmail(rcpt), "error", err)
 	}

--- a/internal/worker/dispatcher_trace_test.go
+++ b/internal/worker/dispatcher_trace_test.go
@@ -1,0 +1,148 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/tamago0224/kuroshio-mta/internal/config"
+	"github.com/tamago0224/kuroshio-mta/internal/delivery"
+	"github.com/tamago0224/kuroshio-mta/internal/model"
+	"github.com/tamago0224/kuroshio-mta/internal/observability"
+	"github.com/tamago0224/kuroshio-mta/internal/queue"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestHandleMessagePropagatesTraceThroughRetry(t *testing.T) {
+	exp, tp, restore := setupWorkerTraceExporter(t)
+	defer restore()
+
+	queueDir := t.TempDir()
+	backend, err := queue.NewBackend(config.Config{QueueDir: queueDir})
+	if err != nil {
+		t.Fatalf("NewBackend: %v", err)
+	}
+
+	rootCtx, rootSpan := tp.Tracer("test").Start(context.Background(), "root")
+	msg := &model.Message{
+		ID:         "msg-1",
+		RemoteAddr: "127.0.0.1:2525",
+		Helo:       "client.example",
+		MailFrom:   "alice@example.com",
+		RcptTo:     []string{"bob@example.net"},
+		Data:       []byte("Subject: trace\r\n\r\nhello\r\n"),
+	}
+	observability.InjectTraceContext(rootCtx, msg)
+	originalTraceParent := msg.TraceParent
+	if err := backend.Enqueue(msg); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+
+	d := &Dispatcher{
+		cfg:   config.Config{},
+		queue: backend,
+		cl:    delivery.NewClient(config.Config{DeliveryMode: "relay"}),
+	}
+	d.handleMessage(context.Background(), msg)
+	rootSpan.End()
+
+	spans := waitForWorkerSpans(t, exp, "worker.handle_message")
+	workerSpan := requireWorkerSpan(t, spans, "worker.handle_message")
+
+	if workerSpan.Parent.SpanID() != rootSpan.SpanContext().SpanID() {
+		t.Fatalf("worker parent=%s want root=%s", workerSpan.Parent.SpanID(), rootSpan.SpanContext().SpanID())
+	}
+
+	stored := readStoredMessage(t, filepath.Join(queueDir, "mail.retry", "msg-1.json"))
+	if stored.TraceParent == "" {
+		t.Fatal("stored retry message should keep trace_parent")
+	}
+	if stored.TraceParent == originalTraceParent {
+		t.Fatal("stored retry message should update trace_parent to worker span context")
+	}
+	storedCtx := observability.ExtractTraceContext(context.Background(), &stored)
+	storedSpanCtx := trace.SpanContextFromContext(storedCtx)
+	if storedSpanCtx.SpanID() != workerSpan.SpanContext.SpanID() {
+		t.Fatalf("stored span=%s want worker=%s", storedSpanCtx.SpanID(), workerSpan.SpanContext.SpanID())
+	}
+}
+
+func setupWorkerTraceExporter(t *testing.T) (*tracetest.InMemoryExporter, *sdktrace.TracerProvider, func()) {
+	t.Helper()
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	prevProvider := otel.GetTracerProvider()
+	prevPropagator := otel.GetTextMapPropagator()
+	prevWorkerTracer := workerTracer
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	workerTracer = tp.Tracer("github.com/tamago0224/kuroshio-mta/internal/worker")
+	return exp, tp, func() {
+		_ = tp.Shutdown(context.Background())
+		otel.SetTracerProvider(prevProvider)
+		otel.SetTextMapPropagator(prevPropagator)
+		workerTracer = prevWorkerTracer
+	}
+}
+
+func waitForWorkerSpans(t *testing.T, exp *tracetest.InMemoryExporter, names ...string) tracetest.SpanStubs {
+	t.Helper()
+	deadline := time.Now().Add(300 * time.Millisecond)
+	for {
+		spans := exp.GetSpans()
+		if hasWorkerSpanNames(spans, names...) {
+			return spans
+		}
+		if time.Now().After(deadline) {
+			return spans
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func hasWorkerSpanNames(spans tracetest.SpanStubs, names ...string) bool {
+	for _, name := range names {
+		found := false
+		for _, span := range spans {
+			if span.Name == name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func requireWorkerSpan(t *testing.T, spans tracetest.SpanStubs, name string) tracetest.SpanStub {
+	t.Helper()
+	for _, span := range spans {
+		if span.Name == name {
+			return span
+		}
+	}
+	t.Fatalf("span %q not found", name)
+	return tracetest.SpanStub{}
+}
+
+func readStoredMessage(t *testing.T, path string) model.Message {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", path, err)
+	}
+	var msg model.Message
+	if err := json.Unmarshal(b, &msg); err != nil {
+		t.Fatalf("Unmarshal(%s): %v", path, err)
+	}
+	return msg
+}


### PR DESCRIPTION
## Summary
- `model.Message` に trace context を保持して、queue 保存後も trace を再開できるようにした
- queue span は message の trace context から親を引き継ぎ、retry / fail に reason event を追加
- worker は message から trace を再開し、retry 用に最新の span context を message へ戻すようにした
- queue / worker の trace 伝播テストを追加した

## Related Issue
- Closes #219

## Validation
- [x] `go test ./internal/queue ./internal/worker ./internal/smtp ./internal/observability`
- [x] `go test ./...`
- [x] `git diff --check`

## TDD Checklist
- [ ] Red: failing test was added first
- [x] Green: queue / worker の trace 伝播を検証するテストを追加して実装を通した
- [x] Refactor: trace context の保存・再開 helper を observability に切り出した