### PR TITLE
docs: observability stack guide を追加

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -34,6 +34,7 @@ export default defineConfig({
         text: "Guide",
         items: [
           { text: "Configuration", link: "/configuration" },
+          { text: "Observability Stack", link: "/observability_stack" },
           { text: "Observability", link: "/observability" },
           { text: "S3 Spool Backend", link: "/s3_spool_backend" },
           { text: "Rate Limit", link: "/rate_limit" },

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -58,6 +58,7 @@ compose ベースの tutorial 一覧は [Tutorials](/tutorials/) にまとめて
 ## 6. 次に読む Guide
 
 - 設定全体: [Configuration](/configuration)
+- 全体像: [Observability Stack](/observability_stack)
 - 観測系: [Observability](/observability)
 - 受信制御: [Rate Limit](/rate_limit)
 - S3-compatible 保存先: [S3 Spool Backend](/s3_spool_backend)

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ features:
   - title: 機能チュートリアル
     details: 最小メールフロー、メール認証、TLS 配送、Rate Limit、Admin API など主要機能を `docker compose` で順に試せます。
   - title: 設定と運用
-    details: YAML ベースの設定、Observability、Rate Limit、Kafka Queue モード、Admin API や SLO runbook までまとめて参照できます。
+    details: YAML ベースの設定、Observability Stack、Rate Limit、Kafka Queue モード、Admin API や SLO runbook までまとめて参照できます。
   - title: RFC 対応状況
     details: SMTP、STARTTLS、SPF、DKIM、DMARC、ARC、MTA-STS、DANE などの実装範囲とギャップを追えます。
   - title: 設計メモ
@@ -43,6 +43,7 @@ features:
 - [Rate Limit を試す](/tutorials/rate-limit)
 - [Admin API を試す](/tutorials/admin-operations)
 - [設定ガイド](/configuration)
+- [Observability Stack](/observability_stack)
 - [Observability](/observability)
 - [S3 Spool Backend](/s3_spool_backend)
 - [Rate Limit](/rate_limit)

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -2,7 +2,10 @@
 
 `kuroshio-mta` の observability は、`Prometheus` 形式の metrics、`/slo` の JSON レポート、`slog` による JSON ログを中心に構成しています。加えて、現在は OpenTelemetry tracing を OTLP/HTTP exporter 経由で有効化できます。
 
-このページでは、今ある観測手段と OpenTelemetry (`OTEL`) との関係を整理します。
+このページでは、`kuroshio-mta` 自身が今どんな signal を出しているかを整理します。
+
+Alloy / Tempo / Loki / Grafana を含む stack 全体の見取り図は
+[Observability Stack](/observability_stack) を参照してください。
 
 ## 現在あるもの
 
@@ -107,12 +110,14 @@ tutorial から試すなら次を入口にしてください。
 
 - [最小メールフローを試す](/tutorials/basic-mail-flow)
 - [OTEL Tracing を試す](/tutorials/otel-tracing)
+- [Grafana で trace と log を紐づける](/tutorials/otel-logs-loki)
 - [Rate Limit を試す](/tutorials/rate-limit)
 - [Admin API を試す](/tutorials/admin-operations)
 
 ## 関連ドキュメント
 
 - [Configuration](/configuration)
+- [Observability Stack](/observability_stack)
 - [SLO Delivery](/runbooks/slo_delivery)
 - [SLO Retry](/runbooks/slo_retry)
 - [HA Reference](/architecture/ha_reference)

--- a/docs/observability_stack.md
+++ b/docs/observability_stack.md
@@ -1,0 +1,158 @@
+# Observability Stack
+
+`kuroshio-mta` の observability は、1 つの製品や 1 つの protocol だけで完結しているわけではありません。
+
+いまの構成は大きく分けると次の 3 層です。
+
+- `kuroshio-mta` 自身が出す signal
+- signal を受け取って転送する collector / agent
+- signal を保存して可視化する backend / UI
+
+このページでは、`Alloy`、`Tempo`、`Loki`、`Grafana`、そして `kuroshio-mta` 自身の役割をまとめます。
+
+## 全体像
+
+最小構成のイメージは次です。
+
+```text
+kuroshio-mta
+  |- /metrics
+  |- slog JSON logs
+  `- OTLP/HTTP traces
+
+           |
+           v
+        Alloy
+      /       \
+     v         v
+  Tempo      Loki
+     \         /
+      \       /
+       v     v
+        Grafana
+```
+
+signal ごとに言い換えると次の通りです。
+
+- metrics:
+  `kuroshio-mta` が `/metrics` で公開し、Prometheus 互換の取り方で収集する
+- logs:
+  `kuroshio-mta` が `slog` JSON を出し、`trace_id` / `span_id` を含めて Loki へ送る
+- traces:
+  `kuroshio-mta` が OTLP/HTTP で span を出し、Alloy 経由で Tempo へ送る
+
+## 各コンポーネントの役割
+
+### `kuroshio-mta`
+
+観測対象そのものです。
+
+いまの実装で出しているもの:
+
+- `/healthz`
+- `/metrics`
+- `/slo`
+- `/reputation`
+- `slog` JSON logs
+- OpenTelemetry traces
+
+trace では、少なくとも次の流れを追えます。
+
+- SMTP session
+- `MAIL` / `RCPT` / `DATA` / `AUTH` / `STARTTLS`
+- queue の `enqueue` / `due` / `ack` / `retry` / `fail`
+- worker の message 処理
+- delivery の MX / DANE / MTA-STS / SMTP 試行
+
+実装側の signal については [Observability](/observability) を参照してください。
+
+### `Alloy`
+
+`Alloy` は collector / agent の役目です。
+
+この repo の tutorial では、次を Alloy にまとめています。
+
+- OTLP/HTTP で trace を受ける
+- `kuroshio-mta` のログファイルを読む
+- Tempo へ trace を転送する
+- Loki へログを転送する
+
+つまり `Alloy` 自体は可視化 UI ではなく、signal の受け口と中継点です。
+
+### `Tempo`
+
+`Tempo` は trace backend です。
+
+ここに保存された span を、Grafana の Explore から確認します。
+SMTP セッション、queue、worker、delivery の span は Tempo 側でまとまって見えます。
+
+### `Loki`
+
+`Loki` はログ backend です。
+
+`kuroshio-mta` の JSON ログを保存し、`trace_id` / `span_id` を使って trace と相互参照できるようにします。
+
+### `Grafana`
+
+`Grafana` は UI です。
+
+この tutorial では主に次を行います。
+
+- Tempo の trace を見る
+- Loki のログを検索する
+- trace からログへ飛ぶ
+- ログの `trace_id` から trace へ戻る
+
+## 今の `kuroshio-mta` で何をどこで見るか
+
+| 見たいもの | 主な場所 | 役割 |
+| --- | --- | --- |
+| alive / health | `/healthz` | 最小の生存確認 |
+| counters / rates | `/metrics` | Prometheus 互換 metrics |
+| SLO 判定 | `/slo` | backlog / delivery / retry の簡易評価 |
+| 構造化ログ | stdout / file -> Loki | 運用ログとエラー確認 |
+| request / flow trace | OTLP/HTTP -> Tempo | どこで reject / retry / fail したか |
+
+つまり:
+
+- まず数字を見るなら `/metrics`
+- アラート判断の近道は `/slo`
+- 個別の失敗原因は logs
+- 流れ全体は traces
+
+という読み分けです。
+
+## Tutorials との関係
+
+この guide は「全体像」を理解するページです。
+実際に手元で触る手順は tutorial 側にあります。
+
+- trace の基本: [OTEL Tracing を試す](/tutorials/otel-tracing)
+- trace とログの相関: [Grafana で trace と log を紐づける](/tutorials/otel-logs-loki)
+- 基本の SMTP フロー: [最小メールフローを試す](/tutorials/basic-mail-flow)
+
+## ローカル tutorial 構成と本番寄り構成
+
+local tutorial では、できるだけ理解しやすい最小構成を使っています。
+
+- `kuroshio-mta`
+- `Alloy`
+- `Tempo`
+- `Loki`
+- `Grafana`
+
+本番寄りの構成では、次の違いが出ます。
+
+- Grafana / Tempo / Loki を外部サービス化する
+- Alloy を複数ノードに分散する
+- `/metrics` は Prometheus に scrape させる
+- retention、auth、network policy を別途設計する
+
+ただし、signal の役割分担そのものは大きく変わりません。
+
+## まず読む順番
+
+1. `kuroshio-mta` 自身の signal を知る: [Observability](/observability)
+2. stack 全体の役割をつかむ: このページ
+3. 実際に trace を見る: [OTEL Tracing を試す](/tutorials/otel-tracing)
+4. ログ相関を見る: [Grafana で trace と log を紐づける](/tutorials/otel-logs-loki)

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -27,8 +27,9 @@
 ## 進み方のおすすめ
 
 1. [Getting Started](/getting-started) で最初の起動方法を確認する
-2. [最小メールフローを試す](/tutorials/basic-mail-flow) で 1 通受ける
-3. [OTEL Tracing を試す](/tutorials/otel-tracing) で trace の見え方を確認する
-4. [Grafana で trace と log を紐づける](/tutorials/otel-logs-loki) で trace とログの相関を見る
-5. [Rate Limit を試す](/tutorials/rate-limit) と [Admin API を試す](/tutorials/admin-operations) で運用系を見る
-6. [メール認証を試す](/tutorials/mail-auth) と [TLS 配送ポリシーを試す](/tutorials/tls-policy) で DNS / policy 系を確認する
+2. 先に [Observability Stack](/observability_stack) で Alloy / Tempo / Loki / Grafana の役割をつかむ
+3. [最小メールフローを試す](/tutorials/basic-mail-flow) で 1 通受ける
+4. [OTEL Tracing を試す](/tutorials/otel-tracing) で trace の見え方を確認する
+5. [Grafana で trace と log を紐づける](/tutorials/otel-logs-loki) で trace とログの相関を見る
+6. [Rate Limit を試す](/tutorials/rate-limit) と [Admin API を試す](/tutorials/admin-operations) で運用系を見る
+7. [メール認証を試す](/tutorials/mail-auth) と [TLS 配送ポリシーを試す](/tutorials/tls-policy) で DNS / policy 系を確認する


### PR DESCRIPTION
## Summary
- Alloy / Tempo / Loki / Grafana と `kuroshio-mta` の役割分担を説明する `Observability Stack` ガイドを追加
- `Observability` は実装が出している signal の説明に寄せ、stack 全体像は新しい guide に分離
- Getting Started、Tutorials、Docs Home、sidebar から新しい guide へ導線を追加

## Related Issue
- Closes #221

## Validation
- [x] `npm run docs:build`
- [x] `git diff --check`

## TDD Checklist
- [ ] Red: failing test was added first
- [x] Green: docs 構成を最小変更で整理した
- [x] Refactor: guide / observability / tutorial の役割分担を明確にした