### PR TITLE
feat: domain throttle observability を追加

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -68,6 +68,7 @@ OpenTelemetry tracing を有効にしていて、かつ `InfoContext` / `WarnCon
   - SMTP session
   - worker の message 処理
   - queue の enqueue / due / ack / retry / fail
+  - domain throttle の acquire wait と backend fallback event
   - MX lookup
   - DANE lookup
   - MTA-STS lookup
@@ -115,6 +116,21 @@ tutorial から試すなら次を入口にしてください。
 - [Grafana で trace と log を紐づける](/tutorials/otel-logs-loki)
 - [Rate Limit を試す](/tutorials/rate-limit)
 - [Admin API を試す](/tutorials/admin-operations)
+
+## domain throttle の観測
+
+配送側 `domain throttle` では、少なくとも次の signal を見られます。
+
+- metrics:
+  - `worker_domain_throttle_acquire_total`
+  - `worker_domain_throttle_wait_ms_total`
+  - `worker_domain_throttle_backend_error_total`
+- traces:
+  - `domain_throttle.acquire`
+  - `domain_throttle.backend_error`
+
+`domain_throttle_backend: redis` を使っている場合、Redis / Valkey 障害で fail-open に入ると
+`domain_throttle.backend_error` event と `worker_domain_throttle_backend_error_total` が増えます。
 
 ## 関連ドキュメント
 

--- a/internal/worker/dispatcher.go
+++ b/internal/worker/dispatcher.go
@@ -111,7 +111,25 @@ func (d *Dispatcher) handleMessage(ctx context.Context, msg *model.Message) {
 		domain, _ := util.DomainOf(rcpt)
 		release := func() {}
 		if d.throttle != nil {
-			release = d.throttle.acquire(domain)
+			lease := d.throttle.acquire(domain)
+			release = lease.release
+			if lease.waitDuration > 0 {
+				waitMs := lease.waitDuration.Milliseconds()
+				d.metricInc("worker_domain_throttle_acquire")
+				d.metricAdd("worker_domain_throttle_wait_ms", uint64(waitMs))
+				span.AddEvent("domain_throttle.acquire", trace.WithAttributes(
+					attribute.String("mail.domain", domain),
+					attribute.Int64("domain_throttle.wait_ms", waitMs),
+				))
+			}
+			if lease.backendError {
+				d.metricInc("worker_domain_throttle_backend_error")
+				span.AddEvent("domain_throttle.backend_error", trace.WithAttributes(
+					attribute.String("mail.domain", domain),
+					attribute.String("domain_throttle.backend", d.cfg.DomainThrottleBackend),
+					attribute.String("domain_throttle.stage", "acquire"),
+				))
+			}
 		}
 		func() {
 			defer release()
@@ -145,7 +163,14 @@ func (d *Dispatcher) handleMessage(ctx context.Context, msg *model.Message) {
 					}
 					d.emitHardBounceDSN(ctx, msg, rcpt, smtpErr.Error())
 					if d.throttle != nil {
-						d.throttle.observe(domain, false)
+						if d.throttle.observe(domain, false) {
+							d.metricInc("worker_domain_throttle_backend_error")
+							span.AddEvent("domain_throttle.backend_error", trace.WithAttributes(
+								attribute.String("mail.domain", domain),
+								attribute.String("domain_throttle.backend", d.cfg.DomainThrottleBackend),
+								attribute.String("domain_throttle.stage", "observe"),
+							))
+						}
 					}
 					d.metricInc("worker_permanent_bounce")
 					if d.sup != nil {
@@ -161,7 +186,14 @@ func (d *Dispatcher) handleMessage(ctx context.Context, msg *model.Message) {
 				}
 				d.emitSoftBounceDSN(ctx, msg, rcpt, err.Error())
 				if d.throttle != nil {
-					d.throttle.observe(domain, true)
+					if d.throttle.observe(domain, true) {
+						d.metricInc("worker_domain_throttle_backend_error")
+						span.AddEvent("domain_throttle.backend_error", trace.WithAttributes(
+							attribute.String("mail.domain", domain),
+							attribute.String("domain_throttle.backend", d.cfg.DomainThrottleBackend),
+							attribute.String("domain_throttle.stage", "observe"),
+						))
+					}
 				}
 				errs = append(errs, err)
 			} else {
@@ -169,7 +201,14 @@ func (d *Dispatcher) handleMessage(ctx context.Context, msg *model.Message) {
 					d.rep.ObserveDelivery(domain, false, false)
 				}
 				if d.throttle != nil {
-					d.throttle.observe(domain, false)
+					if d.throttle.observe(domain, false) {
+						d.metricInc("worker_domain_throttle_backend_error")
+						span.AddEvent("domain_throttle.backend_error", trace.WithAttributes(
+							attribute.String("mail.domain", domain),
+							attribute.String("domain_throttle.backend", d.cfg.DomainThrottleBackend),
+							attribute.String("domain_throttle.stage", "observe"),
+						))
+					}
 				}
 				d.metricInc("worker_delivery_success")
 			}
@@ -303,5 +342,11 @@ func shouldFail(msg *model.Message, errs []error, cfg config.Config, now time.Ti
 func (d *Dispatcher) metricInc(name string) {
 	if d.m != nil {
 		d.m.Counter(name).Inc()
+	}
+}
+
+func (d *Dispatcher) metricAdd(name string, value uint64) {
+	if d.m != nil {
+		d.m.Counter(name).Add(value)
 	}
 }

--- a/internal/worker/domain_throttle.go
+++ b/internal/worker/domain_throttle.go
@@ -7,8 +7,14 @@ import (
 )
 
 type domainThrottle interface {
-	acquire(domain string) func()
-	observe(domain string, temporaryFailure bool)
+	acquire(domain string) domainThrottleLease
+	observe(domain string, temporaryFailure bool) bool
+}
+
+type domainThrottleLease struct {
+	release      func()
+	waitDuration time.Duration
+	backendError bool
 }
 
 type localDomainThrottle struct {
@@ -48,19 +54,23 @@ func newLocalDomainThrottle(defLimit int, rules map[string]int, adaptive bool, t
 	}
 }
 
-func (d *localDomainThrottle) acquire(domain string) func() {
+func (d *localDomainThrottle) acquire(domain string) domainThrottleLease {
+	started := time.Now()
 	domain = strings.ToLower(strings.TrimSpace(domain))
 	st := d.get(domain)
 	if p := d.currentPenalty(st); p > 0 {
 		time.Sleep(p)
 	}
 	st.sem <- struct{}{}
-	return func() { <-st.sem }
+	return domainThrottleLease{
+		release:      func() { <-st.sem },
+		waitDuration: time.Since(started),
+	}
 }
 
-func (d *localDomainThrottle) observe(domain string, temporaryFailure bool) {
+func (d *localDomainThrottle) observe(domain string, temporaryFailure bool) bool {
 	if !d.adaptive {
-		return
+		return false
 	}
 	domain = strings.ToLower(strings.TrimSpace(domain))
 	st := d.get(domain)
@@ -71,7 +81,7 @@ func (d *localDomainThrottle) observe(domain string, temporaryFailure bool) {
 		st.tempFail++
 	}
 	if st.samples < 20 {
-		return
+		return false
 	}
 	ratio := float64(st.tempFail) / float64(st.samples)
 	if ratio >= d.threshold {
@@ -91,6 +101,7 @@ func (d *localDomainThrottle) observe(domain string, temporaryFailure bool) {
 	}
 	st.samples = 0
 	st.tempFail = 0
+	return false
 }
 
 func (d *localDomainThrottle) get(domain string) *domainState {

--- a/internal/worker/domain_throttle_redis.go
+++ b/internal/worker/domain_throttle_redis.go
@@ -144,8 +144,10 @@ func newRedisDomainThrottle(cfg redisDomainThrottleConfig) (domainThrottle, erro
 	}, nil
 }
 
-func (d *redisDomainThrottle) acquire(domain string) func() {
+func (d *redisDomainThrottle) acquire(domain string) domainThrottleLease {
+	started := time.Now()
 	domain = strings.ToLower(strings.TrimSpace(domain))
+	backendError := false
 	if p := d.currentPenalty(domain); p > 0 {
 		time.Sleep(p)
 	}
@@ -161,32 +163,43 @@ func (d *redisDomainThrottle) acquire(domain string) func() {
 	for {
 		token, err := d.tryAcquire(domain, limit)
 		if err != nil {
+			backendError = true
 			slog.Warn("domain throttle backend error", "component", "worker", "backend", "redis", "domain", domain, "error", err)
-			return func() {}
+			return domainThrottleLease{
+				release:      func() {},
+				waitDuration: time.Since(started),
+				backendError: backendError,
+			}
 		}
 		if token != "" {
-			return func() {
-				if err := d.release(domain, token); err != nil {
-					slog.Warn("domain throttle release failed", "component", "worker", "backend", "redis", "domain", domain, "error", err)
-				}
+			return domainThrottleLease{
+				release: func() {
+					if err := d.release(domain, token); err != nil {
+						slog.Warn("domain throttle release failed", "component", "worker", "backend", "redis", "domain", domain, "error", err)
+					}
+				},
+				waitDuration: time.Since(started),
+				backendError: backendError,
 			}
 		}
 		time.Sleep(redisDomainThrottlePollInterval)
 	}
 }
 
-func (d *redisDomainThrottle) observe(domain string, temporaryFailure bool) {
+func (d *redisDomainThrottle) observe(domain string, temporaryFailure bool) bool {
 	d.penalty.observe(domain, temporaryFailure)
 	if !d.adaptive {
-		return
+		return false
 	}
 	domain = strings.ToLower(strings.TrimSpace(domain))
 	if domain == "" {
-		return
+		return false
 	}
 	if err := d.observeRedis(domain, temporaryFailure); err != nil {
 		slog.Warn("domain throttle observe failed", "component", "worker", "backend", "redis", "domain", domain, "error", err)
+		return true
 	}
+	return false
 }
 
 func (d *redisDomainThrottle) tryAcquire(domain string, limit int) (string, error) {

--- a/internal/worker/domain_throttle_test.go
+++ b/internal/worker/domain_throttle_test.go
@@ -21,14 +21,16 @@ func TestParseDomainRules(t *testing.T) {
 
 func TestDomainThrottleConcurrencyLimit(t *testing.T) {
 	th := newLocalDomainThrottle(1, map[string]int{"gmail.com": 2}, false, 0.3, time.Second)
-	release1 := th.acquire("gmail.com")
-	release2 := th.acquire("gmail.com")
+	lease1 := th.acquire("gmail.com")
+	lease2 := th.acquire("gmail.com")
+	release1 := lease1.release
+	release2 := lease2.release
 
 	var done int32
 	go func() {
-		release3 := th.acquire("gmail.com")
+		lease3 := th.acquire("gmail.com")
 		atomic.StoreInt32(&done, 1)
-		release3()
+		lease3.release()
 	}()
 	time.Sleep(100 * time.Millisecond)
 	if atomic.LoadInt32(&done) != 0 {
@@ -51,6 +53,18 @@ func TestDomainThrottleAdaptivePenalty(t *testing.T) {
 	if p := th.currentPenalty(st); p == 0 {
 		t.Fatal("penalty must increase after high temporary failure ratio")
 	}
+}
+
+func TestLocalDomainThrottleAcquireReportsWaitDuration(t *testing.T) {
+	th := newLocalDomainThrottle(1, nil, false, 0.3, time.Second)
+	lease := th.acquire("example.com")
+	if lease.waitDuration < 0 {
+		t.Fatalf("wait duration must be non-negative: %s", lease.waitDuration)
+	}
+	if lease.backendError {
+		t.Fatal("local throttle should not report backend error")
+	}
+	lease.release()
 }
 
 func TestNewDomainThrottleDefaultsToMemory(t *testing.T) {


### PR DESCRIPTION
## 概要
- domain throttle の acquire wait を worker trace event と metrics から見えるようにした
- Redis / Valkey backend の fallback を trace event と metrics で確認できるようにした
- observability ドキュメントに domain throttle の見方を追記した

## 確認したこと
- go test ./internal/worker ./internal/observability ./cmd/kuroshio
- npm run docs:build
- git diff --check

## 補足
- 追加した metrics は worker_domain_throttle_acquire_total、worker_domain_throttle_wait_ms_total、worker_domain_throttle_backend_error_total
- 追加した trace event は domain_throttle.acquire と domain_throttle.backend_error
- .codex は未追跡のままで PR 差分には含めていません
