### PR TITLE
feat: spool backend の observability を追加

### DIFF
--- a/cmd/kuroshio/main.go
+++ b/cmd/kuroshio/main.go
@@ -75,7 +75,7 @@ func main() {
 		MinSamples:         cfg.ReputationMinSamples,
 	})
 
-	d, err := worker.New(cfg, q, delivery.NewClient(cfg), sup, metrics, rep)
+	d, err := worker.New(cfg, q, delivery.NewClientWithMetrics(cfg, metrics), sup, metrics, rep)
 	if err != nil {
 		fatal("worker init failed", "error", err)
 	}

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -68,6 +68,7 @@ OpenTelemetry tracing を有効にしていて、かつ `InfoContext` / `WarnCon
   - SMTP session
   - worker の message 処理
   - queue の enqueue / due / ack / retry / fail
+  - spool backend への保存
   - domain throttle の acquire wait と backend fallback event
   - MX lookup
   - DANE lookup
@@ -131,6 +132,23 @@ tutorial から試すなら次を入口にしてください。
 
 `domain_throttle_backend: redis` を使っている場合、Redis / Valkey 障害で fail-open に入ると
 `domain_throttle.backend_error` event と `worker_domain_throttle_backend_error_total` が増えます。
+
+## spool backend の観測
+
+`delivery_mode: local_spool` を使っている場合、spool backend 保存では次の signal を見られます。
+
+- metrics:
+  - `delivery_spool_store_total`
+  - `delivery_spool_store_bytes_total`
+  - `delivery_spool_store_error_total`
+  - `delivery_spool_store_local_total`
+  - `delivery_spool_store_s3_total`
+- traces:
+  - `delivery.spool_store`
+
+`spool_backend: s3` を使っているときは、S3-compatible object storage への保存成功や失敗を
+`delivery.spool_store` span と `delivery_spool_store_s3_total` / `delivery_spool_store_s3_error_total`
+で追えます。
 
 ## 関連ドキュメント
 

--- a/docs/s3_spool_backend.md
+++ b/docs/s3_spool_backend.md
@@ -88,6 +88,18 @@ outbound/m123_user_example.net.eml
 - object の一覧取得や再読込はまだ実装していません
 - provider 固有機能には依存していません
 
+## observability
+
+spool 保存自体は observability の対象に入っています。
+
+- metrics:
+  - `delivery_spool_store_total`
+  - `delivery_spool_store_bytes_total`
+  - `delivery_spool_store_s3_total`
+  - `delivery_spool_store_s3_error_total`
+- traces:
+  - `delivery.spool_store`
+
 ## 関連ドキュメント
 
 - 実際に試す: [S3 Spool Backend を観測する](/tutorials/s3-spool-observability)

--- a/docs/tutorials/s3-spool-observability.md
+++ b/docs/tutorials/s3-spool-observability.md
@@ -59,10 +59,17 @@ EOF
 ## 3. metrics を確認する
 
 ```bash
-curl http://127.0.0.1:9090/metrics | head
+curl http://127.0.0.1:9090/metrics | grep delivery_spool_store
 ```
 
-まずは observability endpoint が生きていることを確認します。
+特に次を見ます。
+
+- `delivery_spool_store_total`
+- `delivery_spool_store_bytes_total`
+- `delivery_spool_store_s3_total`
+- `delivery_spool_store_s3_bytes_total`
+
+`delivery_spool_store_s3_total` が増えていれば、S3-compatible backend への保存が成功しています。
 
 ## 4. MinIO に object が入ったことを確認する
 
@@ -94,6 +101,8 @@ docker compose -f examples/tutorials/s3-spool-observability/compose.yaml logs ku
 - 保存結果: MinIO 上の object
 
 の 3 点で backend 切り替え時の挙動を確認できます。
+
+OpenTelemetry を有効化している構成では、`delivery.spool_store` span も trace 上で確認できます。
 
 ## 6. 後片付け
 

--- a/internal/delivery/modes_test.go
+++ b/internal/delivery/modes_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/tamago0224/kuroshio-mta/internal/config"
 	"github.com/tamago0224/kuroshio-mta/internal/model"
+	"github.com/tamago0224/kuroshio-mta/internal/observability"
 )
 
 func TestDeliverLocalSpoolWritesFile(t *testing.T) {
@@ -199,6 +200,75 @@ func TestDeliverS3SpoolStoresObject(t *testing.T) {
 	}
 }
 
+func TestDeliverS3SpoolRecordsMetrics(t *testing.T) {
+	orig := newS3PutObjectClient
+	t.Cleanup(func() { newS3PutObjectClient = orig })
+
+	fake := &fakeS3Client{}
+	newS3PutObjectClient = func(cfg config.Config) (s3PutObjectAPI, error) {
+		return fake, nil
+	}
+
+	metrics := observability.NewMetrics()
+	cfg := config.Config{
+		DeliveryMode:  "local_spool",
+		SpoolBackend:  "s3",
+		SpoolS3Bucket: "mail-spool",
+	}
+	cl := NewClientWithMetrics(cfg, metrics)
+	msg := &model.Message{ID: "m8m", MailFrom: "sender@example.com", Data: []byte("From: sender@example.com\r\n\r\nhello")}
+
+	if err := cl.Deliver(context.Background(), msg, "user@example.net"); err != nil {
+		t.Fatalf("deliver s3 spool with metrics: %v", err)
+	}
+
+	snap := metrics.Snapshot()
+	if snap["delivery_spool_store_total"] != 1 {
+		t.Fatalf("delivery_spool_store_total=%d", snap["delivery_spool_store_total"])
+	}
+	if snap["delivery_spool_store_s3_total"] != 1 {
+		t.Fatalf("delivery_spool_store_s3_total=%d", snap["delivery_spool_store_s3_total"])
+	}
+	if snap["delivery_spool_store_bytes_total"] == 0 {
+		t.Fatal("expected delivery_spool_store_bytes_total to be > 0")
+	}
+	if snap["delivery_spool_store_s3_bytes_total"] == 0 {
+		t.Fatal("expected delivery_spool_store_s3_bytes_total to be > 0")
+	}
+}
+
+func TestDeliverS3SpoolRecordsErrorMetrics(t *testing.T) {
+	orig := newS3PutObjectClient
+	t.Cleanup(func() { newS3PutObjectClient = orig })
+
+	fake := &fakeS3Client{err: errors.New("put failed")}
+	newS3PutObjectClient = func(cfg config.Config) (s3PutObjectAPI, error) {
+		return fake, nil
+	}
+
+	metrics := observability.NewMetrics()
+	cfg := config.Config{
+		DeliveryMode:  "local_spool",
+		SpoolBackend:  "s3",
+		SpoolS3Bucket: "mail-spool",
+	}
+	cl := NewClientWithMetrics(cfg, metrics)
+	msg := &model.Message{ID: "m8e", MailFrom: "sender@example.com", Data: []byte("From: sender@example.com\r\n\r\nhello")}
+
+	err := cl.Deliver(context.Background(), msg, "user@example.net")
+	if err == nil {
+		t.Fatal("expected s3 spool error")
+	}
+
+	snap := metrics.Snapshot()
+	if snap["delivery_spool_store_error_total"] != 1 {
+		t.Fatalf("delivery_spool_store_error_total=%d", snap["delivery_spool_store_error_total"])
+	}
+	if snap["delivery_spool_store_s3_error_total"] != 1 {
+		t.Fatalf("delivery_spool_store_s3_error_total=%d", snap["delivery_spool_store_s3_error_total"])
+	}
+}
+
 func TestDeliverS3SpoolRequiresBucket(t *testing.T) {
 	cfg := config.Config{DeliveryMode: "local_spool", SpoolBackend: "s3"}
 	cl := NewClient(cfg)
@@ -225,9 +295,13 @@ type fakeS3Client struct {
 	contentType string
 	body        []byte
 	metadata    map[string]string
+	err         error
 }
 
 func (f *fakeS3Client) PutObject(_ context.Context, in *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
 	f.bucket = *in.Bucket
 	f.key = *in.Key
 	if in.ContentType != nil {

--- a/internal/delivery/smtp_client.go
+++ b/internal/delivery/smtp_client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/tamago0224/kuroshio-mta/internal/config"
 	"github.com/tamago0224/kuroshio-mta/internal/dkim"
 	"github.com/tamago0224/kuroshio-mta/internal/model"
+	"github.com/tamago0224/kuroshio-mta/internal/observability"
 	"github.com/tamago0224/kuroshio-mta/internal/router"
 	"github.com/tamago0224/kuroshio-mta/internal/util"
 	"go.opentelemetry.io/otel"
@@ -29,13 +30,13 @@ type messageSigner interface {
 }
 
 type spoolBackend interface {
-	Store(*model.Message, string) error
+	Store(context.Context, *model.Message, string) (int, error)
 }
 
-type spoolBackendFunc func(*model.Message, string) error
+type spoolBackendFunc func(context.Context, *model.Message, string) (int, error)
 
-func (f spoolBackendFunc) Store(msg *model.Message, rcpt string) error {
-	return f(msg, rcpt)
+func (f spoolBackendFunc) Store(ctx context.Context, msg *model.Message, rcpt string) (int, error) {
+	return f(ctx, msg, rcpt)
 }
 
 var deliveryTracer = otel.Tracer("github.com/tamago0224/kuroshio-mta/internal/delivery")
@@ -51,14 +52,20 @@ type Client struct {
 	spoolStore                     spoolBackend
 	spoolStoreErr                  error
 	reportMTASTSTestingViolationFn func(context.Context, string, string, string)
+	metrics                        *observability.Metrics
 }
 
 func NewClient(cfg config.Config) *Client {
+	return NewClientWithMetrics(cfg, nil)
+}
+
+func NewClientWithMetrics(cfg config.Config, metrics *observability.Metrics) *Client {
 	c := &Client{
 		cfg:         cfg,
 		dane:        NewDANEResolver(cfg.DialTimeout, nil),
 		mtaSTS:      NewMTASTSResolver(cfg.MTASTSCacheTTL, cfg.MTASTSFetchTimeout, nil),
 		resolveMXFn: router.LookupWithTimeout,
+		metrics:     metrics,
 	}
 	if cfg.DKIMSignDomain != "" || cfg.DKIMSignSelector != "" || cfg.DKIMPrivateKeyFile != "" {
 		if signer, err := dkim.NewFileSigner(cfg.DKIMSignDomain, cfg.DKIMSignSelector, cfg.DKIMPrivateKeyFile, cfg.DKIMSignHeaders); err == nil {
@@ -115,7 +122,7 @@ func (c *Client) Deliver(ctx context.Context, msg *model.Message, rcpt string) e
 			err = errors.New("spool backend is not configured")
 			break
 		}
-		err = c.spoolStore.Store(msg, rcpt)
+		err = c.storeToSpool(ctx, msg, rcpt)
 	case "relay":
 		if strings.TrimSpace(c.cfg.RelayHost) == "" {
 			err = errors.New("relay mode requires MTA_RELAY_HOST")
@@ -145,6 +152,37 @@ func (c *Client) newSpoolBackend() (spoolBackend, error) {
 	default:
 		return nil, fmt.Errorf("unknown spool backend: %s", backend)
 	}
+}
+
+func (c *Client) storeToSpool(ctx context.Context, msg *model.Message, rcpt string) error {
+	backend := strings.ToLower(strings.TrimSpace(c.cfg.SpoolBackend))
+	if backend == "" {
+		backend = "local"
+	}
+	ctx, span := deliveryTracer.Start(ctx, "delivery.spool_store")
+	span.SetAttributes(
+		attribute.String("delivery.spool_backend", backend),
+		attribute.String("mail.message_id", msg.ID),
+	)
+	defer span.End()
+
+	size, err := c.spoolStore.Store(ctx, msg, rcpt)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		c.metricInc("delivery_spool_store_error")
+		c.metricInc("delivery_spool_store_" + backend + "_error")
+		return err
+	}
+
+	span.SetAttributes(attribute.Int("mail.size_bytes", size))
+	c.metricInc("delivery_spool_store")
+	c.metricInc("delivery_spool_store_" + backend)
+	if size > 0 {
+		c.metricAdd("delivery_spool_store_bytes", uint64(size))
+		c.metricAdd("delivery_spool_store_"+backend+"_bytes", uint64(size))
+	}
+	return nil
 }
 
 func (c *Client) deliverByMX(ctx context.Context, msg *model.Message, rcpt string) error {
@@ -400,13 +438,13 @@ func (c *Client) deliverHost(ctx context.Context, host string, port int, msg *mo
 	return nil
 }
 
-func (c *Client) writeLocalSpool(msg *model.Message, rcpt string) error {
+func (c *Client) writeLocalSpool(_ context.Context, msg *model.Message, rcpt string) (int, error) {
 	dir := strings.TrimSpace(c.cfg.LocalSpoolDir)
 	if dir == "" {
 		dir = "./var/spool"
 	}
 	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return err
+		return 0, err
 	}
 	id := strings.TrimSpace(msg.ID)
 	if id == "" {
@@ -416,9 +454,26 @@ func (c *Client) writeLocalSpool(msg *model.Message, rcpt string) error {
 	path := filepath.Join(dir, name)
 	payload, err := c.prepareOutboundData(msg.Data)
 	if err != nil {
-		return err
+		return 0, err
 	}
-	return os.WriteFile(path, payload, 0o644)
+	if err := os.WriteFile(path, payload, 0o644); err != nil {
+		return 0, err
+	}
+	return len(payload), nil
+}
+
+func (c *Client) metricInc(name string) {
+	if c.metrics == nil {
+		return
+	}
+	c.metrics.Counter(name).Inc()
+}
+
+func (c *Client) metricAdd(name string, n uint64) {
+	if c.metrics == nil {
+		return
+	}
+	c.metrics.Counter(name).Add(n)
 }
 
 func sanitizeFilename(v string) string {

--- a/internal/delivery/spool_s3.go
+++ b/internal/delivery/spool_s3.go
@@ -76,11 +76,11 @@ func newS3SpoolStore(cfg config.Config, prepareFn func([]byte) ([]byte, error)) 
 	return &s3SpoolStore{cfg: cfg, client: client, prepareFn: prepareFn}, nil
 }
 
-func (s *s3SpoolStore) Store(msg *model.Message, rcpt string) error {
+func (s *s3SpoolStore) Store(_ context.Context, msg *model.Message, rcpt string) (int, error) {
 	key := spoolObjectKey(s.cfg, msg, rcpt)
 	payload, err := s.prepareFn(msg.Data)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	_, err = s.client.PutObject(context.Background(), &s3.PutObjectInput{
@@ -94,7 +94,10 @@ func (s *s3SpoolStore) Store(msg *model.Message, rcpt string) error {
 		},
 		StorageClass: types.StorageClassStandard,
 	})
-	return err
+	if err != nil {
+		return 0, err
+	}
+	return len(payload), nil
 }
 
 func spoolObjectKey(cfg config.Config, msg *model.Message, rcpt string) string {


### PR DESCRIPTION
## 概要
- spool backend 保存時の trace / metrics を追加
- delivery.spool_store span と spool 保存件数・サイズ・失敗件数の metrics を追加
- S3 spool backend の guide / tutorial / observability docs を更新

Closes #200

## 変更内容
- delivery.NewClientWithMetrics を追加し、delivery 側から metrics を記録できるように変更
- local_spool / spool_backend: s3 の両方で spool 保存時に観測を追加
- S3 spool tutorial で delivery_spool_store 系 metrics を確認できるように更新

## 確認内容
- go test ./internal/delivery ./cmd/kuroshio
- go test ./...
- npm run docs:build
- git diff --check