### PR TITLE
feat: Admin API の hashed token をサポート

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -12,7 +12,7 @@ otel_exporter_otlp_endpoint: http://localhost:4318/v1/traces
 otel_exporter_otlp_insecure: true
 otel_trace_sample_ratio: 1.0
 admin_addr: ":8080"
-admin_tokens: "viewer-token:viewer,operator-token:operator"
+admin_tokens: "sha256=d036bd6d01a1cae081d39a2f8dab751dc042de814fd60df31fcb553170950f29:viewer,sha256=0850123315d21ab90f4f7236408a52ef6dbd6a02a6550e5c10dc73f4d993680e:operator"
 hostname: kuroshio.local
 queue_dir: ./var/queue
 queue_backend: local

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,7 +29,7 @@ go run ./cmd/kuroshio -config ./config.yaml
 | `-` | `MTA_CONFIG_FILE` | unset | 互換用の設定ファイル指定です。通常は起動引数 `-config` を優先して使います |
 | `submission_users` | `MTA_SUBMISSION_USERS` | unset | Submission 認証ユーザーを `user@example.com:password,...` 形式で指定します |
 | `-` | `MTA_SUBMISSION_USERS_FILE` | unset | `MTA_SUBMISSION_USERS` の代わりにファイルから Submission 認証情報を読み込みます |
-| `admin_tokens` | `MTA_ADMIN_TOKENS` | unset | Admin API の Bearer token と role を `token:role,...` 形式で指定します |
+| `admin_tokens` | `MTA_ADMIN_TOKENS` | unset | Admin API の Bearer token と role を `token:role,...` または `sha256=<hex>:role,...` 形式で指定します |
 | `-` | `MTA_ADMIN_TOKENS_FILE` | unset | `MTA_ADMIN_TOKENS` の代わりにファイルから管理トークンを読み込みます |
 
 補足:

--- a/docs/runbooks/admin_api.md
+++ b/docs/runbooks/admin_api.md
@@ -11,9 +11,17 @@ Issue: #36
 ## 有効化
 
 - `MTA_ADMIN_ADDR=:9091`
-- `MTA_ADMIN_TOKENS=viewer-token:viewer,operator-token:operator,admin-token:admin`
+- `MTA_ADMIN_TOKENS=sha256=d036bd6d01a1cae081d39a2f8dab751dc042de814fd60df31fcb553170950f29:viewer,sha256=0850123315d21ab90f4f7236408a52ef6dbd6a02a6550e5c10dc73f4d993680e:operator`
 
-`MTA_ADMIN_TOKENS` は `token:role` のカンマ区切りで指定する。
+`MTA_ADMIN_TOKENS` は `token:role` のカンマ区切り、または `sha256=<hex>:role` のカンマ区切りで指定する。
+短期的には hash 形式を推奨する。
+
+例:
+
+```bash
+printf 'viewer-token' | sha256sum
+printf 'operator-token' | sha256sum
+```
 
 ## 権限
 

--- a/docs/tutorials/admin-operations.md
+++ b/docs/tutorials/admin-operations.md
@@ -25,6 +25,9 @@ token は次を使います。
 - `viewer-token`
 - `operator-token`
 
+設定ファイル側では、これらの token をそのまま平文で置く代わりに
+`sha256=<hex>:role` 形式で hash 保存することもできます。
+
 ## 2. queue に 1 通入れる
 
 ```bash
@@ -66,7 +69,7 @@ scripts/admin/kuroshio_admin.sh requeue dlq msg-1 --dry-run
 
 ```bash
 curl -H 'Authorization: Bearer viewer-token' \
-  http://127.0.0.1:9091/suppressions
+  http://127.0.0.1:9091/api/v1/suppressions
 ```
 
 ## 6. 後片付け

--- a/internal/admin/api.go
+++ b/internal/admin/api.go
@@ -1,6 +1,9 @@
 package admin
 
 import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -32,7 +35,7 @@ type API struct {
 	suppressions *bounce.SuppressionStore
 	queue        queueManager
 	reputation   *reputation.Tracker
-	tokens       map[string]role
+	tokens       tokenStore
 	now          func() time.Time
 }
 
@@ -56,26 +59,47 @@ func (a *API) Handler() http.Handler {
 	return mux
 }
 
-func parseTokens(v string) map[string]role {
-	out := map[string]role{}
+type tokenStore struct {
+	plain  map[string]role
+	hashed []hashedToken
+}
+
+type hashedToken struct {
+	sum  [32]byte
+	role role
+}
+
+func parseTokens(v string) tokenStore {
+	out := tokenStore{plain: map[string]role{}}
 	for _, part := range strings.Split(v, ",") {
 		part = strings.TrimSpace(part)
 		if part == "" {
 			continue
 		}
-		fields := strings.SplitN(part, ":", 2)
-		if len(fields) != 2 {
+		tokenSpec, roleSpec, ok := strings.Cut(part, ":")
+		if !ok {
 			continue
 		}
-		token := strings.TrimSpace(fields[0])
-		r := role(strings.ToLower(strings.TrimSpace(fields[1])))
-		if token == "" {
-			continue
-		}
+		tokenSpec = strings.TrimSpace(tokenSpec)
+		r := role(strings.ToLower(strings.TrimSpace(roleSpec)))
 		switch r {
 		case roleViewer, roleOperator, roleAdmin:
-			out[token] = r
+		default:
+			continue
 		}
+		if tokenSpec == "" {
+			continue
+		}
+		if strings.HasPrefix(strings.ToLower(tokenSpec), "sha256=") {
+			raw := strings.TrimSpace(tokenSpec[len("sha256="):])
+			sum, ok := decodeSHA256Hex(raw)
+			if !ok {
+				continue
+			}
+			out.hashed = append(out.hashed, hashedToken{sum: sum, role: r})
+			continue
+		}
+		out.plain[tokenSpec] = r
 	}
 	return out
 }
@@ -87,12 +111,35 @@ func (a *API) authorize(w http.ResponseWriter, r *http.Request, min role) (role,
 		return "", false
 	}
 	token := strings.TrimSpace(strings.TrimPrefix(header, "Bearer "))
-	got, ok := a.tokens[token]
+	got, ok := a.tokens.lookup(token)
 	if !ok || !roleAllowed(got, min) {
 		http.Error(w, "forbidden", http.StatusForbidden)
 		return "", false
 	}
 	return got, true
+}
+
+func (s tokenStore) lookup(token string) (role, bool) {
+	if got, ok := s.plain[token]; ok {
+		return got, true
+	}
+	sum := sha256.Sum256([]byte(token))
+	for _, hashed := range s.hashed {
+		if subtle.ConstantTimeCompare(sum[:], hashed.sum[:]) == 1 {
+			return hashed.role, true
+		}
+	}
+	return "", false
+}
+
+func decodeSHA256Hex(v string) ([32]byte, bool) {
+	var out [32]byte
+	b, err := hex.DecodeString(v)
+	if err != nil || len(b) != len(out) {
+		return out, false
+	}
+	copy(out[:], b)
+	return out, true
 }
 
 func roleAllowed(got, min role) bool {

--- a/internal/admin/api_test.go
+++ b/internal/admin/api_test.go
@@ -1,6 +1,8 @@
 package admin
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -28,6 +30,38 @@ func TestSuppressionsAPIRequiresBearerToken(t *testing.T) {
 
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("status=%d want=%d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestSuppressionsAPIAcceptsSHA256Token(t *testing.T) {
+	s, err := bounce.NewSuppressionStore(filepath.Join(t.TempDir(), "suppression.json"))
+	if err != nil {
+		t.Fatalf("new suppression store: %v", err)
+	}
+	token := "operator-token"
+	sum := sha256.Sum256([]byte(token))
+	api := NewAPI(s, nil, nil, "sha256="+hex.EncodeToString(sum[:])+":operator")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/suppressions", strings.NewReader(`{"address":"user@example.com","reason":"manual"}`))
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	api.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if !s.IsSuppressed("user@example.com") {
+		t.Fatal("suppression was not added")
+	}
+}
+
+func TestParseTokensSkipsInvalidSHA256Spec(t *testing.T) {
+	store := parseTokens("sha256=not-hex:viewer,viewer-token:viewer")
+	if _, ok := store.lookup("viewer-token"); !ok {
+		t.Fatal("expected plain token to remain available")
+	}
+	if _, ok := store.lookup("not-hex"); ok {
+		t.Fatal("invalid sha256 token spec must be ignored")
 	}
 }
 


### PR DESCRIPTION
## 概要
- Admin API の token 設定で sha256 hash 形式をサポート
- 平文 token 形式との後方互換は維持
- config / runbook / tutorial を hash 形式前提に更新

Part of #196

## 変更内容
- MTA_ADMIN_TOKENS で sha256=<hex>:role を解釈できるように変更
- Bearer token 認証時に plain token と sha256 hash token の両方を照合
- Admin API の unit test を追加
- Admin tutorial の直接 curl 例を現在の API path に修正

## 確認内容
- go test ./internal/admin ./cmd/kuroshio
- go test ./...
- npm run docs:build
- git diff --check