### PR TITLE
feat: Admin 認証 backend interface を追加

### DIFF
--- a/internal/admin/api.go
+++ b/internal/admin/api.go
@@ -1,9 +1,6 @@
 package admin
 
 import (
-	"crypto/sha256"
-	"crypto/subtle"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -35,16 +32,20 @@ type API struct {
 	suppressions *bounce.SuppressionStore
 	queue        queueManager
 	reputation   *reputation.Tracker
-	tokens       tokenStore
+	authBackend  AuthBackend
 	now          func() time.Time
 }
 
 func NewAPI(s *bounce.SuppressionStore, q queueManager, rep *reputation.Tracker, tokenConfig string) *API {
+	return NewAPIWithBackend(s, q, rep, NewConfigTokenBackend(tokenConfig))
+}
+
+func NewAPIWithBackend(s *bounce.SuppressionStore, q queueManager, rep *reputation.Tracker, authBackend AuthBackend) *API {
 	return &API{
 		suppressions: s,
 		queue:        q,
 		reputation:   rep,
-		tokens:       parseTokens(tokenConfig),
+		authBackend:  authBackend,
 		now:          time.Now,
 	}
 }
@@ -59,51 +60,6 @@ func (a *API) Handler() http.Handler {
 	return mux
 }
 
-type tokenStore struct {
-	plain  map[string]role
-	hashed []hashedToken
-}
-
-type hashedToken struct {
-	sum  [32]byte
-	role role
-}
-
-func parseTokens(v string) tokenStore {
-	out := tokenStore{plain: map[string]role{}}
-	for _, part := range strings.Split(v, ",") {
-		part = strings.TrimSpace(part)
-		if part == "" {
-			continue
-		}
-		tokenSpec, roleSpec, ok := strings.Cut(part, ":")
-		if !ok {
-			continue
-		}
-		tokenSpec = strings.TrimSpace(tokenSpec)
-		r := role(strings.ToLower(strings.TrimSpace(roleSpec)))
-		switch r {
-		case roleViewer, roleOperator, roleAdmin:
-		default:
-			continue
-		}
-		if tokenSpec == "" {
-			continue
-		}
-		if strings.HasPrefix(strings.ToLower(tokenSpec), "sha256=") {
-			raw := strings.TrimSpace(tokenSpec[len("sha256="):])
-			sum, ok := decodeSHA256Hex(raw)
-			if !ok {
-				continue
-			}
-			out.hashed = append(out.hashed, hashedToken{sum: sum, role: r})
-			continue
-		}
-		out.plain[tokenSpec] = r
-	}
-	return out
-}
-
 func (a *API) authorize(w http.ResponseWriter, r *http.Request, min role) (role, bool) {
 	header := strings.TrimSpace(r.Header.Get("Authorization"))
 	if !strings.HasPrefix(header, "Bearer ") {
@@ -111,35 +67,12 @@ func (a *API) authorize(w http.ResponseWriter, r *http.Request, min role) (role,
 		return "", false
 	}
 	token := strings.TrimSpace(strings.TrimPrefix(header, "Bearer "))
-	got, ok := a.tokens.lookup(token)
-	if !ok || !roleAllowed(got, min) {
+	principal, ok := a.authBackend.AuthenticateBearerToken(token)
+	if !ok || !roleAllowed(principal.Role, min) {
 		http.Error(w, "forbidden", http.StatusForbidden)
 		return "", false
 	}
-	return got, true
-}
-
-func (s tokenStore) lookup(token string) (role, bool) {
-	if got, ok := s.plain[token]; ok {
-		return got, true
-	}
-	sum := sha256.Sum256([]byte(token))
-	for _, hashed := range s.hashed {
-		if subtle.ConstantTimeCompare(sum[:], hashed.sum[:]) == 1 {
-			return hashed.role, true
-		}
-	}
-	return "", false
-}
-
-func decodeSHA256Hex(v string) ([32]byte, bool) {
-	var out [32]byte
-	b, err := hex.DecodeString(v)
-	if err != nil || len(b) != len(out) {
-		return out, false
-	}
-	copy(out[:], b)
-	return out, true
+	return principal.Role, true
 }
 
 func roleAllowed(got, min role) bool {

--- a/internal/admin/api_test.go
+++ b/internal/admin/api_test.go
@@ -55,13 +55,45 @@ func TestSuppressionsAPIAcceptsSHA256Token(t *testing.T) {
 	}
 }
 
-func TestParseTokensSkipsInvalidSHA256Spec(t *testing.T) {
-	store := parseTokens("sha256=not-hex:viewer,viewer-token:viewer")
-	if _, ok := store.lookup("viewer-token"); !ok {
+func TestConfigTokenBackendSkipsInvalidSHA256Spec(t *testing.T) {
+	backend := NewConfigTokenBackend("sha256=not-hex:viewer,viewer-token:viewer")
+	if _, ok := backend.AuthenticateBearerToken("viewer-token"); !ok {
 		t.Fatal("expected plain token to remain available")
 	}
-	if _, ok := store.lookup("not-hex"); ok {
+	if _, ok := backend.AuthenticateBearerToken("not-hex"); ok {
 		t.Fatal("invalid sha256 token spec must be ignored")
+	}
+}
+
+type fakeAuthBackend struct {
+	principal Principal
+	ok        bool
+}
+
+func (f fakeAuthBackend) AuthenticateBearerToken(string) (Principal, bool) {
+	return f.principal, f.ok
+}
+
+func TestAPIUsesAuthBackend(t *testing.T) {
+	s, err := bounce.NewSuppressionStore(filepath.Join(t.TempDir(), "suppression.json"))
+	if err != nil {
+		t.Fatalf("new suppression store: %v", err)
+	}
+	api := NewAPIWithBackend(s, nil, nil, fakeAuthBackend{
+		principal: Principal{Role: roleOperator},
+		ok:        true,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/suppressions", strings.NewReader(`{"address":"user@example.com","reason":"manual"}`))
+	req.Header.Set("Authorization", "Bearer any-token")
+	rec := httptest.NewRecorder()
+	api.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if !s.IsSuppressed("user@example.com") {
+		t.Fatal("suppression was not added")
 	}
 }
 

--- a/internal/admin/auth_backend.go
+++ b/internal/admin/auth_backend.go
@@ -1,0 +1,88 @@
+package admin
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"strings"
+)
+
+type Principal struct {
+	Role role
+}
+
+type AuthBackend interface {
+	AuthenticateBearerToken(token string) (Principal, bool)
+}
+
+type configTokenBackend struct {
+	plain  map[string]Principal
+	hashed []hashedToken
+}
+
+type hashedToken struct {
+	sum       [32]byte
+	principal Principal
+}
+
+func NewConfigTokenBackend(v string) AuthBackend {
+	out := &configTokenBackend{plain: map[string]Principal{}}
+	for _, part := range strings.Split(v, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		tokenSpec, roleSpec, ok := strings.Cut(part, ":")
+		if !ok {
+			continue
+		}
+		tokenSpec = strings.TrimSpace(tokenSpec)
+		r := role(strings.ToLower(strings.TrimSpace(roleSpec)))
+		switch r {
+		case roleViewer, roleOperator, roleAdmin:
+		default:
+			continue
+		}
+		if tokenSpec == "" {
+			continue
+		}
+		p := Principal{Role: r}
+		if strings.HasPrefix(strings.ToLower(tokenSpec), "sha256=") {
+			raw := strings.TrimSpace(tokenSpec[len("sha256="):])
+			sum, ok := decodeSHA256Hex(raw)
+			if !ok {
+				continue
+			}
+			out.hashed = append(out.hashed, hashedToken{sum: sum, principal: p})
+			continue
+		}
+		out.plain[tokenSpec] = p
+	}
+	return out
+}
+
+func (b *configTokenBackend) AuthenticateBearerToken(token string) (Principal, bool) {
+	if b == nil {
+		return Principal{}, false
+	}
+	if got, ok := b.plain[token]; ok {
+		return got, true
+	}
+	sum := sha256.Sum256([]byte(token))
+	for _, hashed := range b.hashed {
+		if subtle.ConstantTimeCompare(sum[:], hashed.sum[:]) == 1 {
+			return hashed.principal, true
+		}
+	}
+	return Principal{}, false
+}
+
+func decodeSHA256Hex(v string) ([32]byte, bool) {
+	var out [32]byte
+	b, err := hex.DecodeString(v)
+	if err != nil || len(b) != len(out) {
+		return out, false
+	}
+	copy(out[:], b)
+	return out, true
+}

--- a/internal/admin/server.go
+++ b/internal/admin/server.go
@@ -10,10 +10,14 @@ import (
 )
 
 func RunServer(ctx context.Context, addr, tokenConfig string, suppressions *bounce.SuppressionStore, queue queueManager, rep *reputation.Tracker) error {
+	return RunServerWithBackend(ctx, addr, NewConfigTokenBackend(tokenConfig), suppressions, queue, rep)
+}
+
+func RunServerWithBackend(ctx context.Context, addr string, authBackend AuthBackend, suppressions *bounce.SuppressionStore, queue queueManager, rep *reputation.Tracker) error {
 	if addr == "" {
 		return nil
 	}
-	api := NewAPI(suppressions, queue, rep, tokenConfig)
+	api := NewAPIWithBackend(suppressions, queue, rep, authBackend)
 	srv := &http.Server{Addr: addr, Handler: api.Handler()}
 	go func() {
 		<-ctx.Done()


### PR DESCRIPTION
## 概要
- Admin API の token source を backend interface 経由で扱うように変更
- config token backend を独立実装へ切り出し
- 将来の db-backed backend を差し込める構造を追加

Closes #236

## 変更内容
- internal/admin/auth_backend.go を追加
- API 本体は AuthBackend から principal を受け取る形へ変更
- RunServerWithBackend を追加し、server と backend 構築責務を分離
- config backend / fake backend の unit test を追加

## 確認内容
- go test ./internal/admin ./cmd/kuroshio
- go test ./...
- git diff --check