### PR TITLE
feat: SMTP AUTH backend interface を追加

### DIFF
--- a/internal/smtp/server.go
+++ b/internal/smtp/server.go
@@ -1034,7 +1034,11 @@ func (s *Server) handleAuth(r *bufio.Reader, w *bufio.Writer, arg string) (strin
 		if err != nil {
 			return "", false, err
 		}
-		return user, s.authBackend.Validate(user, pass), nil
+		principal, ok := s.authBackend.AuthenticatePassword(user, pass)
+		if !ok {
+			return user, false, nil
+		}
+		return principal.Username, true, nil
 	case "LOGIN":
 		var userRaw []byte
 		if len(parts) >= 2 {
@@ -1072,7 +1076,11 @@ func (s *Server) handleAuth(r *bufio.Reader, w *bufio.Writer, arg string) (strin
 		if user == "" || pass == "" {
 			return "", false, errors.New("empty credentials")
 		}
-		return user, s.authBackend.Validate(user, pass), nil
+		principal, ok := s.authBackend.AuthenticatePassword(user, pass)
+		if !ok {
+			return user, false, nil
+		}
+		return principal.Username, true, nil
 	default:
 		return "", false, errors.New("unsupported auth mechanism")
 	}

--- a/internal/userauth/backend.go
+++ b/internal/userauth/backend.go
@@ -5,8 +5,12 @@ import (
 	"strings"
 )
 
+type Principal struct {
+	Username string
+}
+
 type Backend interface {
-	Validate(username, password string) bool
+	AuthenticatePassword(username, password string) (Principal, bool)
 }
 
 type StaticBackend struct {
@@ -28,7 +32,7 @@ func NewStatic(raw string) (*StaticBackend, error) {
 		if i <= 0 || i == len(p)-1 {
 			return nil, errors.New("invalid submission user entry")
 		}
-		u := strings.ToLower(strings.TrimSpace(p[:i]))
+		u := normalizeUsername(p[:i])
 		pw := strings.TrimSpace(p[i+1:])
 		if u == "" || pw == "" {
 			return nil, errors.New("invalid submission user entry")
@@ -38,13 +42,18 @@ func NewStatic(raw string) (*StaticBackend, error) {
 	return &StaticBackend{users: users}, nil
 }
 
-func (b *StaticBackend) Validate(username, password string) bool {
+func (b *StaticBackend) AuthenticatePassword(username, password string) (Principal, bool) {
 	if b == nil {
-		return false
+		return Principal{}, false
 	}
-	pw, ok := b.users[strings.ToLower(strings.TrimSpace(username))]
-	if !ok {
-		return false
+	u := normalizeUsername(username)
+	pw, ok := b.users[u]
+	if !ok || pw != password {
+		return Principal{}, false
 	}
-	return pw == password
+	return Principal{Username: u}, true
+}
+
+func normalizeUsername(username string) string {
+	return strings.ToLower(strings.TrimSpace(username))
 }

--- a/internal/userauth/static_test.go
+++ b/internal/userauth/static_test.go
@@ -2,21 +2,25 @@ package userauth
 
 import "testing"
 
-func TestNewStaticAndValidate(t *testing.T) {
+func TestNewStaticAndAuthenticatePassword(t *testing.T) {
 	b, err := NewStatic("alice@example.com:s3cr3t, bob@example.com:pass")
 	if err != nil {
 		t.Fatalf("new static: %v", err)
 	}
-	if !b.Validate("alice@example.com", "s3cr3t") {
+	principal, ok := b.AuthenticatePassword("alice@example.com", "s3cr3t")
+	if !ok {
 		t.Fatal("alice should authenticate")
 	}
-	if !b.Validate("ALICE@EXAMPLE.COM", "s3cr3t") {
+	if principal.Username != "alice@example.com" {
+		t.Fatalf("principal username=%q", principal.Username)
+	}
+	if _, ok := b.AuthenticatePassword("ALICE@EXAMPLE.COM", "s3cr3t"); !ok {
 		t.Fatal("username lookup should be case-insensitive")
 	}
-	if b.Validate("bob@example.com", "wrong") {
+	if _, ok := b.AuthenticatePassword("bob@example.com", "wrong"); ok {
 		t.Fatal("wrong password must fail")
 	}
-	if b.Validate("charlie@example.com", "pass") {
+	if _, ok := b.AuthenticatePassword("charlie@example.com", "pass"); ok {
 		t.Fatal("unknown user must fail")
 	}
 }


### PR DESCRIPTION
## 概要
- Submission 認証 backend が principal を返せる interface へ拡張
- static backend を新しい interface に載せ替え
- SMTP server は認証 backend から canonical username を受け取る形へ変更

Closes #237

## 変更内容
- internal/userauth を backend interface 前提の実装へ整理
- AuthenticatePassword で Principal を返すように変更
- SMTP AUTH PLAIN / LOGIN は backend から返る principal username を使うように更新

## 確認内容
- go test ./internal/userauth ./internal/smtp ./cmd/kuroshio
- go test ./...
- git diff --check