### PR TITLE
feat: Admin API の監査ログに principal と fingerprint を追加

### DIFF
--- a/docs/runbooks/admin_api.md
+++ b/docs/runbooks/admin_api.md
@@ -62,7 +62,9 @@ scripts/admin/kuroshio_admin.sh requeue dlq msg-1 --dry-run
 ## 監査ログ
 
 - すべての運用操作は `component=audit` で JSON ログ出力
-- `event`, `actor`, `path`, `message_id`, `dry_run` を含む
+- `event`, `actor`, `actor_header`, `auth_principal`, `auth_role`, `auth_source`, `token_fingerprint`, `path`, `message_id`, `dry_run` を含む
+- `X-Admin-Actor` は人間や runbook 上の実行主体を表し、`auth_principal` は認証 backend が返す principal を表す
+- token の平文は出力せず、`token_fingerprint` には安全な識別子だけを出す
 
 ## 制約
 

--- a/internal/admin/api.go
+++ b/internal/admin/api.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -36,6 +37,8 @@ type API struct {
 	now          func() time.Time
 }
 
+type principalContextKey struct{}
+
 func NewAPI(s *bounce.SuppressionStore, q queueManager, rep *reputation.Tracker, tokenConfig string) *API {
 	return NewAPIWithBackend(s, q, rep, NewConfigTokenBackend(tokenConfig))
 }
@@ -60,19 +63,19 @@ func (a *API) Handler() http.Handler {
 	return mux
 }
 
-func (a *API) authorize(w http.ResponseWriter, r *http.Request, min role) (role, bool) {
+func (a *API) authorize(w http.ResponseWriter, r *http.Request, min role) (*http.Request, Principal, bool) {
 	header := strings.TrimSpace(r.Header.Get("Authorization"))
 	if !strings.HasPrefix(header, "Bearer ") {
 		http.Error(w, "missing bearer token", http.StatusUnauthorized)
-		return "", false
+		return r, Principal{}, false
 	}
 	token := strings.TrimSpace(strings.TrimPrefix(header, "Bearer "))
 	principal, ok := a.authBackend.AuthenticateBearerToken(token)
 	if !ok || !roleAllowed(principal.Role, min) {
 		http.Error(w, "forbidden", http.StatusForbidden)
-		return "", false
+		return r, Principal{}, false
 	}
-	return principal.Role, true
+	return withPrincipal(r, principal), principal, true
 }
 
 func roleAllowed(got, min role) bool {
@@ -83,8 +86,10 @@ func roleAllowed(got, min role) bool {
 func (a *API) handleSuppressions(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
-		if _, ok := a.authorize(w, r, roleViewer); !ok {
+		if next, _, ok := a.authorize(w, r, roleViewer); !ok {
 			return
+		} else {
+			r = next
 		}
 		if a.suppressions == nil {
 			http.Error(w, "suppression admin is unavailable", http.StatusNotImplemented)
@@ -92,8 +97,10 @@ func (a *API) handleSuppressions(w http.ResponseWriter, r *http.Request) {
 		}
 		writeJSON(w, http.StatusOK, map[string]any{"items": a.suppressions.List()})
 	case http.MethodPost:
-		if _, ok := a.authorize(w, r, roleOperator); !ok {
+		if next, _, ok := a.authorize(w, r, roleOperator); !ok {
 			return
+		} else {
+			r = next
 		}
 		if a.suppressions == nil {
 			http.Error(w, "suppression admin is unavailable", http.StatusNotImplemented)
@@ -130,8 +137,10 @@ func (a *API) handleSuppressionByAddress(w http.ResponseWriter, r *http.Request)
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	if _, ok := a.authorize(w, r, roleOperator); !ok {
+	if next, _, ok := a.authorize(w, r, roleOperator); !ok {
 		return
+	} else {
+		r = next
 	}
 	if a.suppressions == nil {
 		http.Error(w, "suppression admin is unavailable", http.StatusNotImplemented)
@@ -164,8 +173,10 @@ func (a *API) handleQueue(w http.ResponseWriter, r *http.Request) {
 	path := strings.TrimPrefix(r.URL.Path, "/api/v1/queue/")
 	parts := strings.Split(path, "/")
 	if len(parts) == 1 && r.Method == http.MethodGet {
-		if _, ok := a.authorize(w, r, roleViewer); !ok {
+		if next, _, ok := a.authorize(w, r, roleViewer); !ok {
 			return
+		} else {
+			r = next
 		}
 		state := strings.TrimSpace(parts[0])
 		limit := 50
@@ -183,8 +194,10 @@ func (a *API) handleQueue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if len(parts) == 3 && r.Method == http.MethodPost && parts[2] == "requeue" {
-		if _, ok := a.authorize(w, r, roleOperator); !ok {
+		if next, _, ok := a.authorize(w, r, roleOperator); !ok {
 			return
+		} else {
+			r = next
 		}
 		state := strings.TrimSpace(parts[0])
 		id := strings.TrimSpace(parts[1])
@@ -217,8 +230,10 @@ func (a *API) handleComplaint(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	if _, ok := a.authorize(w, r, roleOperator); !ok {
+	if next, _, ok := a.authorize(w, r, roleOperator); !ok {
 		return
+	} else {
+		r = next
 	}
 	if a.reputation == nil {
 		http.Error(w, "reputation admin is unavailable", http.StatusNotImplemented)
@@ -248,8 +263,10 @@ func (a *API) handleTLSReport(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	if _, ok := a.authorize(w, r, roleOperator); !ok {
+	if next, _, ok := a.authorize(w, r, roleOperator); !ok {
 		return
+	} else {
+		r = next
 	}
 	if a.reputation == nil {
 		http.Error(w, "reputation admin is unavailable", http.StatusNotImplemented)
@@ -276,7 +293,23 @@ func (a *API) handleTLSReport(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) audit(r *http.Request, event string, attrs map[string]any) {
-	fields := []any{"component", "audit", "event", event, "actor", actorFromRequest(r), "method", r.Method, "path", r.URL.Path}
+	fields := []any{
+		"component", "audit",
+		"event", event,
+		"actor", actorFromRequest(r),
+		"actor_header", actorHeaderFromRequest(r),
+		"method", r.Method,
+		"path", r.URL.Path,
+	}
+	if principal, ok := principalFromRequest(r); ok {
+		fields = append(
+			fields,
+			"auth_principal", principal.Subject,
+			"auth_role", principal.Role,
+			"auth_source", principal.AuthSource,
+			"token_fingerprint", principal.TokenFingerprint,
+		)
+	}
 	for k, v := range attrs {
 		fields = append(fields, k, v)
 	}
@@ -284,10 +317,30 @@ func (a *API) audit(r *http.Request, event string, attrs map[string]any) {
 }
 
 func actorFromRequest(r *http.Request) string {
-	if v := strings.TrimSpace(r.Header.Get("X-Admin-Actor")); v != "" {
+	if v := actorHeaderFromRequest(r); v != "" {
 		return v
 	}
+	if principal, ok := principalFromRequest(r); ok && strings.TrimSpace(principal.Subject) != "" {
+		return principal.Subject
+	}
 	return "unknown"
+}
+
+func actorHeaderFromRequest(r *http.Request) string {
+	return strings.TrimSpace(r.Header.Get("X-Admin-Actor"))
+}
+
+func withPrincipal(r *http.Request, principal Principal) *http.Request {
+	ctx := context.WithValue(r.Context(), principalContextKey{}, principal)
+	return r.WithContext(ctx)
+}
+
+func principalFromRequest(r *http.Request) (Principal, bool) {
+	if r == nil {
+		return Principal{}, false
+	}
+	principal, ok := r.Context().Value(principalContextKey{}).(Principal)
+	return principal, ok
 }
 
 func writeJSON(w http.ResponseWriter, code int, v any) {

--- a/internal/admin/api_test.go
+++ b/internal/admin/api_test.go
@@ -1,9 +1,11 @@
 package admin
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -62,6 +64,25 @@ func TestConfigTokenBackendSkipsInvalidSHA256Spec(t *testing.T) {
 	}
 	if _, ok := backend.AuthenticateBearerToken("not-hex"); ok {
 		t.Fatal("invalid sha256 token spec must be ignored")
+	}
+}
+
+func TestConfigTokenBackendReturnsFingerprintAndPrincipalMetadata(t *testing.T) {
+	backend := NewConfigTokenBackend("viewer-token:viewer")
+	principal, ok := backend.AuthenticateBearerToken("viewer-token")
+	if !ok {
+		t.Fatal("expected token authentication to succeed")
+	}
+	if principal.Subject != "config:viewer" {
+		t.Fatalf("subject=%q want=%q", principal.Subject, "config:viewer")
+	}
+	if principal.AuthSource != "config_token" {
+		t.Fatalf("auth source=%q want=%q", principal.AuthSource, "config_token")
+	}
+	sum := sha256.Sum256([]byte("viewer-token"))
+	want := "sha256:" + hex.EncodeToString(sum[:8])
+	if principal.TokenFingerprint != want {
+		t.Fatalf("fingerprint=%q want=%q", principal.TokenFingerprint, want)
 	}
 }
 
@@ -202,5 +223,51 @@ func TestReputationAPIRecordsComplaintAndTLSReport(t *testing.T) {
 	}
 	if snap[0].Complaints != 1 || snap[0].TLSRPTFailures != 1 {
 		t.Fatalf("snapshot=%+v", snap[0])
+	}
+}
+
+func TestAuditLogIncludesActorHeaderAndAuthPrincipal(t *testing.T) {
+	s, err := bounce.NewSuppressionStore(filepath.Join(t.TempDir(), "suppression.json"))
+	if err != nil {
+		t.Fatalf("new suppression store: %v", err)
+	}
+	api := NewAPIWithBackend(s, nil, nil, fakeAuthBackend{
+		principal: Principal{
+			Role:             roleOperator,
+			Subject:          "principal:ops-team",
+			AuthSource:       "config_token",
+			TokenFingerprint: "sha256:deadbeefcafebabe",
+		},
+		ok: true,
+	})
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	slog.SetDefault(logger)
+	defer slog.SetDefault(prev)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/suppressions", strings.NewReader(`{"address":"user@example.com","reason":"manual","dry_run":true}`))
+	req.Header.Set("Authorization", "Bearer operator-token")
+	req.Header.Set("X-Admin-Actor", "operator@example.com")
+	rec := httptest.NewRecorder()
+	api.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	out := buf.String()
+	for _, want := range []string{
+		`"component":"audit"`,
+		`"actor":"operator@example.com"`,
+		`"actor_header":"operator@example.com"`,
+		`"auth_principal":"principal:ops-team"`,
+		`"auth_role":"operator"`,
+		`"auth_source":"config_token"`,
+		`"token_fingerprint":"sha256:deadbeefcafebabe"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %s in audit log: %q", want, out)
+		}
 	}
 }

--- a/internal/admin/auth_backend.go
+++ b/internal/admin/auth_backend.go
@@ -8,7 +8,10 @@ import (
 )
 
 type Principal struct {
-	Role role
+	Role             role
+	Subject          string
+	AuthSource       string
+	TokenFingerprint string
 }
 
 type AuthBackend interface {
@@ -46,16 +49,22 @@ func NewConfigTokenBackend(v string) AuthBackend {
 		if tokenSpec == "" {
 			continue
 		}
-		p := Principal{Role: r}
+		p := Principal{
+			Role:       r,
+			Subject:    "config:" + string(r),
+			AuthSource: "config_token",
+		}
 		if strings.HasPrefix(strings.ToLower(tokenSpec), "sha256=") {
 			raw := strings.TrimSpace(tokenSpec[len("sha256="):])
 			sum, ok := decodeSHA256Hex(raw)
 			if !ok {
 				continue
 			}
+			p.TokenFingerprint = tokenFingerprint(sum)
 			out.hashed = append(out.hashed, hashedToken{sum: sum, principal: p})
 			continue
 		}
+		p.TokenFingerprint = tokenFingerprint(sha256.Sum256([]byte(tokenSpec)))
 		out.plain[tokenSpec] = p
 	}
 	return out
@@ -85,4 +94,8 @@ func decodeSHA256Hex(v string) ([32]byte, bool) {
 	}
 	copy(out[:], b)
 	return out, true
+}
+
+func tokenFingerprint(sum [32]byte) string {
+	return "sha256:" + hex.EncodeToString(sum[:8])
 }


### PR DESCRIPTION
## 概要
- Admin API 認証成功時に principal を request context へ載せるように整理
- audit log に actor header、auth principal、auth source、token fingerprint を追加
- token 平文を出さないことをテストと runbook で明示

## 確認
- go test ./internal/admin ./cmd/kuroshio
- go test ./...
- npm run docs:build
- git diff --check

Closes #239