### PR TITLE
Admin API に SQLite ベースの認証 backend を追加

### DIFF
--- a/cmd/kuroshio/main.go
+++ b/cmd/kuroshio/main.go
@@ -115,7 +115,16 @@ func main() {
 		if localQueue, ok := q.(*queue.Store); ok {
 			queueAdmin = localQueue
 		}
-		go func() { errCh <- admin.RunServer(ctx, cfg.AdminAddr, cfg.AdminTokens, sup, queueAdmin, rep) }()
+		adminAuthBackend := admin.NewConfigTokenBackend(cfg.AdminTokens)
+		if cfg.AdminAuthBackend == "sqlite" {
+			adminAuthBackend, err = admin.NewSQLiteTokenBackend(cfg.AdminAuthDSN)
+			if err != nil {
+				fatal("admin auth init failed", "error", err)
+			}
+		}
+		go func() {
+			errCh <- admin.RunServerWithBackend(ctx, cfg.AdminAddr, adminAuthBackend, sup, queueAdmin, rep)
+		}()
 	}
 	go func() {
 		errCh <- retention.Run(ctx, cfg.QueueDir, retention.Policy{

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -13,6 +13,8 @@ otel_exporter_otlp_insecure: true
 otel_trace_sample_ratio: 1.0
 admin_addr: ":8080"
 admin_tokens: "sha256=d036bd6d01a1cae081d39a2f8dab751dc042de814fd60df31fcb553170950f29:viewer,sha256=0850123315d21ab90f4f7236408a52ef6dbd6a02a6550e5c10dc73f4d993680e:operator"
+admin_auth_backend: config
+admin_auth_dsn: ""
 hostname: kuroshio.local
 queue_dir: ./var/queue
 queue_backend: local

--- a/docs/runbooks/admin_api.md
+++ b/docs/runbooks/admin_api.md
@@ -10,6 +10,8 @@ Issue: #36
 
 ## 有効化
 
+config token backend:
+
 - `MTA_ADMIN_ADDR=:9091`
 - `MTA_ADMIN_TOKENS=sha256=d036bd6d01a1cae081d39a2f8dab751dc042de814fd60df31fcb553170950f29:viewer,sha256=0850123315d21ab90f4f7236408a52ef6dbd6a02a6550e5c10dc73f4d993680e:operator`
 
@@ -22,6 +24,21 @@ Issue: #36
 printf 'viewer-token' | sha256sum
 printf 'operator-token' | sha256sum
 ```
+
+SQLite backend:
+
+- `MTA_ADMIN_ADDR=:9091`
+- `MTA_ADMIN_AUTH_BACKEND=sqlite`
+- `MTA_ADMIN_AUTH_DSN=file:./var/admin-auth.db`
+
+SQLite backend は次の 2 テーブルを参照する。
+
+- `admin_principals(id, name, role, enabled, description, created_at, updated_at)`
+- `admin_tokens(id, principal_id, token_hash, enabled, expires_at, last_used_at, created_at, updated_at)`
+
+`token_hash` には Bearer token の SHA-256 hex を保存する。
+`expires_at` は SQLite が `datetime()` で解釈できる形式で保存する。
+認証成功時は `last_used_at` を更新する。
 
 ## 権限
 
@@ -65,6 +82,7 @@ scripts/admin/kuroshio_admin.sh requeue dlq msg-1 --dry-run
 - `event`, `actor`, `actor_header`, `auth_principal`, `auth_role`, `auth_source`, `token_fingerprint`, `path`, `message_id`, `dry_run` を含む
 - `X-Admin-Actor` は人間や runbook 上の実行主体を表し、`auth_principal` は認証 backend が返す principal を表す
 - token の平文は出力せず、`token_fingerprint` には安全な識別子だけを出す
+- SQLite backend では `auth_source=sqlite_token` となる
 
 ## 制約
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,13 @@ go 1.25.0
 toolchain go1.25.9
 
 require (
+	go.opentelemetry.io/otel v1.43.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0
+	go.opentelemetry.io/otel/sdk v1.43.0
+	go.opentelemetry.io/otel/trace v1.43.0
+)
+
+require (
 	github.com/aws/aws-sdk-go-v2 v1.41.5 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.32.14 // indirect
@@ -27,21 +34,21 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/klauspost/compress v1.15.9 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.15 // indirect
 	github.com/redis/go-redis/v9 v9.18.0 // indirect
+	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/segmentio/kafka-go v0.4.47 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.43.0
-	go.opentelemetry.io/otel/trace v1.43.0
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
@@ -52,4 +59,8 @@ require (
 	google.golang.org/grpc v1.80.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	modernc.org/libc v1.70.0 // indirect
+	modernc.org/mathutil v1.7.1 // indirect
+	modernc.org/memory v1.11.0 // indirect
+	modernc.org/sqlite v1.48.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
+github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -55,11 +57,17 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
 github.com/klauspost/compress v1.15.9 h1:wKRjX6JRtDdrE9qwa4b/Cip7ACOshUI4smpCQanqjSY=
 github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
+github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
+github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
+github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/pierrec/lz4/v4 v4.1.15 h1:MO0/ucJhngq7299dKLwIMtgTfbkoSPF6AoMYDd8Q4q0=
 github.com/pierrec/lz4/v4 v4.1.15/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
 github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
+github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
+github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/segmentio/kafka-go v0.4.47 h1:IqziR4pA3vrZq7YdRxaT3w1/5fvIH5qpCwstUanQQB0=
 github.com/segmentio/kafka-go v0.4.47/go.mod h1:HjF6XbOKh0Pjlkr5GVZxt6CsjjwnmhVOfURM5KMd8qg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -110,6 +118,7 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
@@ -145,3 +154,11 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+modernc.org/libc v1.70.0 h1:U58NawXqXbgpZ/dcdS9kMshu08aiA6b7gusEusqzNkw=
+modernc.org/libc v1.70.0/go.mod h1:OVmxFGP1CI/Z4L3E0Q3Mf1PDE0BucwMkcXjjLntvHJo=
+modernc.org/mathutil v1.7.1 h1:GCZVGXdaN8gTqB1Mf/usp1Y/hSqgI2vAGGP4jZMCxOU=
+modernc.org/mathutil v1.7.1/go.mod h1:4p5IwJITfppl0G4sUEDtCr4DthTaT47/N3aT6MhfgJg=
+modernc.org/memory v1.11.0 h1:o4QC8aMQzmcwCK3t3Ux/ZHmwFPzE6hf2Y5LbkRs+hbI=
+modernc.org/memory v1.11.0/go.mod h1:/JP4VbVC+K5sU2wZi9bHoq2MAkCnrt2r98UGeSK7Mjw=
+modernc.org/sqlite v1.48.1 h1:S85iToyU6cgeojybE2XJlSbcsvcWkQ6qqNXJHtW5hWA=
+modernc.org/sqlite v1.48.1/go.mod h1:hWjRO6Tj/5Ik8ieqxQybiEOUXy0NJFNp2tpvVpKlvig=

--- a/internal/admin/api_test.go
+++ b/internal/admin/api_test.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"bytes"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"log/slog"
@@ -17,6 +18,7 @@ import (
 	"github.com/tamago0224/kuroshio-mta/internal/model"
 	"github.com/tamago0224/kuroshio-mta/internal/queue"
 	"github.com/tamago0224/kuroshio-mta/internal/reputation"
+	_ "modernc.org/sqlite"
 )
 
 func TestSuppressionsAPIRequiresBearerToken(t *testing.T) {
@@ -84,6 +86,74 @@ func TestConfigTokenBackendReturnsFingerprintAndPrincipalMetadata(t *testing.T) 
 	if principal.TokenFingerprint != want {
 		t.Fatalf("fingerprint=%q want=%q", principal.TokenFingerprint, want)
 	}
+}
+
+func TestSQLiteTokenBackendAuthenticatesEnabledTokenAndUpdatesLastUsedAt(t *testing.T) {
+	dsn := filepath.Join(t.TempDir(), "admin-auth.db")
+	db := openAdminSQLiteForTest(t, dsn)
+	seedAdminSQLiteForTest(t, db, "operator@example.com", "operator", "operator-token", true, nil)
+
+	backend, err := NewSQLiteTokenBackend(dsn)
+	if err != nil {
+		t.Fatalf("new sqlite backend: %v", err)
+	}
+	principal, ok := backend.AuthenticateBearerToken("operator-token")
+	if !ok {
+		t.Fatal("expected token authentication to succeed")
+	}
+	if principal.Subject != "operator@example.com" {
+		t.Fatalf("subject=%q want=%q", principal.Subject, "operator@example.com")
+	}
+	if principal.Role != roleOperator {
+		t.Fatalf("role=%q want=%q", principal.Role, roleOperator)
+	}
+	if principal.AuthSource != "sqlite_token" {
+		t.Fatalf("auth source=%q want=%q", principal.AuthSource, "sqlite_token")
+	}
+	sum := sha256.Sum256([]byte("operator-token"))
+	want := "sha256:" + hex.EncodeToString(sum[:8])
+	if principal.TokenFingerprint != want {
+		t.Fatalf("fingerprint=%q want=%q", principal.TokenFingerprint, want)
+	}
+
+	var lastUsedAt sql.NullString
+	if err := db.QueryRow(`SELECT last_used_at FROM admin_tokens LIMIT 1`).Scan(&lastUsedAt); err != nil {
+		t.Fatalf("query last_used_at: %v", err)
+	}
+	if !lastUsedAt.Valid || strings.TrimSpace(lastUsedAt.String) == "" {
+		t.Fatalf("last_used_at should be updated, got=%+v", lastUsedAt)
+	}
+}
+
+func TestSQLiteTokenBackendRejectsDisabledOrExpiredToken(t *testing.T) {
+	t.Run("disabled token", func(t *testing.T) {
+		dsn := filepath.Join(t.TempDir(), "disabled.db")
+		db := openAdminSQLiteForTest(t, dsn)
+		seedAdminSQLiteForTest(t, db, "operator@example.com", "operator", "operator-token", false, nil)
+
+		backend, err := NewSQLiteTokenBackend(dsn)
+		if err != nil {
+			t.Fatalf("new sqlite backend: %v", err)
+		}
+		if _, ok := backend.AuthenticateBearerToken("operator-token"); ok {
+			t.Fatal("disabled token must be rejected")
+		}
+	})
+
+	t.Run("expired token", func(t *testing.T) {
+		dsn := filepath.Join(t.TempDir(), "expired.db")
+		db := openAdminSQLiteForTest(t, dsn)
+		expiredAt := time.Now().Add(-time.Hour).UTC()
+		seedAdminSQLiteForTest(t, db, "viewer@example.com", "viewer", "viewer-token", true, &expiredAt)
+
+		backend, err := NewSQLiteTokenBackend(dsn)
+		if err != nil {
+			t.Fatalf("new sqlite backend: %v", err)
+		}
+		if _, ok := backend.AuthenticateBearerToken("viewer-token"); ok {
+			t.Fatal("expired token must be rejected")
+		}
+	})
 }
 
 type fakeAuthBackend struct {
@@ -269,5 +339,68 @@ func TestAuditLogIncludesActorHeaderAndAuthPrincipal(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Fatalf("missing %s in audit log: %q", want, out)
 		}
+	}
+}
+
+func openAdminSQLiteForTest(t *testing.T, dsn string) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		t.Fatalf("open sqlite db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(`
+CREATE TABLE admin_principals (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	name TEXT NOT NULL,
+	role TEXT NOT NULL,
+	enabled INTEGER NOT NULL DEFAULT 1,
+	description TEXT,
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE TABLE admin_tokens (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	principal_id INTEGER NOT NULL,
+	token_hash TEXT NOT NULL,
+	enabled INTEGER NOT NULL DEFAULT 1,
+	expires_at TEXT,
+	last_used_at TEXT,
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	FOREIGN KEY(principal_id) REFERENCES admin_principals(id)
+);
+`); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	return db
+}
+
+func seedAdminSQLiteForTest(t *testing.T, db *sql.DB, subject, roleName, token string, enabled bool, expiresAt *time.Time) {
+	t.Helper()
+	res, err := db.Exec(`INSERT INTO admin_principals(name, role, enabled, description) VALUES (?, ?, 1, ?)`, subject, roleName, "seed")
+	if err != nil {
+		t.Fatalf("insert admin principal: %v", err)
+	}
+	principalID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("principal last insert id: %v", err)
+	}
+
+	tokenEnabled := 0
+	if enabled {
+		tokenEnabled = 1
+	}
+	sum := sha256.Sum256([]byte(token))
+	tokenHash := hex.EncodeToString(sum[:])
+	var expires any
+	if expiresAt != nil {
+		expires = expiresAt.UTC().Format("2006-01-02 15:04:05")
+	}
+	if _, err := db.Exec(`
+INSERT INTO admin_tokens(principal_id, token_hash, enabled, expires_at)
+VALUES (?, ?, ?, ?)
+`, principalID, tokenHash, tokenEnabled, expires); err != nil {
+		t.Fatalf("insert admin token: %v", err)
 	}
 }

--- a/internal/admin/sqlite_backend.go
+++ b/internal/admin/sqlite_backend.go
@@ -1,0 +1,87 @@
+package admin
+
+import (
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"log/slog"
+	"strings"
+
+	_ "modernc.org/sqlite"
+)
+
+type sqliteTokenBackend struct {
+	db *sql.DB
+}
+
+func NewSQLiteTokenBackend(dsn string) (AuthBackend, error) {
+	dsn = strings.TrimSpace(dsn)
+	if dsn == "" {
+		return nil, errors.New("admin auth sqlite dsn is required")
+	}
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxOpenConns(1)
+	if err := db.Ping(); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return &sqliteTokenBackend{db: db}, nil
+}
+
+func (b *sqliteTokenBackend) AuthenticateBearerToken(token string) (Principal, bool) {
+	if b == nil || b.db == nil {
+		return Principal{}, false
+	}
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return Principal{}, false
+	}
+	sum := sha256.Sum256([]byte(token))
+	tokenHash := hex.EncodeToString(sum[:])
+
+	var subject string
+	var rawRole string
+	err := b.db.QueryRow(`
+SELECT p.name, p.role
+FROM admin_tokens AS t
+JOIN admin_principals AS p ON p.id = t.principal_id
+WHERE t.token_hash = ?
+  AND t.enabled = 1
+  AND p.enabled = 1
+  AND (t.expires_at IS NULL OR datetime(t.expires_at) > CURRENT_TIMESTAMP)
+LIMIT 1
+`, tokenHash).Scan(&subject, &rawRole)
+	if err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			slog.Error("admin sqlite auth lookup failed", "component", "admin", "error", err)
+		}
+		return Principal{}, false
+	}
+
+	r := role(strings.ToLower(strings.TrimSpace(rawRole)))
+	switch r {
+	case roleViewer, roleOperator, roleAdmin:
+	default:
+		slog.Warn("admin sqlite auth returned unknown role", "component", "admin", "role", rawRole)
+		return Principal{}, false
+	}
+
+	if _, err := b.db.Exec(`
+UPDATE admin_tokens
+SET last_used_at = CURRENT_TIMESTAMP
+WHERE token_hash = ?
+`, tokenHash); err != nil {
+		slog.Error("admin sqlite auth last_used_at update failed", "component", "admin", "error", err)
+	}
+
+	return Principal{
+		Role:             r,
+		Subject:          strings.TrimSpace(subject),
+		AuthSource:       "sqlite_token",
+		TokenFingerprint: tokenFingerprint(sum),
+	}, true
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,8 @@ type Config struct {
 	OTELTraceSampleRatio         float64
 	AdminAddr                    string
 	AdminTokens                  string
+	AdminAuthBackend             string
+	AdminAuthDSN                 string
 	Hostname                     string
 	QueueDir                     string
 	QueueBackend                 string
@@ -117,6 +119,8 @@ type yamlConfig struct {
 	OTELTraceSampleRatio         *float64 `yaml:"otel_trace_sample_ratio"`
 	AdminAddr                    *string  `yaml:"admin_addr"`
 	AdminTokens                  *string  `yaml:"admin_tokens"`
+	AdminAuthBackend             *string  `yaml:"admin_auth_backend"`
+	AdminAuthDSN                 *string  `yaml:"admin_auth_dsn"`
 	Hostname                     *string  `yaml:"hostname"`
 	QueueDir                     *string  `yaml:"queue_dir"`
 	QueueBackend                 *string  `yaml:"queue_backend"`
@@ -225,6 +229,8 @@ func LoadWithPath(explicitPath string) (Config, error) {
 	cfg.OTELTraceSampleRatio = normalizeSampleRatio(envFloat64("MTA_OTEL_TRACE_SAMPLE_RATIO", cfg.OTELTraceSampleRatio), cfg.OTELTraceSampleRatio)
 	cfg.AdminAddr = env("MTA_ADMIN_ADDR", cfg.AdminAddr)
 	cfg.AdminTokens = envOrFile("MTA_ADMIN_TOKENS", "MTA_ADMIN_TOKENS_FILE", cfg.AdminTokens)
+	cfg.AdminAuthBackend = envEnum("MTA_ADMIN_AUTH_BACKEND", cfg.AdminAuthBackend, []string{"config", "sqlite"})
+	cfg.AdminAuthDSN = env("MTA_ADMIN_AUTH_DSN", cfg.AdminAuthDSN)
 	cfg.Hostname = env("MTA_HOSTNAME", cfg.Hostname)
 	cfg.QueueDir = env("MTA_QUEUE_DIR", cfg.QueueDir)
 	cfg.QueueBackend = env("MTA_QUEUE_BACKEND", cfg.QueueBackend)
@@ -319,6 +325,8 @@ func defaultConfig() Config {
 		OTELTraceSampleRatio:         1.0,
 		AdminAddr:                    "",
 		AdminTokens:                  "",
+		AdminAuthBackend:             "config",
+		AdminAuthDSN:                 "",
 		Hostname:                     "kuroshio.local",
 		QueueDir:                     "./var/queue",
 		QueueBackend:                 "local",
@@ -466,6 +474,12 @@ func loadYAMLConfig(path string, base Config) (Config, error) {
 	}
 	if raw.AdminTokens != nil {
 		cfg.AdminTokens = *raw.AdminTokens
+	}
+	if raw.AdminAuthBackend != nil {
+		cfg.AdminAuthBackend = normalizeEnum(*raw.AdminAuthBackend, cfg.AdminAuthBackend, []string{"config", "sqlite"})
+	}
+	if raw.AdminAuthDSN != nil {
+		cfg.AdminAuthDSN = *raw.AdminAuthDSN
 	}
 	if raw.Hostname != nil {
 		cfg.Hostname = *raw.Hostname

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -197,6 +197,31 @@ func TestLoadSubmissionUsersFromFile(t *testing.T) {
 	}
 }
 
+func TestLoadAdminAuthSQLiteConfig(t *testing.T) {
+	t.Setenv("MTA_ADMIN_ADDR", ":9091")
+	t.Setenv("MTA_ADMIN_AUTH_BACKEND", "sqlite")
+	t.Setenv("MTA_ADMIN_AUTH_DSN", "file:./var/admin-auth.db")
+
+	cfg := mustLoadForTest(t)
+	if cfg.AdminAddr != ":9091" {
+		t.Fatalf("admin addr=%q", cfg.AdminAddr)
+	}
+	if cfg.AdminAuthBackend != "sqlite" {
+		t.Fatalf("admin auth backend=%q", cfg.AdminAuthBackend)
+	}
+	if cfg.AdminAuthDSN != "file:./var/admin-auth.db" {
+		t.Fatalf("admin auth dsn=%q", cfg.AdminAuthDSN)
+	}
+}
+
+func TestLoadAdminAuthBackendFallsBackOnInvalidValue(t *testing.T) {
+	t.Setenv("MTA_ADMIN_AUTH_BACKEND", "unsupported")
+	cfg := mustLoadForTest(t)
+	if cfg.AdminAuthBackend != "config" {
+		t.Fatalf("admin auth backend=%q want=%q", cfg.AdminAuthBackend, "config")
+	}
+}
+
 func TestLoadLogLevel(t *testing.T) {
 	t.Setenv("MTA_LOG_LEVEL", "debug")
 	cfg := mustLoadForTest(t)


### PR DESCRIPTION
## Summary
- Admin API に config backend と切り替え可能な SQLite-backed 認証 backend を追加
- `admin_auth_backend` / `admin_auth_dsn` を config と環境変数から読めるように変更
- runbook と config example に SQLite backend の利用方法を追記

## Related Issue
- Closes #245

## Validation
- [ ] `go vet ./...`
- [x] `go test ./...`
- [ ] `go test -race ./...`

## TDD Checklist
- [ ] Red: failing test was added first
- [x] Green: minimal implementation to pass tests
- [x] Refactor: cleanup completed without behavior change