### PR TITLE
Submission に SQLite ベースの認証 backend を追加

### DIFF
--- a/cmd/kuroshio/main.go
+++ b/cmd/kuroshio/main.go
@@ -82,12 +82,24 @@ func main() {
 	s := smtp.NewServer(cfg, q, metrics)
 	var submissionServer *smtp.Server
 	if cfg.SubmissionAddr != "" {
-		authBackend, aErr := userauth.NewStatic(cfg.SubmissionUsers)
-		if aErr != nil {
-			fatal("submission auth init failed", "error", aErr)
-		}
-		if cfg.SubmissionAuth && strings.TrimSpace(cfg.SubmissionUsers) == "" {
-			fatal("submission auth is required but MTA_SUBMISSION_USERS is empty")
+		var (
+			authBackend userauth.Backend
+			aErr        error
+		)
+		switch cfg.SubmissionAuthBackend {
+		case "sqlite":
+			authBackend, aErr = userauth.NewSQLite(cfg.SubmissionAuthDSN)
+			if aErr != nil {
+				fatal("submission auth init failed", "error", aErr)
+			}
+		default:
+			authBackend, aErr = userauth.NewStatic(cfg.SubmissionUsers)
+			if aErr != nil {
+				fatal("submission auth init failed", "error", aErr)
+			}
+			if cfg.SubmissionAuth && strings.TrimSpace(cfg.SubmissionUsers) == "" {
+				fatal("submission auth is required but MTA_SUBMISSION_USERS is empty")
+			}
 		}
 		submissionServer = smtp.NewSubmissionServer(cfg, q, metrics, authBackend)
 	}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -2,6 +2,8 @@ listen_addr: ":2525"
 submission_addr: ":587"
 submission_auth_required: true
 submission_users: "alice@example.com:s3cr3t"
+submission_auth_backend: static
+submission_auth_dsn: ""
 submission_enforce_sender_identity: true
 log_level: info
 observability_addr: ":9090"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,6 +29,7 @@ go run ./cmd/kuroshio -config ./config.yaml
 | `-` | `MTA_CONFIG_FILE` | unset | 互換用の設定ファイル指定です。通常は起動引数 `-config` を優先して使います |
 | `submission_users` | `MTA_SUBMISSION_USERS` | unset | Submission 認証ユーザーを `user@example.com:password,...` 形式で指定します |
 | `-` | `MTA_SUBMISSION_USERS_FILE` | unset | `MTA_SUBMISSION_USERS` の代わりにファイルから Submission 認証情報を読み込みます |
+| `submission_auth_dsn` | `MTA_SUBMISSION_AUTH_DSN` | unset | `submission_auth_backend: sqlite` で使う SQLite DSN です |
 | `admin_tokens` | `MTA_ADMIN_TOKENS` | unset | Admin API の Bearer token と role を `token:role,...` または `sha256=<hex>:role,...` 形式で指定します |
 | `-` | `MTA_ADMIN_TOKENS_FILE` | unset | `MTA_ADMIN_TOKENS` の代わりにファイルから管理トークンを読み込みます |
 
@@ -43,11 +44,17 @@ go run ./cmd/kuroshio -config ./config.yaml
 | `listen_addr` | `MTA_LISTEN_ADDR` | `:2525` | SMTP 受信サーバーの待受アドレスです |
 | `submission_addr` | `MTA_SUBMISSION_ADDR` | unset | Submission リスナーの待受アドレスです。設定すると有効になります |
 | `submission_auth_required` | `MTA_SUBMISSION_AUTH_REQUIRED` | `true` | Submission で認証を必須にするかを制御します |
+| `submission_auth_backend` | `MTA_SUBMISSION_AUTH_BACKEND` | `static` | Submission の認証 backend を切り替えます。`static` / `sqlite` を使います |
 | `submission_enforce_sender_identity` | `MTA_SUBMISSION_ENFORCE_SENDER_IDENTITY` | `true` | 認証ユーザーのドメインと `MAIL FROM` の整合を要求します |
 | `hostname` | `MTA_HOSTNAME` | `kuroshio.local` | SMTP 応答や配送で使うホスト名です |
 | `tls_cert_file` | `MTA_TLS_CERT_FILE` | unset | 受信側 TLS に使う証明書ファイルです |
 | `tls_key_file` | `MTA_TLS_KEY_FILE` | unset | 受信側 TLS に使う秘密鍵ファイルです |
 | `max_message_bytes` | `MTA_MAX_MESSAGE_BYTES` | `10485760` | 受信するメッセージの最大サイズです |
+
+補足:
+- `submission_auth_backend: static` では既存通り `submission_users` / `MTA_SUBMISSION_USERS(_FILE)` を使います
+- `submission_auth_backend: sqlite` では `submission_credentials` テーブルを参照し、`username`, `password_hash`, `enabled`, `expires_at`, `last_auth_at` を使います
+- `password_hash` は平文ではなく SHA-256 hex を保存します
 
 ## ログ・監視・運用 API
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,8 @@ type Config struct {
 	SubmissionAddr               string
 	SubmissionAuth               bool
 	SubmissionUsers              string
+	SubmissionAuthBackend        string
+	SubmissionAuthDSN            string
 	SubmissionSenderID           bool
 	LogLevel                     string
 	ObservabilityAddr            string
@@ -108,6 +110,8 @@ type yamlConfig struct {
 	SubmissionAddr               *string  `yaml:"submission_addr"`
 	SubmissionAuth               *bool    `yaml:"submission_auth_required"`
 	SubmissionUsers              *string  `yaml:"submission_users"`
+	SubmissionAuthBackend        *string  `yaml:"submission_auth_backend"`
+	SubmissionAuthDSN            *string  `yaml:"submission_auth_dsn"`
 	SubmissionSenderID           *bool    `yaml:"submission_enforce_sender_identity"`
 	LogLevel                     *string  `yaml:"log_level"`
 	ObservabilityAddr            *string  `yaml:"observability_addr"`
@@ -218,6 +222,8 @@ func LoadWithPath(explicitPath string) (Config, error) {
 	cfg.SubmissionAddr = env("MTA_SUBMISSION_ADDR", cfg.SubmissionAddr)
 	cfg.SubmissionAuth = envBool("MTA_SUBMISSION_AUTH_REQUIRED", cfg.SubmissionAuth)
 	cfg.SubmissionUsers = envOrFile("MTA_SUBMISSION_USERS", "MTA_SUBMISSION_USERS_FILE", cfg.SubmissionUsers)
+	cfg.SubmissionAuthBackend = envEnum("MTA_SUBMISSION_AUTH_BACKEND", cfg.SubmissionAuthBackend, []string{"static", "sqlite"})
+	cfg.SubmissionAuthDSN = env("MTA_SUBMISSION_AUTH_DSN", cfg.SubmissionAuthDSN)
 	cfg.SubmissionSenderID = envBool("MTA_SUBMISSION_ENFORCE_SENDER_IDENTITY", cfg.SubmissionSenderID)
 	cfg.LogLevel = env("MTA_LOG_LEVEL", cfg.LogLevel)
 	cfg.ObservabilityAddr = env("MTA_OBSERVABILITY_ADDR", cfg.ObservabilityAddr)
@@ -314,6 +320,8 @@ func defaultConfig() Config {
 		SubmissionAddr:               "",
 		SubmissionAuth:               true,
 		SubmissionUsers:              "",
+		SubmissionAuthBackend:        "static",
+		SubmissionAuthDSN:            "",
 		SubmissionSenderID:           true,
 		LogLevel:                     "info",
 		ObservabilityAddr:            ":9090",
@@ -441,6 +449,12 @@ func loadYAMLConfig(path string, base Config) (Config, error) {
 	}
 	if raw.SubmissionUsers != nil {
 		cfg.SubmissionUsers = *raw.SubmissionUsers
+	}
+	if raw.SubmissionAuthBackend != nil {
+		cfg.SubmissionAuthBackend = normalizeEnum(*raw.SubmissionAuthBackend, cfg.SubmissionAuthBackend, []string{"static", "sqlite"})
+	}
+	if raw.SubmissionAuthDSN != nil {
+		cfg.SubmissionAuthDSN = *raw.SubmissionAuthDSN
 	}
 	if raw.SubmissionSenderID != nil {
 		cfg.SubmissionSenderID = *raw.SubmissionSenderID

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -166,6 +166,7 @@ func TestLoadSubmissionConfig(t *testing.T) {
 	t.Setenv("MTA_SUBMISSION_ADDR", ":587")
 	t.Setenv("MTA_SUBMISSION_AUTH_REQUIRED", "true")
 	t.Setenv("MTA_SUBMISSION_USERS", "alice@example.com:s3cr3t")
+	t.Setenv("MTA_SUBMISSION_AUTH_BACKEND", "static")
 	t.Setenv("MTA_SUBMISSION_ENFORCE_SENDER_IDENTITY", "true")
 
 	cfg := mustLoadForTest(t)
@@ -178,8 +179,33 @@ func TestLoadSubmissionConfig(t *testing.T) {
 	if cfg.SubmissionUsers != "alice@example.com:s3cr3t" {
 		t.Fatalf("submission users=%q", cfg.SubmissionUsers)
 	}
+	if cfg.SubmissionAuthBackend != "static" {
+		t.Fatalf("submission auth backend=%q", cfg.SubmissionAuthBackend)
+	}
 	if !cfg.SubmissionSenderID {
 		t.Fatal("submission sender identity should be true")
+	}
+}
+
+func TestLoadSubmissionSQLiteConfig(t *testing.T) {
+	t.Setenv("MTA_SUBMISSION_ADDR", ":587")
+	t.Setenv("MTA_SUBMISSION_AUTH_BACKEND", "sqlite")
+	t.Setenv("MTA_SUBMISSION_AUTH_DSN", "file:./var/submission-auth.db")
+
+	cfg := mustLoadForTest(t)
+	if cfg.SubmissionAuthBackend != "sqlite" {
+		t.Fatalf("submission auth backend=%q", cfg.SubmissionAuthBackend)
+	}
+	if cfg.SubmissionAuthDSN != "file:./var/submission-auth.db" {
+		t.Fatalf("submission auth dsn=%q", cfg.SubmissionAuthDSN)
+	}
+}
+
+func TestLoadSubmissionAuthBackendFallsBackOnInvalidValue(t *testing.T) {
+	t.Setenv("MTA_SUBMISSION_AUTH_BACKEND", "unsupported")
+	cfg := mustLoadForTest(t)
+	if cfg.SubmissionAuthBackend != "static" {
+		t.Fatalf("submission auth backend=%q want=%q", cfg.SubmissionAuthBackend, "static")
 	}
 }
 

--- a/internal/userauth/sqlite_backend.go
+++ b/internal/userauth/sqlite_backend.go
@@ -1,0 +1,77 @@
+package userauth
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"log/slog"
+	"strings"
+
+	_ "modernc.org/sqlite"
+)
+
+type SQLiteBackend struct {
+	db *sql.DB
+}
+
+func NewSQLite(dsn string) (*SQLiteBackend, error) {
+	dsn = strings.TrimSpace(dsn)
+	if dsn == "" {
+		return nil, errors.New("submission auth sqlite dsn is required")
+	}
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxOpenConns(1)
+	if err := db.Ping(); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return &SQLiteBackend{db: db}, nil
+}
+
+func (b *SQLiteBackend) AuthenticatePassword(username, password string) (Principal, bool) {
+	if b == nil || b.db == nil {
+		return Principal{}, false
+	}
+	user := normalizeUsername(username)
+	password = strings.TrimSpace(password)
+	if user == "" || password == "" {
+		return Principal{}, false
+	}
+
+	var storedHash string
+	err := b.db.QueryRow(`
+SELECT password_hash
+FROM submission_credentials
+WHERE username = ?
+  AND enabled = 1
+  AND (expires_at IS NULL OR datetime(expires_at) > CURRENT_TIMESTAMP)
+LIMIT 1
+`, user).Scan(&storedHash)
+	if err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			slog.Error("submission sqlite auth lookup failed", "component", "smtp", "error", err, "username", user)
+		}
+		return Principal{}, false
+	}
+
+	sum := sha256.Sum256([]byte(password))
+	gotHash := hex.EncodeToString(sum[:])
+	if subtle.ConstantTimeCompare([]byte(strings.ToLower(strings.TrimSpace(storedHash))), []byte(gotHash)) != 1 {
+		return Principal{}, false
+	}
+
+	if _, err := b.db.Exec(`
+UPDATE submission_credentials
+SET last_auth_at = CURRENT_TIMESTAMP
+WHERE username = ?
+`, user); err != nil {
+		slog.Error("submission sqlite auth last_auth_at update failed", "component", "smtp", "error", err, "username", user)
+	}
+
+	return Principal{Username: user}, true
+}

--- a/internal/userauth/static_test.go
+++ b/internal/userauth/static_test.go
@@ -1,6 +1,16 @@
 package userauth
 
-import "testing"
+import (
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
 
 func TestNewStaticAndAuthenticatePassword(t *testing.T) {
 	b, err := NewStatic("alice@example.com:s3cr3t, bob@example.com:pass")
@@ -28,5 +38,123 @@ func TestNewStaticAndAuthenticatePassword(t *testing.T) {
 func TestNewStaticRejectsInvalidEntry(t *testing.T) {
 	if _, err := NewStatic("alice@example.com"); err == nil {
 		t.Fatal("invalid entry must fail")
+	}
+}
+
+func TestNewSQLiteAndAuthenticatePassword(t *testing.T) {
+	dsn := filepath.Join(t.TempDir(), "submission-auth.db")
+	db := openSubmissionSQLiteForTest(t, dsn)
+	seedSubmissionSQLiteForTest(t, db, "alice@example.com", "s3cr3t", true, nil)
+
+	backend, err := NewSQLite(dsn)
+	if err != nil {
+		t.Fatalf("new sqlite: %v", err)
+	}
+	principal, ok := backend.AuthenticatePassword("ALICE@EXAMPLE.COM", "s3cr3t")
+	if !ok {
+		t.Fatal("alice should authenticate")
+	}
+	if principal.Username != "alice@example.com" {
+		t.Fatalf("principal username=%q", principal.Username)
+	}
+
+	var lastAuthAt sql.NullString
+	if err := db.QueryRow(`SELECT last_auth_at FROM submission_credentials LIMIT 1`).Scan(&lastAuthAt); err != nil {
+		t.Fatalf("query last_auth_at: %v", err)
+	}
+	if !lastAuthAt.Valid || strings.TrimSpace(lastAuthAt.String) == "" {
+		t.Fatalf("last_auth_at should be updated, got=%+v", lastAuthAt)
+	}
+}
+
+func TestSQLiteRejectsDisabledExpiredOrWrongPassword(t *testing.T) {
+	t.Run("disabled user", func(t *testing.T) {
+		dsn := filepath.Join(t.TempDir(), "disabled.db")
+		db := openSubmissionSQLiteForTest(t, dsn)
+		seedSubmissionSQLiteForTest(t, db, "alice@example.com", "s3cr3t", false, nil)
+
+		backend, err := NewSQLite(dsn)
+		if err != nil {
+			t.Fatalf("new sqlite: %v", err)
+		}
+		if _, ok := backend.AuthenticatePassword("alice@example.com", "s3cr3t"); ok {
+			t.Fatal("disabled user must be rejected")
+		}
+	})
+
+	t.Run("expired user", func(t *testing.T) {
+		dsn := filepath.Join(t.TempDir(), "expired.db")
+		db := openSubmissionSQLiteForTest(t, dsn)
+		expiredAt := time.Now().Add(-time.Hour).UTC()
+		seedSubmissionSQLiteForTest(t, db, "alice@example.com", "s3cr3t", true, &expiredAt)
+
+		backend, err := NewSQLite(dsn)
+		if err != nil {
+			t.Fatalf("new sqlite: %v", err)
+		}
+		if _, ok := backend.AuthenticatePassword("alice@example.com", "s3cr3t"); ok {
+			t.Fatal("expired user must be rejected")
+		}
+	})
+
+	t.Run("wrong password", func(t *testing.T) {
+		dsn := filepath.Join(t.TempDir(), "wrong-pass.db")
+		db := openSubmissionSQLiteForTest(t, dsn)
+		seedSubmissionSQLiteForTest(t, db, "alice@example.com", "s3cr3t", true, nil)
+
+		backend, err := NewSQLite(dsn)
+		if err != nil {
+			t.Fatalf("new sqlite: %v", err)
+		}
+		if _, ok := backend.AuthenticatePassword("alice@example.com", "wrong"); ok {
+			t.Fatal("wrong password must fail")
+		}
+	})
+}
+
+func openSubmissionSQLiteForTest(t *testing.T, dsn string) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		t.Fatalf("open sqlite db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(`
+CREATE TABLE submission_credentials (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	username TEXT NOT NULL,
+	password_hash TEXT NOT NULL,
+	enabled INTEGER NOT NULL DEFAULT 1,
+	expires_at TEXT,
+	allowed_sender_domains TEXT,
+	allowed_sender_addresses TEXT,
+	description TEXT,
+	last_auth_at TEXT,
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+`); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	return db
+}
+
+func seedSubmissionSQLiteForTest(t *testing.T, db *sql.DB, username, password string, enabled bool, expiresAt *time.Time) {
+	t.Helper()
+	enabledInt := 0
+	if enabled {
+		enabledInt = 1
+	}
+	sum := sha256.Sum256([]byte(password))
+	passwordHash := hex.EncodeToString(sum[:])
+	var expires any
+	if expiresAt != nil {
+		expires = expiresAt.UTC().Format("2006-01-02 15:04:05")
+	}
+	if _, err := db.Exec(`
+INSERT INTO submission_credentials(username, password_hash, enabled, expires_at, description)
+VALUES (?, ?, ?, ?, ?)
+`, normalizeUsername(username), passwordHash, enabledInt, expires, "seed"); err != nil {
+		t.Fatalf("insert submission credential: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- Submission の static backend と切り替え可能な SQLite-backed password backend を追加
- `submission_auth_backend` / `submission_auth_dsn` を config と環境変数から読めるように変更
- 設定ドキュメントと example config に SQLite backend の利用方法を追記

## Related Issue
- Closes #247

## Validation
- [ ] `go vet ./...`
- [x] `go test ./...`
- [ ] `go test -race ./...`

## TDD Checklist
- [ ] Red: failing test was added first
- [x] Green: minimal implementation to pass tests
- [x] Refactor: cleanup completed without behavior change