### PR TITLE
Submission credential の sender scope を sender identity 判定へ反映

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,6 +54,7 @@ go run ./cmd/kuroshio -config ./config.yaml
 補足:
 - `submission_auth_backend: static` では既存通り `submission_users` / `MTA_SUBMISSION_USERS(_FILE)` を使います
 - `submission_auth_backend: sqlite` では `submission_credentials` テーブルを参照し、`username`, `password_hash`, `enabled`, `expires_at`, `last_auth_at` を使います
+- `submission_auth_backend: sqlite` では `allowed_sender_domains` / `allowed_sender_addresses` を使って sender identity の許可範囲を広げられます
 - `password_hash` は平文ではなく SHA-256 hex を保存します
 
 ## ログ・監視・運用 API

--- a/internal/smtp/server.go
+++ b/internal/smtp/server.go
@@ -139,6 +139,7 @@ type session struct {
 	extended bool
 	tls      bool
 	authUser string
+	auth     userauth.Principal
 	authOK   bool
 }
 
@@ -360,7 +361,7 @@ func (s *Server) handleConnWithContext(ctx context.Context, conn net.Conn) {
 				writeResp(w, 552, "message size exceeds fixed maximum message size")
 				continue
 			}
-			if s.submission && s.cfg.SubmissionSenderID && ss.authOK && !senderAllowedForAuth(ss.authUser, mailArgs.Address) {
+			if s.submission && s.cfg.SubmissionSenderID && ss.authOK && !senderAllowedForAuth(ss.auth, mailArgs.Address) {
 				cmdSpan.reject("sender_not_allowed_for_auth", 553, "sender address rejected for authenticated identity")
 				cmdSpan.end()
 				writeResp(w, 553, "sender address rejected for authenticated identity")
@@ -557,7 +558,7 @@ func (s *Server) handleConnWithContext(ctx context.Context, conn net.Conn) {
 				writeResp(w, 454, "authentication backend unavailable")
 				continue
 			}
-			user, ok, err := s.handleAuth(r, w, arg)
+			principal, ok, err := s.handleAuth(r, w, arg)
 			if err != nil {
 				cmdSpan.recordError(err)
 				cmdSpan.setResponse(501, err.Error())
@@ -572,11 +573,12 @@ func (s *Server) handleConnWithContext(ctx context.Context, conn net.Conn) {
 				writeResp(w, 535, "authentication credentials invalid")
 				continue
 			}
-			ss.authUser = user
+			ss.authUser = principal.Username
+			ss.auth = principal
 			ss.authOK = true
 			cmdSpan.SetAttributes(
 				attribute.Bool("smtp.auth.success", true),
-				attribute.String("smtp.auth.user", logging.MaskEmail(user)),
+				attribute.String("smtp.auth.user", logging.MaskEmail(principal.Username)),
 			)
 			cmdSpan.setResponse(235, "authentication successful")
 			cmdSpan.end()
@@ -629,6 +631,7 @@ func (s *Server) handleConnWithContext(ctx context.Context, conn net.Conn) {
 			ss.rcptTo = nil
 			ss.data = nil
 			ss.authUser = ""
+			ss.auth = userauth.Principal{}
 			ss.authOK = false
 			cmdSpan.SetAttributes(attribute.Bool("smtp.tls", true))
 			cmdSpan.setResponse(220, "Ready to start TLS")
@@ -1009,9 +1012,9 @@ func isASCII(s string) bool {
 	return true
 }
 
-func (s *Server) handleAuth(r *bufio.Reader, w *bufio.Writer, arg string) (string, bool, error) {
+func (s *Server) handleAuth(r *bufio.Reader, w *bufio.Writer, arg string) (userauth.Principal, bool, error) {
 	if strings.TrimSpace(arg) == "" {
-		return "", false, errors.New("AUTH requires mechanism")
+		return userauth.Principal{}, false, errors.New("AUTH requires mechanism")
 	}
 	parts := strings.Fields(arg)
 	mech := strings.ToUpper(parts[0])
@@ -1022,67 +1025,67 @@ func (s *Server) handleAuth(r *bufio.Reader, w *bufio.Writer, arg string) (strin
 			payload = parts[1]
 		} else {
 			if err := writeLine(w, "334 "); err != nil {
-				return "", false, err
+				return userauth.Principal{}, false, err
 			}
 			line, err := r.ReadString('\n')
 			if err != nil {
-				return "", false, err
+				return userauth.Principal{}, false, err
 			}
 			payload = strings.TrimSpace(line)
 		}
 		user, pass, err := decodeAuthPlain(payload)
 		if err != nil {
-			return "", false, err
+			return userauth.Principal{}, false, err
 		}
 		principal, ok := s.authBackend.AuthenticatePassword(user, pass)
 		if !ok {
-			return user, false, nil
+			return userauth.Principal{Username: user}, false, nil
 		}
-		return principal.Username, true, nil
+		return principal, true, nil
 	case "LOGIN":
 		var userRaw []byte
 		if len(parts) >= 2 {
 			var err error
 			userRaw, err = decodeBase64Line(parts[1])
 			if err != nil {
-				return "", false, errors.New("invalid base64 username")
+				return userauth.Principal{}, false, errors.New("invalid base64 username")
 			}
 		} else {
 			if err := writeLine(w, "334 VXNlcm5hbWU6"); err != nil {
-				return "", false, err
+				return userauth.Principal{}, false, err
 			}
 			userLine, err := r.ReadString('\n')
 			if err != nil {
-				return "", false, err
+				return userauth.Principal{}, false, err
 			}
 			userRaw, err = decodeBase64Line(userLine)
 			if err != nil {
-				return "", false, errors.New("invalid base64 username")
+				return userauth.Principal{}, false, errors.New("invalid base64 username")
 			}
 		}
 		if err := writeLine(w, "334 UGFzc3dvcmQ6"); err != nil {
-			return "", false, err
+			return userauth.Principal{}, false, err
 		}
 		passLine, err := r.ReadString('\n')
 		if err != nil {
-			return "", false, err
+			return userauth.Principal{}, false, err
 		}
 		passRaw, err := decodeBase64Line(passLine)
 		if err != nil {
-			return "", false, errors.New("invalid base64 password")
+			return userauth.Principal{}, false, errors.New("invalid base64 password")
 		}
 		user := strings.TrimSpace(string(userRaw))
 		pass := strings.TrimSpace(string(passRaw))
 		if user == "" || pass == "" {
-			return "", false, errors.New("empty credentials")
+			return userauth.Principal{}, false, errors.New("empty credentials")
 		}
 		principal, ok := s.authBackend.AuthenticatePassword(user, pass)
 		if !ok {
-			return user, false, nil
+			return userauth.Principal{Username: user}, false, nil
 		}
-		return principal.Username, true, nil
+		return principal, true, nil
 	default:
-		return "", false, errors.New("unsupported auth mechanism")
+		return userauth.Principal{}, false, errors.New("unsupported auth mechanism")
 	}
 }
 
@@ -1115,12 +1118,28 @@ func authMechanism(arg string) (string, bool) {
 	return strings.ToUpper(parts[0]), true
 }
 
-func senderAllowedForAuth(authUser, mailFrom string) bool {
-	authDomain, ok := util.DomainOf(strings.ToLower(strings.TrimSpace(authUser)))
+func senderAllowedForAuth(principal userauth.Principal, mailFrom string) bool {
+	mailFrom = strings.ToLower(strings.TrimSpace(mailFrom))
+	if mailFrom == "" {
+		return false
+	}
+	for _, allowed := range principal.AllowedSenderAddresses {
+		if strings.EqualFold(strings.TrimSpace(allowed), mailFrom) {
+			return true
+		}
+	}
+	if fromDomain, ok := util.DomainOf(mailFrom); ok {
+		for _, allowed := range principal.AllowedSenderDomains {
+			if strings.EqualFold(strings.TrimSpace(allowed), fromDomain) {
+				return true
+			}
+		}
+	}
+	authDomain, ok := util.DomainOf(strings.ToLower(strings.TrimSpace(principal.Username)))
 	if !ok {
 		return false
 	}
-	fromDomain, ok := util.DomainOf(strings.ToLower(strings.TrimSpace(mailFrom)))
+	fromDomain, ok := util.DomainOf(mailFrom)
 	if !ok {
 		return false
 	}

--- a/internal/smtp/server_test.go
+++ b/internal/smtp/server_test.go
@@ -1208,6 +1208,76 @@ func TestSubmissionSenderIdentityMismatchRejected(t *testing.T) {
 	}
 }
 
+func TestSubmissionSenderIdentityAllowsScopedAddress(t *testing.T) {
+	s := &Server{
+		cfg: config.Config{
+			Hostname:           "sub.example.test",
+			SubmissionAuth:     true,
+			SubmissionSenderID: true,
+		},
+		submission: true,
+		authBackend: fakeUserAuthBackend{
+			principal: userauth.Principal{
+				Username:               "alice@example.com",
+				AllowedSenderAddresses: []string{"billing@other.example"},
+			},
+			ok: true,
+		},
+	}
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	go s.handleConn(server)
+
+	r := bufio.NewReader(client)
+	w := bufio.NewWriter(client)
+	_, _ = readSMTPResponse(t, r)
+	mustWriteSMTPLine(t, w, "EHLO client.example")
+	_, _ = readSMTPResponse(t, r)
+	mustWriteSMTPLine(t, w, "AUTH PLAIN AGFsaWNlQGV4YW1wbGUuY29tAHMzY3IzdA==")
+	_, _ = readSMTPResponse(t, r)
+	mustWriteSMTPLine(t, w, "MAIL FROM:<billing@other.example>")
+	_, code := readSMTPResponse(t, r)
+	if code != 250 {
+		t.Fatalf("code=%d want=250", code)
+	}
+}
+
+func TestSubmissionSenderIdentityAllowsScopedDomain(t *testing.T) {
+	s := &Server{
+		cfg: config.Config{
+			Hostname:           "sub.example.test",
+			SubmissionAuth:     true,
+			SubmissionSenderID: true,
+		},
+		submission: true,
+		authBackend: fakeUserAuthBackend{
+			principal: userauth.Principal{
+				Username:             "alice@example.com",
+				AllowedSenderDomains: []string{"other.example"},
+			},
+			ok: true,
+		},
+	}
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	go s.handleConn(server)
+
+	r := bufio.NewReader(client)
+	w := bufio.NewWriter(client)
+	_, _ = readSMTPResponse(t, r)
+	mustWriteSMTPLine(t, w, "EHLO client.example")
+	_, _ = readSMTPResponse(t, r)
+	mustWriteSMTPLine(t, w, "AUTH PLAIN AGFsaWNlQGV4YW1wbGUuY29tAHMzY3IzdA==")
+	_, _ = readSMTPResponse(t, r)
+	mustWriteSMTPLine(t, w, "MAIL FROM:<ops@other.example>")
+	_, code := readSMTPResponse(t, r)
+	if code != 250 {
+		t.Fatalf("code=%d want=250", code)
+	}
+}
+
 func TestSubmissionSTARTTLSResetsAuthState(t *testing.T) {
 	cert, err := selfSignedCert()
 	if err != nil {
@@ -1286,6 +1356,21 @@ func mustWriteSMTPLine(t *testing.T, w *bufio.Writer, line string) {
 
 type recordingQueue struct {
 	msgs []*model.Message
+}
+
+type fakeUserAuthBackend struct {
+	principal userauth.Principal
+	ok        bool
+}
+
+func (f fakeUserAuthBackend) AuthenticatePassword(username, password string) (userauth.Principal, bool) {
+	if !f.ok {
+		return userauth.Principal{}, false
+	}
+	if strings.TrimSpace(f.principal.Username) == "" {
+		f.principal.Username = strings.ToLower(strings.TrimSpace(username))
+	}
+	return f.principal, true
 }
 
 func (q *recordingQueue) Enqueue(msg *model.Message) error {

--- a/internal/userauth/backend.go
+++ b/internal/userauth/backend.go
@@ -6,7 +6,9 @@ import (
 )
 
 type Principal struct {
-	Username string
+	Username               string
+	AllowedSenderDomains   []string
+	AllowedSenderAddresses []string
 }
 
 type Backend interface {

--- a/internal/userauth/sqlite_backend.go
+++ b/internal/userauth/sqlite_backend.go
@@ -44,14 +44,16 @@ func (b *SQLiteBackend) AuthenticatePassword(username, password string) (Princip
 	}
 
 	var storedHash string
+	var allowedDomains sql.NullString
+	var allowedAddresses sql.NullString
 	err := b.db.QueryRow(`
-SELECT password_hash
+SELECT password_hash, allowed_sender_domains, allowed_sender_addresses
 FROM submission_credentials
 WHERE username = ?
   AND enabled = 1
   AND (expires_at IS NULL OR datetime(expires_at) > CURRENT_TIMESTAMP)
 LIMIT 1
-`, user).Scan(&storedHash)
+`, user).Scan(&storedHash, &allowedDomains, &allowedAddresses)
 	if err != nil {
 		if !errors.Is(err, sql.ErrNoRows) {
 			slog.Error("submission sqlite auth lookup failed", "component", "smtp", "error", err, "username", user)
@@ -73,5 +75,27 @@ WHERE username = ?
 		slog.Error("submission sqlite auth last_auth_at update failed", "component", "smtp", "error", err, "username", user)
 	}
 
-	return Principal{Username: user}, true
+	return Principal{
+		Username:               user,
+		AllowedSenderDomains:   parseCSVAllowList(allowedDomains.String),
+		AllowedSenderAddresses: parseCSVAllowList(allowedAddresses.String),
+	}, true
+}
+
+func parseCSVAllowList(v string) []string {
+	if strings.TrimSpace(v) == "" {
+		return nil
+	}
+	items := make([]string, 0, 4)
+	for _, part := range strings.Split(v, ",") {
+		part = normalizeUsername(part)
+		if part == "" {
+			continue
+		}
+		items = append(items, part)
+	}
+	if len(items) == 0 {
+		return nil
+	}
+	return items
 }

--- a/internal/userauth/static_test.go
+++ b/internal/userauth/static_test.go
@@ -24,6 +24,9 @@ func TestNewStaticAndAuthenticatePassword(t *testing.T) {
 	if principal.Username != "alice@example.com" {
 		t.Fatalf("principal username=%q", principal.Username)
 	}
+	if len(principal.AllowedSenderDomains) != 0 || len(principal.AllowedSenderAddresses) != 0 {
+		t.Fatalf("static principal sender scopes should be empty: %+v", principal)
+	}
 	if _, ok := b.AuthenticatePassword("ALICE@EXAMPLE.COM", "s3cr3t"); !ok {
 		t.Fatal("username lookup should be case-insensitive")
 	}
@@ -140,6 +143,10 @@ CREATE TABLE submission_credentials (
 }
 
 func seedSubmissionSQLiteForTest(t *testing.T, db *sql.DB, username, password string, enabled bool, expiresAt *time.Time) {
+	seedSubmissionSQLiteForTestWithScope(t, db, username, password, enabled, expiresAt, "", "")
+}
+
+func seedSubmissionSQLiteForTestWithScope(t *testing.T, db *sql.DB, username, password string, enabled bool, expiresAt *time.Time, domains, addresses string) {
 	t.Helper()
 	enabledInt := 0
 	if enabled {
@@ -152,9 +159,30 @@ func seedSubmissionSQLiteForTest(t *testing.T, db *sql.DB, username, password st
 		expires = expiresAt.UTC().Format("2006-01-02 15:04:05")
 	}
 	if _, err := db.Exec(`
-INSERT INTO submission_credentials(username, password_hash, enabled, expires_at, description)
-VALUES (?, ?, ?, ?, ?)
-`, normalizeUsername(username), passwordHash, enabledInt, expires, "seed"); err != nil {
+INSERT INTO submission_credentials(username, password_hash, enabled, expires_at, allowed_sender_domains, allowed_sender_addresses, description)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+`, normalizeUsername(username), passwordHash, enabledInt, expires, domains, addresses, "seed"); err != nil {
 		t.Fatalf("insert submission credential: %v", err)
+	}
+}
+
+func TestSQLiteReturnsSenderScopes(t *testing.T) {
+	dsn := filepath.Join(t.TempDir(), "scope.db")
+	db := openSubmissionSQLiteForTest(t, dsn)
+	seedSubmissionSQLiteForTestWithScope(t, db, "alice@example.com", "s3cr3t", true, nil, "example.com,example.org", "alerts@example.net, billing@example.net ")
+
+	backend, err := NewSQLite(dsn)
+	if err != nil {
+		t.Fatalf("new sqlite: %v", err)
+	}
+	principal, ok := backend.AuthenticatePassword("alice@example.com", "s3cr3t")
+	if !ok {
+		t.Fatal("alice should authenticate")
+	}
+	if len(principal.AllowedSenderDomains) != 2 || principal.AllowedSenderDomains[0] != "example.com" || principal.AllowedSenderDomains[1] != "example.org" {
+		t.Fatalf("allowed sender domains=%v", principal.AllowedSenderDomains)
+	}
+	if len(principal.AllowedSenderAddresses) != 2 || principal.AllowedSenderAddresses[0] != "alerts@example.net" || principal.AllowedSenderAddresses[1] != "billing@example.net" {
+		t.Fatalf("allowed sender addresses=%v", principal.AllowedSenderAddresses)
 	}
 }


### PR DESCRIPTION
## Summary
- Submission auth principal に sender scope を持たせ、SMTP sender identity 判定を principal ベースへ変更
- SQLite backend で `allowed_sender_domains` / `allowed_sender_addresses` を読み込むように変更
- sender scope 未設定時は既存の username ドメイン一致を fallback に維持

## Related Issue
- Closes #249

## Validation
- [ ] `go vet ./...`
- [x] `go test ./...`
- [ ] `go test -race ./...`

## TDD Checklist
- [ ] Red: failing test was added first
- [x] Green: minimal implementation to pass tests
- [x] Refactor: cleanup completed without behavior change