### PR TITLE
Submission 認証の trace に backend と sender scope 情報を追加

### DIFF
--- a/internal/smtp/server.go
+++ b/internal/smtp/server.go
@@ -362,6 +362,14 @@ func (s *Server) handleConnWithContext(ctx context.Context, conn net.Conn) {
 				continue
 			}
 			if s.submission && s.cfg.SubmissionSenderID && ss.authOK && !senderAllowedForAuth(ss.auth, mailArgs.Address) {
+				scopeMode := submissionSenderScopeMode(ss.auth)
+				cmdSpan.SetAttributes(
+					attribute.String("smtp.auth.backend", ss.auth.AuthSource),
+					attribute.String("smtp.auth.sender_scope_mode", scopeMode),
+					attribute.Int("smtp.auth.allowed_sender_domain_count", len(ss.auth.AllowedSenderDomains)),
+					attribute.Int("smtp.auth.allowed_sender_address_count", len(ss.auth.AllowedSenderAddresses)),
+				)
+				slog.WarnContext(ctx, "submission sender identity rejected", "component", "smtp", "reason", "sender_scope_mismatch", "auth_backend", ss.auth.AuthSource, "auth_user", logging.MaskEmail(ss.auth.Username), "mail_from", logging.MaskEmail(mailArgs.Address), "sender_scope_mode", scopeMode)
 				cmdSpan.reject("sender_not_allowed_for_auth", 553, "sender address rejected for authenticated identity")
 				cmdSpan.end()
 				writeResp(w, 553, "sender address rejected for authenticated identity")
@@ -567,7 +575,10 @@ func (s *Server) handleConnWithContext(ctx context.Context, conn net.Conn) {
 				continue
 			}
 			if !ok {
-				cmdSpan.SetAttributes(attribute.Bool("smtp.auth.success", false))
+				cmdSpan.SetAttributes(
+					attribute.Bool("smtp.auth.success", false),
+					attribute.String("smtp.auth.user", logging.MaskEmail(principal.Username)),
+				)
 				cmdSpan.reject("invalid_credentials", 535, "authentication credentials invalid")
 				cmdSpan.end()
 				writeResp(w, 535, "authentication credentials invalid")
@@ -578,7 +589,11 @@ func (s *Server) handleConnWithContext(ctx context.Context, conn net.Conn) {
 			ss.authOK = true
 			cmdSpan.SetAttributes(
 				attribute.Bool("smtp.auth.success", true),
+				attribute.String("smtp.auth.backend", principal.AuthSource),
 				attribute.String("smtp.auth.user", logging.MaskEmail(principal.Username)),
+				attribute.String("smtp.auth.sender_scope_mode", submissionSenderScopeMode(principal)),
+				attribute.Int("smtp.auth.allowed_sender_domain_count", len(principal.AllowedSenderDomains)),
+				attribute.Int("smtp.auth.allowed_sender_address_count", len(principal.AllowedSenderAddresses)),
 			)
 			cmdSpan.setResponse(235, "authentication successful")
 			cmdSpan.end()
@@ -1144,6 +1159,13 @@ func senderAllowedForAuth(principal userauth.Principal, mailFrom string) bool {
 		return false
 	}
 	return strings.EqualFold(authDomain, fromDomain)
+}
+
+func submissionSenderScopeMode(principal userauth.Principal) string {
+	if len(principal.AllowedSenderDomains) > 0 || len(principal.AllowedSenderAddresses) > 0 {
+		return "credential_scope"
+	}
+	return "username_domain_fallback"
 }
 
 func buildReceivedHeader(hostname, helo, remote, id string, now time.Time, extended, tlsOn bool) string {

--- a/internal/smtp/server_trace_test.go
+++ b/internal/smtp/server_trace_test.go
@@ -3,7 +3,10 @@ package smtp
 import (
 	"bufio"
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
+	"database/sql"
+	"encoding/hex"
 	"net"
 	"testing"
 	"time"
@@ -15,6 +18,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	_ "modernc.org/sqlite"
 )
 
 func TestSMTPTracingCapturesMailRcptAndDataSpans(t *testing.T) {
@@ -152,8 +156,71 @@ func TestSMTPTracingCapturesAuthSpan(t *testing.T) {
 	if got := attrBool(t, auth.Attributes, "smtp.auth.success"); !got {
 		t.Fatal("smtp.auth.success should be true")
 	}
+	if got := attrString(t, auth.Attributes, "smtp.auth.backend"); got != "static_password" {
+		t.Fatalf("smtp.auth.backend=%q want=%q", got, "static_password")
+	}
+	if got := attrString(t, auth.Attributes, "smtp.auth.sender_scope_mode"); got != "username_domain_fallback" {
+		t.Fatalf("smtp.auth.sender_scope_mode=%q want=%q", got, "username_domain_fallback")
+	}
 	if got := attrInt64(t, auth.Attributes, "smtp.response.code"); got != 235 {
 		t.Fatalf("smtp.auth response code=%d want=235", got)
+	}
+}
+
+func TestSMTPTracingCapturesSQLiteAuthScopeMetadata(t *testing.T) {
+	exp := setupSMTPTraceExporter(t)
+	dsn := t.TempDir() + "/submission-auth.db"
+	db := openSubmissionSQLiteForTraceTest(t, dsn)
+	seedSubmissionSQLiteForTraceTest(t, db, "alice@example.com", "s3cr3t", "other.example", "billing@other.example")
+
+	authBackend, err := userauth.NewSQLite(dsn)
+	if err != nil {
+		t.Fatalf("NewSQLite: %v", err)
+	}
+	s := NewSubmissionServer(
+		config.Config{
+			Hostname:           "mx.example.test",
+			SubmissionAddr:     "127.0.0.1:587",
+			SubmissionAuth:     true,
+			SubmissionSenderID: true,
+		},
+		&recordingQueue{},
+		nil,
+		authBackend,
+	)
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	go s.handleConn(server)
+
+	r := bufio.NewReader(client)
+	w := bufio.NewWriter(client)
+	_, _ = readSMTPResponse(t, r)
+	mustWriteSMTPLine(t, w, "EHLO client.example")
+	_, _ = readSMTPResponse(t, r)
+	mustWriteSMTPLine(t, w, "AUTH PLAIN AGFsaWNlQGV4YW1wbGUuY29tAHMzY3IzdA==")
+	_, code := readSMTPResponse(t, r)
+	if code != 235 {
+		t.Fatalf("auth code=%d want=235", code)
+	}
+	mustWriteSMTPLine(t, w, "QUIT")
+	_, quitCode := readSMTPResponse(t, r)
+	if quitCode != 221 {
+		t.Fatalf("quit code=%d want=221", quitCode)
+	}
+
+	auth := requireSpan(t, waitForSpans(t, exp, "smtp.auth"), "smtp.auth")
+	if got := attrString(t, auth.Attributes, "smtp.auth.backend"); got != "sqlite_password" {
+		t.Fatalf("smtp.auth.backend=%q want=%q", got, "sqlite_password")
+	}
+	if got := attrString(t, auth.Attributes, "smtp.auth.sender_scope_mode"); got != "credential_scope" {
+		t.Fatalf("smtp.auth.sender_scope_mode=%q want=%q", got, "credential_scope")
+	}
+	if got := attrInt64(t, auth.Attributes, "smtp.auth.allowed_sender_domain_count"); got != 1 {
+		t.Fatalf("smtp.auth.allowed_sender_domain_count=%d want=1", got)
+	}
+	if got := attrInt64(t, auth.Attributes, "smtp.auth.allowed_sender_address_count"); got != 1 {
+		t.Fatalf("smtp.auth.allowed_sender_address_count=%d want=1", got)
 	}
 }
 
@@ -303,4 +370,42 @@ func attrBool(t *testing.T, attrs []attribute.KeyValue, key string) bool {
 	}
 	t.Fatalf("attribute %q not found", key)
 	return false
+}
+
+func openSubmissionSQLiteForTraceTest(t *testing.T, dsn string) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		t.Fatalf("open sqlite db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(`
+CREATE TABLE submission_credentials (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	username TEXT NOT NULL,
+	password_hash TEXT NOT NULL,
+	enabled INTEGER NOT NULL DEFAULT 1,
+	expires_at TEXT,
+	allowed_sender_domains TEXT,
+	allowed_sender_addresses TEXT,
+	description TEXT,
+	last_auth_at TEXT,
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+`); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	return db
+}
+
+func seedSubmissionSQLiteForTraceTest(t *testing.T, db *sql.DB, username, password, domains, addresses string) {
+	t.Helper()
+	sum := sha256.Sum256([]byte(password))
+	if _, err := db.Exec(`
+INSERT INTO submission_credentials(username, password_hash, enabled, allowed_sender_domains, allowed_sender_addresses, description)
+VALUES (?, ?, 1, ?, ?, ?)
+`, username, hex.EncodeToString(sum[:]), domains, addresses, "trace-test"); err != nil {
+		t.Fatalf("insert submission credential: %v", err)
+	}
 }

--- a/internal/userauth/backend.go
+++ b/internal/userauth/backend.go
@@ -6,6 +6,7 @@ import (
 )
 
 type Principal struct {
+	AuthSource             string
 	Username               string
 	AllowedSenderDomains   []string
 	AllowedSenderAddresses []string
@@ -53,7 +54,10 @@ func (b *StaticBackend) AuthenticatePassword(username, password string) (Princip
 	if !ok || pw != password {
 		return Principal{}, false
 	}
-	return Principal{Username: u}, true
+	return Principal{
+		AuthSource: "static_password",
+		Username:   u,
+	}, true
 }
 
 func normalizeUsername(username string) string {

--- a/internal/userauth/sqlite_backend.go
+++ b/internal/userauth/sqlite_backend.go
@@ -76,6 +76,7 @@ WHERE username = ?
 	}
 
 	return Principal{
+		AuthSource:             "sqlite_password",
 		Username:               user,
 		AllowedSenderDomains:   parseCSVAllowList(allowedDomains.String),
 		AllowedSenderAddresses: parseCSVAllowList(allowedAddresses.String),


### PR DESCRIPTION
## Summary
- Submission 認証成功時の `smtp.auth` span に backend 種別と sender scope 情報を追加
- sender identity reject 時にも backend / scope mode を trace と log に残すように変更
- static / sqlite backend の違いを trace テストで確認できるように変更

## Related Issue
- Closes #251

## Validation
- [ ] `go vet ./...`
- [x] `go test ./...`
- [ ] `go test -race ./...`

## TDD Checklist
- [ ] Red: failing test was added first
- [x] Green: minimal implementation to pass tests
- [x] Refactor: cleanup completed without behavior change