### PR TITLE
Submission 認証の structured log と runbook を追加

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,7 @@ features:
 - [TLS 配送ポリシーを試す](/tutorials/tls-policy)
 - [Rate Limit を試す](/tutorials/rate-limit)
 - [Admin API を試す](/tutorials/admin-operations)
+- [Submission Auth Runbook](/runbooks/submission_auth)
 - [設定ガイド](/configuration)
 - [Observability Stack](/observability_stack)
 - [Observability Signals](/observability_signals)

--- a/docs/runbooks/submission_auth.md
+++ b/docs/runbooks/submission_auth.md
@@ -1,0 +1,88 @@
+# Submission Auth Runbook
+
+Issue: #251
+
+## 目的
+
+- Submission 認証失敗の原因を trace / log から切り分ける
+- static backend と SQLite backend の違いを運用時に判別する
+- sender identity 制約と sender scope 制約の効き方を確認する
+
+## 見る場所
+
+- trace: `smtp.auth` span
+- trace: `smtp.mail` span の reject reason
+- log: `submission auth succeeded`
+- log: `submission auth failed`
+- log: `submission sender identity rejected`
+
+## `smtp.auth` span で見る項目
+
+- `smtp.auth.mechanism`
+- `smtp.auth.success`
+- `smtp.auth.user`
+- `smtp.auth.backend`
+- `smtp.auth.failure_reason`
+- `smtp.auth.sender_scope_mode`
+- `smtp.auth.allowed_sender_domain_count`
+- `smtp.auth.allowed_sender_address_count`
+
+## backend 種別
+
+- `static_password`
+  `submission_users` / `MTA_SUBMISSION_USERS(_FILE)` を使う
+- `sqlite_password`
+  `submission_auth_backend=sqlite` と `submission_auth_dsn` を使う
+
+## failure reason
+
+- `credential_not_found`
+  username に対応する credential がない
+- `invalid_password`
+  password hash が一致しない
+- `credential_disabled`
+  credential はあるが `enabled=false`
+- `credential_expired`
+  `expires_at` を過ぎている
+- `empty_credentials`
+  backend 呼び出し時点で username または password が空
+- `backend_unavailable`
+  backend 初期化や注入に失敗している
+- `backend_error`
+  SQLite lookup や expiry check の内部エラー
+
+SMTP client への応答は従来どおり一般化されており、
+失敗時は基本的に `535 authentication credentials invalid` を返す。
+詳細は trace / log で確認する。
+
+## sender scope mode
+
+- `username_domain_fallback`
+  sender scope 未設定で、認証 username のドメイン一致を使っている
+- `credential_scope`
+  `allowed_sender_domains` または `allowed_sender_addresses` を使っている
+
+## sender identity reject の見方
+
+`submission sender identity rejected` ログでは次を見る。
+
+- `auth_backend`
+- `auth_user`
+- `mail_from`
+- `sender_scope_mode`
+- `reason=sender_scope_mismatch`
+
+trace 側では `smtp.mail` span の reject reason が
+`sender_not_allowed_for_auth` になる。
+
+## SQLite backend の確認ポイント
+
+- `submission_credentials.last_auth_at` が更新されているか
+- `allowed_sender_domains` / `allowed_sender_addresses` の値が意図どおりか
+- `expires_at` が SQLite `datetime()` で解釈できる形式か
+
+## 関連ドキュメント
+
+- [Configuration](/configuration)
+- [RFC 4954 Gap Note](/rfc_4954_gap)
+- [SMTP AUTH Modern Auth Direction](/architecture/smtp_auth_modern_auth)

--- a/internal/smtp/server.go
+++ b/internal/smtp/server.go
@@ -566,7 +566,7 @@ func (s *Server) handleConnWithContext(ctx context.Context, conn net.Conn) {
 				writeResp(w, 454, "authentication backend unavailable")
 				continue
 			}
-			principal, ok, err := s.handleAuth(r, w, arg)
+			authRes, err := s.handleAuth(r, w, arg)
 			if err != nil {
 				cmdSpan.recordError(err)
 				cmdSpan.setResponse(501, err.Error())
@@ -574,16 +574,20 @@ func (s *Server) handleConnWithContext(ctx context.Context, conn net.Conn) {
 				writeResp(w, 501, err.Error())
 				continue
 			}
-			if !ok {
+			if !authRes.Success {
 				cmdSpan.SetAttributes(
 					attribute.Bool("smtp.auth.success", false),
-					attribute.String("smtp.auth.user", logging.MaskEmail(principal.Username)),
+					attribute.String("smtp.auth.backend", authRes.Principal.AuthSource),
+					attribute.String("smtp.auth.user", logging.MaskEmail(authRes.Principal.Username)),
+					attribute.String("smtp.auth.failure_reason", authRes.FailureReason),
 				)
+				slog.WarnContext(ctx, "submission auth failed", "component", "smtp", "auth_backend", authRes.Principal.AuthSource, "auth_user", logging.MaskEmail(authRes.Principal.Username), "mechanism", mech, "failure_reason", authRes.FailureReason)
 				cmdSpan.reject("invalid_credentials", 535, "authentication credentials invalid")
 				cmdSpan.end()
 				writeResp(w, 535, "authentication credentials invalid")
 				continue
 			}
+			principal := authRes.Principal
 			ss.authUser = principal.Username
 			ss.auth = principal
 			ss.authOK = true
@@ -595,6 +599,7 @@ func (s *Server) handleConnWithContext(ctx context.Context, conn net.Conn) {
 				attribute.Int("smtp.auth.allowed_sender_domain_count", len(principal.AllowedSenderDomains)),
 				attribute.Int("smtp.auth.allowed_sender_address_count", len(principal.AllowedSenderAddresses)),
 			)
+			slog.InfoContext(ctx, "submission auth succeeded", "component", "smtp", "auth_backend", principal.AuthSource, "auth_user", logging.MaskEmail(principal.Username), "mechanism", mech, "sender_scope_mode", submissionSenderScopeMode(principal), "allowed_sender_domain_count", len(principal.AllowedSenderDomains), "allowed_sender_address_count", len(principal.AllowedSenderAddresses))
 			cmdSpan.setResponse(235, "authentication successful")
 			cmdSpan.end()
 			writeResp(w, 235, "authentication successful")
@@ -1027,9 +1032,9 @@ func isASCII(s string) bool {
 	return true
 }
 
-func (s *Server) handleAuth(r *bufio.Reader, w *bufio.Writer, arg string) (userauth.Principal, bool, error) {
+func (s *Server) handleAuth(r *bufio.Reader, w *bufio.Writer, arg string) (userauth.AuthResult, error) {
 	if strings.TrimSpace(arg) == "" {
-		return userauth.Principal{}, false, errors.New("AUTH requires mechanism")
+		return userauth.AuthResult{}, errors.New("AUTH requires mechanism")
 	}
 	parts := strings.Fields(arg)
 	mech := strings.ToUpper(parts[0])
@@ -1040,67 +1045,67 @@ func (s *Server) handleAuth(r *bufio.Reader, w *bufio.Writer, arg string) (usera
 			payload = parts[1]
 		} else {
 			if err := writeLine(w, "334 "); err != nil {
-				return userauth.Principal{}, false, err
+				return userauth.AuthResult{}, err
 			}
 			line, err := r.ReadString('\n')
 			if err != nil {
-				return userauth.Principal{}, false, err
+				return userauth.AuthResult{}, err
 			}
 			payload = strings.TrimSpace(line)
 		}
 		user, pass, err := decodeAuthPlain(payload)
 		if err != nil {
-			return userauth.Principal{}, false, err
+			return userauth.AuthResult{}, err
+		}
+		if detailed, ok := s.authBackend.(userauth.DetailedBackend); ok {
+			return detailed.AuthenticatePasswordDetailed(user, pass), nil
 		}
 		principal, ok := s.authBackend.AuthenticatePassword(user, pass)
-		if !ok {
-			return userauth.Principal{Username: user}, false, nil
-		}
-		return principal, true, nil
+		return userauth.AuthResult{Principal: principal, Success: ok}, nil
 	case "LOGIN":
 		var userRaw []byte
 		if len(parts) >= 2 {
 			var err error
 			userRaw, err = decodeBase64Line(parts[1])
 			if err != nil {
-				return userauth.Principal{}, false, errors.New("invalid base64 username")
+				return userauth.AuthResult{}, errors.New("invalid base64 username")
 			}
 		} else {
 			if err := writeLine(w, "334 VXNlcm5hbWU6"); err != nil {
-				return userauth.Principal{}, false, err
+				return userauth.AuthResult{}, err
 			}
 			userLine, err := r.ReadString('\n')
 			if err != nil {
-				return userauth.Principal{}, false, err
+				return userauth.AuthResult{}, err
 			}
 			userRaw, err = decodeBase64Line(userLine)
 			if err != nil {
-				return userauth.Principal{}, false, errors.New("invalid base64 username")
+				return userauth.AuthResult{}, errors.New("invalid base64 username")
 			}
 		}
 		if err := writeLine(w, "334 UGFzc3dvcmQ6"); err != nil {
-			return userauth.Principal{}, false, err
+			return userauth.AuthResult{}, err
 		}
 		passLine, err := r.ReadString('\n')
 		if err != nil {
-			return userauth.Principal{}, false, err
+			return userauth.AuthResult{}, err
 		}
 		passRaw, err := decodeBase64Line(passLine)
 		if err != nil {
-			return userauth.Principal{}, false, errors.New("invalid base64 password")
+			return userauth.AuthResult{}, errors.New("invalid base64 password")
 		}
 		user := strings.TrimSpace(string(userRaw))
 		pass := strings.TrimSpace(string(passRaw))
 		if user == "" || pass == "" {
-			return userauth.Principal{}, false, errors.New("empty credentials")
+			return userauth.AuthResult{}, errors.New("empty credentials")
+		}
+		if detailed, ok := s.authBackend.(userauth.DetailedBackend); ok {
+			return detailed.AuthenticatePasswordDetailed(user, pass), nil
 		}
 		principal, ok := s.authBackend.AuthenticatePassword(user, pass)
-		if !ok {
-			return userauth.Principal{Username: user}, false, nil
-		}
-		return principal, true, nil
+		return userauth.AuthResult{Principal: principal, Success: ok}, nil
 	default:
-		return userauth.Principal{}, false, errors.New("unsupported auth mechanism")
+		return userauth.AuthResult{}, errors.New("unsupported auth mechanism")
 	}
 }
 

--- a/internal/smtp/server_trace_test.go
+++ b/internal/smtp/server_trace_test.go
@@ -224,6 +224,52 @@ func TestSMTPTracingCapturesSQLiteAuthScopeMetadata(t *testing.T) {
 	}
 }
 
+func TestSMTPTracingCapturesAuthFailureReason(t *testing.T) {
+	exp := setupSMTPTraceExporter(t)
+	authBackend, err := userauth.NewStatic("alice@example.com:s3cr3t")
+	if err != nil {
+		t.Fatalf("NewStatic: %v", err)
+	}
+	s := NewSubmissionServer(
+		config.Config{
+			Hostname:       "mx.example.test",
+			SubmissionAddr: "127.0.0.1:587",
+			SubmissionAuth: true,
+		},
+		&recordingQueue{},
+		nil,
+		authBackend,
+	)
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	go s.handleConn(server)
+
+	r := bufio.NewReader(client)
+	w := bufio.NewWriter(client)
+	_, _ = readSMTPResponse(t, r)
+	mustWriteSMTPLine(t, w, "EHLO client.example")
+	_, _ = readSMTPResponse(t, r)
+	mustWriteSMTPLine(t, w, "AUTH PLAIN AGFsaWNlQGV4YW1wbGUuY29tAHdyb25n")
+	_, code := readSMTPResponse(t, r)
+	if code != 535 {
+		t.Fatalf("auth code=%d want=535", code)
+	}
+	mustWriteSMTPLine(t, w, "QUIT")
+	_, _ = readSMTPResponse(t, r)
+
+	auth := requireSpan(t, waitForSpans(t, exp, "smtp.auth"), "smtp.auth")
+	if got := attrBool(t, auth.Attributes, "smtp.auth.success"); got {
+		t.Fatal("smtp.auth.success should be false")
+	}
+	if got := attrString(t, auth.Attributes, "smtp.auth.failure_reason"); got != "invalid_password" {
+		t.Fatalf("smtp.auth.failure_reason=%q want=%q", got, "invalid_password")
+	}
+	if got := attrString(t, auth.Attributes, "smtp.auth.backend"); got != "static_password" {
+		t.Fatalf("smtp.auth.backend=%q want=%q", got, "static_password")
+	}
+}
+
 func TestSMTPTracingCapturesStartTLSSpan(t *testing.T) {
 	exp := setupSMTPTraceExporter(t)
 	cert, err := selfSignedCert()

--- a/internal/userauth/backend.go
+++ b/internal/userauth/backend.go
@@ -5,6 +5,12 @@ import (
 	"strings"
 )
 
+type AuthResult struct {
+	Principal     Principal
+	Success       bool
+	FailureReason string
+}
+
 type Principal struct {
 	AuthSource             string
 	Username               string
@@ -14,6 +20,10 @@ type Principal struct {
 
 type Backend interface {
 	AuthenticatePassword(username, password string) (Principal, bool)
+}
+
+type DetailedBackend interface {
+	AuthenticatePasswordDetailed(username, password string) AuthResult
 }
 
 type StaticBackend struct {
@@ -46,18 +56,35 @@ func NewStatic(raw string) (*StaticBackend, error) {
 }
 
 func (b *StaticBackend) AuthenticatePassword(username, password string) (Principal, bool) {
+	result := b.AuthenticatePasswordDetailed(username, password)
+	return result.Principal, result.Success
+}
+
+func (b *StaticBackend) AuthenticatePasswordDetailed(username, password string) AuthResult {
 	if b == nil {
-		return Principal{}, false
+		return AuthResult{FailureReason: "backend_unavailable"}
 	}
 	u := normalizeUsername(username)
 	pw, ok := b.users[u]
-	if !ok || pw != password {
-		return Principal{}, false
+	if !ok {
+		return AuthResult{
+			Principal:     Principal{AuthSource: "static_password", Username: u},
+			FailureReason: "credential_not_found",
+		}
 	}
-	return Principal{
-		AuthSource: "static_password",
-		Username:   u,
-	}, true
+	if pw != password {
+		return AuthResult{
+			Principal:     Principal{AuthSource: "static_password", Username: u},
+			FailureReason: "invalid_password",
+		}
+	}
+	return AuthResult{
+		Principal: Principal{
+			AuthSource: "static_password",
+			Username:   u,
+		},
+		Success: true,
+	}
 }
 
 func normalizeUsername(username string) string {

--- a/internal/userauth/sqlite_backend.go
+++ b/internal/userauth/sqlite_backend.go
@@ -34,37 +34,78 @@ func NewSQLite(dsn string) (*SQLiteBackend, error) {
 }
 
 func (b *SQLiteBackend) AuthenticatePassword(username, password string) (Principal, bool) {
+	result := b.AuthenticatePasswordDetailed(username, password)
+	return result.Principal, result.Success
+}
+
+func (b *SQLiteBackend) AuthenticatePasswordDetailed(username, password string) AuthResult {
 	if b == nil || b.db == nil {
-		return Principal{}, false
+		return AuthResult{FailureReason: "backend_unavailable"}
 	}
 	user := normalizeUsername(username)
 	password = strings.TrimSpace(password)
 	if user == "" || password == "" {
-		return Principal{}, false
+		return AuthResult{
+			Principal:     Principal{AuthSource: "sqlite_password", Username: user},
+			FailureReason: "empty_credentials",
+		}
 	}
 
 	var storedHash string
 	var allowedDomains sql.NullString
 	var allowedAddresses sql.NullString
+	var enabled bool
+	var expiresAt sql.NullString
 	err := b.db.QueryRow(`
-SELECT password_hash, allowed_sender_domains, allowed_sender_addresses
+SELECT password_hash, enabled, expires_at, allowed_sender_domains, allowed_sender_addresses
 FROM submission_credentials
 WHERE username = ?
-  AND enabled = 1
-  AND (expires_at IS NULL OR datetime(expires_at) > CURRENT_TIMESTAMP)
 LIMIT 1
-`, user).Scan(&storedHash, &allowedDomains, &allowedAddresses)
+`, user).Scan(&storedHash, &enabled, &expiresAt, &allowedDomains, &allowedAddresses)
 	if err != nil {
 		if !errors.Is(err, sql.ErrNoRows) {
 			slog.Error("submission sqlite auth lookup failed", "component", "smtp", "error", err, "username", user)
+			return AuthResult{
+				Principal:     Principal{AuthSource: "sqlite_password", Username: user},
+				FailureReason: "backend_error",
+			}
 		}
-		return Principal{}, false
+		return AuthResult{
+			Principal:     Principal{AuthSource: "sqlite_password", Username: user},
+			FailureReason: "credential_not_found",
+		}
+	}
+	if !enabled {
+		return AuthResult{
+			Principal:     Principal{AuthSource: "sqlite_password", Username: user},
+			FailureReason: "credential_disabled",
+		}
+	}
+	if expiresAt.Valid {
+		var expired bool
+		err := b.db.QueryRow(`SELECT datetime(?) <= CURRENT_TIMESTAMP`, expiresAt.String).Scan(&expired)
+		if err != nil {
+			slog.Error("submission sqlite auth expiry check failed", "component", "smtp", "error", err, "username", user)
+			return AuthResult{
+				Principal:     Principal{AuthSource: "sqlite_password", Username: user},
+				FailureReason: "backend_error",
+			}
+		}
+		if expired {
+			return AuthResult{
+				Principal:     Principal{AuthSource: "sqlite_password", Username: user},
+				FailureReason: "credential_expired",
+			}
+		}
 	}
 
 	sum := sha256.Sum256([]byte(password))
 	gotHash := hex.EncodeToString(sum[:])
 	if subtle.ConstantTimeCompare([]byte(strings.ToLower(strings.TrimSpace(storedHash))), []byte(gotHash)) != 1 {
-		return Principal{}, false
+		return AuthResult{
+			Principal:     Principal{AuthSource: "sqlite_password", Username: user},
+			FailureReason: "invalid_password",
+		}
 	}
 
 	if _, err := b.db.Exec(`
@@ -75,12 +116,15 @@ WHERE username = ?
 		slog.Error("submission sqlite auth last_auth_at update failed", "component", "smtp", "error", err, "username", user)
 	}
 
-	return Principal{
-		AuthSource:             "sqlite_password",
-		Username:               user,
-		AllowedSenderDomains:   parseCSVAllowList(allowedDomains.String),
-		AllowedSenderAddresses: parseCSVAllowList(allowedAddresses.String),
-	}, true
+	return AuthResult{
+		Principal: Principal{
+			AuthSource:             "sqlite_password",
+			Username:               user,
+			AllowedSenderDomains:   parseCSVAllowList(allowedDomains.String),
+			AllowedSenderAddresses: parseCSVAllowList(allowedAddresses.String),
+		},
+		Success: true,
+	}
 }
 
 func parseCSVAllowList(v string) []string {

--- a/internal/userauth/static_test.go
+++ b/internal/userauth/static_test.go
@@ -44,6 +44,19 @@ func TestNewStaticRejectsInvalidEntry(t *testing.T) {
 	}
 }
 
+func TestStaticAuthenticatePasswordDetailedReturnsFailureReason(t *testing.T) {
+	b, err := NewStatic("alice@example.com:s3cr3t")
+	if err != nil {
+		t.Fatalf("new static: %v", err)
+	}
+	if got := b.AuthenticatePasswordDetailed("alice@example.com", "wrong"); got.FailureReason != "invalid_password" {
+		t.Fatalf("failure reason=%q want=%q", got.FailureReason, "invalid_password")
+	}
+	if got := b.AuthenticatePasswordDetailed("bob@example.com", "pass"); got.FailureReason != "credential_not_found" {
+		t.Fatalf("failure reason=%q want=%q", got.FailureReason, "credential_not_found")
+	}
+}
+
 func TestNewSQLiteAndAuthenticatePassword(t *testing.T) {
 	dsn := filepath.Join(t.TempDir(), "submission-auth.db")
 	db := openSubmissionSQLiteForTest(t, dsn)
@@ -83,6 +96,9 @@ func TestSQLiteRejectsDisabledExpiredOrWrongPassword(t *testing.T) {
 		if _, ok := backend.AuthenticatePassword("alice@example.com", "s3cr3t"); ok {
 			t.Fatal("disabled user must be rejected")
 		}
+		if got := backend.AuthenticatePasswordDetailed("alice@example.com", "s3cr3t"); got.FailureReason != "credential_disabled" {
+			t.Fatalf("failure reason=%q want=%q", got.FailureReason, "credential_disabled")
+		}
 	})
 
 	t.Run("expired user", func(t *testing.T) {
@@ -98,6 +114,9 @@ func TestSQLiteRejectsDisabledExpiredOrWrongPassword(t *testing.T) {
 		if _, ok := backend.AuthenticatePassword("alice@example.com", "s3cr3t"); ok {
 			t.Fatal("expired user must be rejected")
 		}
+		if got := backend.AuthenticatePasswordDetailed("alice@example.com", "s3cr3t"); got.FailureReason != "credential_expired" {
+			t.Fatalf("failure reason=%q want=%q", got.FailureReason, "credential_expired")
+		}
 	})
 
 	t.Run("wrong password", func(t *testing.T) {
@@ -111,6 +130,9 @@ func TestSQLiteRejectsDisabledExpiredOrWrongPassword(t *testing.T) {
 		}
 		if _, ok := backend.AuthenticatePassword("alice@example.com", "wrong"); ok {
 			t.Fatal("wrong password must fail")
+		}
+		if got := backend.AuthenticatePasswordDetailed("alice@example.com", "wrong"); got.FailureReason != "invalid_password" {
+			t.Fatalf("failure reason=%q want=%q", got.FailureReason, "invalid_password")
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- Submission auth failure の detailed reason を trace と structured log に追加
- static / sqlite backend で internal failure reason を返せるように変更
- Submission auth runbook を追加して、調査ポイントと failure reason の意味を整理

## Related Issue
- Closes #253

## Validation
- [ ] `go vet ./...`
- [x] `go test ./...`
- [ ] `go test -race ./...`

## TDD Checklist
- [ ] Red: failing test was added first
- [x] Green: minimal implementation to pass tests
- [x] Refactor: cleanup completed without behavior change