### PR TITLE
Submission auth tutorial を追加

### DIFF
--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -16,6 +16,7 @@
 | [Rate Limit を試す](/tutorials/rate-limit) | 接続元 IP や `MAIL FROM` 単位の制限 | `kuroshio` + `smtp-client` |
 | [Domain Throttle を観測する](/tutorials/domain-throttle-observability) | Redis backend で配送側 throttle の wait と fail-open を見る | `kuroshio` + `redis` + `slow-smtp` |
 | [Admin API を試す](/tutorials/admin-operations) | queue 操作と Admin API / CLI | `kuroshio` + `smtp-client` |
+| [Submission Auth を試す](/tutorials/submission-auth) | `AUTH PLAIN` / `AUTH LOGIN` と sender scope | `kuroshio` + `smtp-client` |
 | [メール認証を試す](/tutorials/mail-auth) | SPF / DMARC 評価、DKIM / ARC 署名 | `CoreDNS` + `policy` + `tester` |
 | [TLS 配送ポリシーを試す](/tutorials/tls-policy) | STARTTLS、MTA-STS、DANE | `CoreDNS` + `policy` + `tester` |
 
@@ -28,6 +29,7 @@
 - Rate Limit: [examples/tutorials/rate-limit](https://github.com/tamago0224/kuroshio-mta/tree/main/examples/tutorials/rate-limit)
 - Domain throttle observability: [examples/tutorials/domain-throttle-observability](https://github.com/tamago0224/kuroshio-mta/tree/main/examples/tutorials/domain-throttle-observability)
 - Admin API: [examples/tutorials/admin-operations](https://github.com/tamago0224/kuroshio-mta/tree/main/examples/tutorials/admin-operations)
+- Submission Auth: [examples/tutorials/submission-auth](https://github.com/tamago0224/kuroshio-mta/tree/main/examples/tutorials/submission-auth)
 - DNS / Web: [examples/tutorials/dns-services](https://github.com/tamago0224/kuroshio-mta/tree/main/examples/tutorials/dns-services)
 
 ## 進み方のおすすめ

--- a/docs/tutorials/submission-auth.md
+++ b/docs/tutorials/submission-auth.md
@@ -1,0 +1,81 @@
+# Submission Auth を試す
+
+Submission の `AUTH PLAIN` / `AUTH LOGIN` を、SQLite-backed credential と sender scope つきで確認する tutorial です。
+
+## 1. tutorial 用の compose を起動する
+
+この tutorial 用に、`compose.yaml` / `config.yaml` / `init.sql` を
+`examples/tutorials/submission-auth/` に用意しています。
+
+```bash
+mkdir -p examples/tutorials/submission-auth/var/queue
+docker compose -f examples/tutorials/submission-auth/compose.yaml up --build -d
+```
+
+## 2. Submission AUTH の成功例を確認する
+
+```bash
+docker compose -f examples/tutorials/submission-auth/compose.yaml exec -T smtp-client sh -lc "cat <<'EOF' | nc kuroshio 587
+EHLO tutorial.local
+AUTH PLAIN AGFsaWNlQGV4YW1wbGUuY29tAHMzY3IzdA==
+MAIL FROM:<billing@example.net>
+RCPT TO:<receiver@example.org>
+DATA
+Subject: submission auth tutorial
+
+hello from submission auth
+.
+QUIT
+EOF"
+```
+
+`AUTH` が `235`、`MAIL FROM` が `250` で返れば成功です。
+
+## 3. sender scope mismatch を確認する
+
+`allowed_sender_domains` / `allowed_sender_addresses` に含まれない送信元は reject されます。
+
+```bash
+docker compose -f examples/tutorials/submission-auth/compose.yaml exec -T smtp-client sh -lc "cat <<'EOF' | nc kuroshio 587
+EHLO tutorial.local
+AUTH PLAIN AGFsaWNlQGV4YW1wbGUuY29tAHMzY3IzdA==
+MAIL FROM:<alice@other.example>
+QUIT
+EOF"
+```
+
+`MAIL FROM` が `553` で reject されれば期待どおりです。
+
+## 4. 認証失敗を確認する
+
+```bash
+docker compose -f examples/tutorials/submission-auth/compose.yaml exec -T smtp-client sh -lc "cat <<'EOF' | nc kuroshio 587
+EHLO tutorial.local
+AUTH PLAIN AGFsaWNlQGV4YW1wbGUuY29tAHdyb25n
+QUIT
+EOF"
+```
+
+`AUTH` が `535` で返れば認証失敗です。
+
+## 5. trace / log を確認する
+
+- trace: `smtp.auth` span
+- log: `submission auth succeeded`
+- log: `submission auth failed`
+- log: `submission sender identity rejected`
+
+詳しい読み方は [Submission Auth Runbook](/runbooks/submission_auth) を参照してください。
+
+## 後片付け
+
+```bash
+docker compose -f examples/tutorials/submission-auth/compose.yaml down
+rm -rf examples/tutorials/submission-auth/var
+```
+
+## 次に読む
+
+- [Tutorials Home](/tutorials/)
+- [RFC 4954: SMTP AUTH](/rfc_4954_gap)
+- [Submission Auth Runbook](/runbooks/submission_auth)

--- a/examples/tutorials/submission-auth/compose.yaml
+++ b/examples/tutorials/submission-auth/compose.yaml
@@ -1,0 +1,30 @@
+services:
+  init-db:
+    image: alpine:3.20
+    command:
+      - sh
+      - -lc
+      - apk add --no-cache sqlite && sqlite3 /var/lib/kuroshio/submission-auth.db < /init.sql
+    volumes:
+      - ./init.sql:/init.sql:ro
+      - ./var:/var/lib/kuroshio
+    restart: "no"
+
+  kuroshio:
+    build:
+      context: ../../..
+      dockerfile: Dockerfile
+    ports:
+      - "2525:2525"
+      - "587:587"
+      - "9090:9090"
+    volumes:
+      - ./config.yaml:/etc/kuroshio/config.yaml:ro
+      - ./var/queue:/var/lib/kuroshio/queue
+      - ./var:/var/lib/kuroshio
+    depends_on:
+      - init-db
+
+  smtp-client:
+    image: busybox:1.37
+    command: ["sh", "-c", "tail -f /dev/null"]

--- a/examples/tutorials/submission-auth/config.yaml
+++ b/examples/tutorials/submission-auth/config.yaml
@@ -1,0 +1,10 @@
+listen_addr: ":2525"
+submission_addr: ":587"
+submission_auth_required: true
+submission_auth_backend: sqlite
+submission_auth_dsn: "file:/var/lib/kuroshio/submission-auth.db"
+submission_enforce_sender_identity: true
+hostname: tutorial.local
+queue_dir: /var/lib/kuroshio/queue
+log_level: info
+observability_addr: ":9090"

--- a/examples/tutorials/submission-auth/init.sql
+++ b/examples/tutorials/submission-auth/init.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS submission_credentials (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  username TEXT NOT NULL,
+  password_hash TEXT NOT NULL,
+  enabled INTEGER NOT NULL DEFAULT 1,
+  expires_at TEXT,
+  allowed_sender_domains TEXT,
+  allowed_sender_addresses TEXT,
+  description TEXT,
+  last_auth_at TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO submission_credentials(
+  username,
+  password_hash,
+  enabled,
+  allowed_sender_domains,
+  allowed_sender_addresses,
+  description
+) VALUES
+  ('alice@example.com', '4e738ca5563c06cfd0018299933d58db1dd8bf97f6973dc99bf6cdc64b5550bd', 1, 'example.com', 'billing@example.net', 'tutorial user'),
+  ('ops@example.com', '4e738ca5563c06cfd0018299933d58db1dd8bf97f6973dc99bf6cdc64b5550bd', 1, 'other.example', '', 'ops user');


### PR DESCRIPTION
## Summary
- Submission AUTH (static/sqlite + sender scope) を確認できる tutorial を追加
- SQLite credential を init する compose / config / init.sql を追加
- tutorials index に導線を追加

## Related Issue
- Closes #255

## Validation
- [ ] `go vet ./...`
- [ ] `go test ./...`
- [ ] `go test -race ./...`

## TDD Checklist
- [ ] Red: failing test was added first
- [x] Green: minimal implementation to pass tests
- [x] Refactor: cleanup completed without behavior change